### PR TITLE
Cleanup a few obscure instructions

### DIFF
--- a/instructions.json
+++ b/instructions.json
@@ -18,7 +18,9 @@
             "defaultInstruction": "Head {modifier}[ on {way_name}]"
         },
         "end of road": {
-            "defaultInstruction": "Turn {modifier}[ onto {way_name}]"
+            "defaultInstruction": "Turn {modifier}[ onto {way_name}] at the end of the road",
+            "straight": "Continue straight[ onto {way_name}]",
+            "uturn": "Make a U-turn[ onto {way_name}] at the end of the road"
         },
         "ferry": {
             "defaultInstruction": "Take the ferry[ - {way_name}]"
@@ -26,17 +28,25 @@
         "fork": {
             "defaultInstruction": "Keep {modifier} at the fork[ onto {way_name}]",
             "slight left": "Keep left at the fork[ onto {way_name}]",
-            "slight right": "Keep right at the fork[ onto {way_name}]"
+            "slight right": "Keep right at the fork[ onto {way_name}]",
+            "sharp left": "Take a sharp left at the fork[ onto {way_name}]",
+            "sharp right": "Take a sharp right at the fork[ onto {way_name}]",
+            "uturn": "Make a U-turn [ onto {way_name}]"
         },
         "merge": {
             "defaultInstruction": "Merge {modifier}[ onto {way_name}]",
             "slight left": "Merge slightly left[ onto {way_name}]",
-            "slight right": "Merge slightly right[ onto {way_name}]"
+            "slight right": "Merge slightly right[ onto {way_name}]",
+            "sharp left": "Merge sharply left[ onto {way_name}]",
+            "sharp right": "Merge sharply right[ onto {way_name}]"
         },
         "new name": {
             "defaultInstruction": "Continue {modifier}[ onto {way_name}]",
+            "sharp left": "Take a sharp left[ onto {way_name}]",
+            "sharp right": "Take a sharp right[ onto {way_name}]",
             "slight left": "Continue slightly left[ onto {way_name}]",
-            "slight right": "Continue slightly right[ onto {way_name}]"
+            "slight right": "Continue slightly right[ onto {way_name}]",
+            "uturn": "Make a U-turn[ onto {way_name}]"
         },
         "notification": {
             "defaultInstruction": "Continue {modifier}[ onto {way_name}]"
@@ -49,7 +59,14 @@
             "slight right": "Take the ramp on the right"
         },
         "on ramp": {
-            "defaultInstruction": "Take the ramp on the {modifier}"
+            "defaultInstruction": "Take the ramp on the {modifier}",
+            "left": "Take the ramp on the left",
+            "right": "Take the ramp on the right",
+            "sharp left": "Take the ramp on the left",
+            "sharp right": "Take the ramp on the right",
+            "slight left": "Take the ramp on the left",
+            "slight right": "Take the ramp on the right",
+            "straight": "Take the ramp"
         },
         "pushing bike": {
             "defaultInstruction": "Get off the bike and push[ onto {way_name}]"

--- a/lib/use-lane.js
+++ b/lib/use-lane.js
@@ -69,7 +69,10 @@ module.exports = function (step, instruction) {
         } else if (laneDiagram[0] === 'x' && laneDiagram[laneDiagram.length - 1] === 'x') {
             // Converts xxooxxx to [2, 3]
             // This represents the not allowed lane 'groups'
-            var notAllowedLaneSets = laneDiagram.join('').split(Array(allowedLanes + 1).join('o'))
+            var notAllowedLaneSets = laneDiagram
+                .join('')
+                .split(Array(allowedLanes + 1)
+                .join('o'))
                 .map(function (i) {
                     return i.length;
                 });

--- a/test/fixtures/v5/end_of_road/left.json
+++ b/test/fixtures/v5/end_of_road/left.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Turn left onto Street Name"
+    "instruction": "Turn left onto Street Name at the end of the road"
 }

--- a/test/fixtures/v5/end_of_road/left_no_name.json
+++ b/test/fixtures/v5/end_of_road/left_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Turn left"
+    "instruction": "Turn left at the end of the road"
 }

--- a/test/fixtures/v5/end_of_road/right.json
+++ b/test/fixtures/v5/end_of_road/right.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Turn right onto Street Name"
+    "instruction": "Turn right onto Street Name at the end of the road"
 }

--- a/test/fixtures/v5/end_of_road/right_no_name.json
+++ b/test/fixtures/v5/end_of_road/right_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Turn right"
+    "instruction": "Turn right at the end of the road"
 }

--- a/test/fixtures/v5/end_of_road/sharp_left.json
+++ b/test/fixtures/v5/end_of_road/sharp_left.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Turn sharp left onto Street Name"
+    "instruction": "Turn sharp left onto Street Name at the end of the road"
 }

--- a/test/fixtures/v5/end_of_road/sharp_left_no_name.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Turn sharp left"
+    "instruction": "Turn sharp left at the end of the road"
 }

--- a/test/fixtures/v5/end_of_road/sharp_right.json
+++ b/test/fixtures/v5/end_of_road/sharp_right.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Turn sharp right onto Street Name"
+    "instruction": "Turn sharp right onto Street Name at the end of the road"
 }

--- a/test/fixtures/v5/end_of_road/sharp_right_no_name.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Turn sharp right"
+    "instruction": "Turn sharp right at the end of the road"
 }

--- a/test/fixtures/v5/end_of_road/slight_left.json
+++ b/test/fixtures/v5/end_of_road/slight_left.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Turn slight left onto Street Name"
+    "instruction": "Turn slight left onto Street Name at the end of the road"
 }

--- a/test/fixtures/v5/end_of_road/slight_left_no_name.json
+++ b/test/fixtures/v5/end_of_road/slight_left_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Turn slight left"
+    "instruction": "Turn slight left at the end of the road"
 }

--- a/test/fixtures/v5/end_of_road/slight_right.json
+++ b/test/fixtures/v5/end_of_road/slight_right.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Turn slight right onto Street Name"
+    "instruction": "Turn slight right onto Street Name at the end of the road"
 }

--- a/test/fixtures/v5/end_of_road/slight_right_no_name.json
+++ b/test/fixtures/v5/end_of_road/slight_right_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Turn slight right"
+    "instruction": "Turn slight right at the end of the road"
 }

--- a/test/fixtures/v5/end_of_road/straight.json
+++ b/test/fixtures/v5/end_of_road/straight.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Turn straight onto Street Name"
+    "instruction": "Continue straight onto Street Name"
 }

--- a/test/fixtures/v5/end_of_road/straight_no_name.json
+++ b/test/fixtures/v5/end_of_road/straight_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Turn straight"
+    "instruction": "Continue straight"
 }

--- a/test/fixtures/v5/end_of_road/uturn.json
+++ b/test/fixtures/v5/end_of_road/uturn.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Turn uturn onto Street Name"
+    "instruction": "Make a U-turn onto Street Name at the end of the road"
 }

--- a/test/fixtures/v5/end_of_road/uturn_no_name.json
+++ b/test/fixtures/v5/end_of_road/uturn_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Turn uturn"
+    "instruction": "Make a U-turn at the end of the road"
 }

--- a/test/fixtures/v5/fork/sharp_left.json
+++ b/test/fixtures/v5/fork/sharp_left.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Keep sharp left at the fork onto Street Name"
+    "instruction": "Take a sharp left at the fork onto Street Name"
 }

--- a/test/fixtures/v5/fork/sharp_left_no_name.json
+++ b/test/fixtures/v5/fork/sharp_left_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Keep sharp left at the fork"
+    "instruction": "Take a sharp left at the fork"
 }

--- a/test/fixtures/v5/fork/sharp_right.json
+++ b/test/fixtures/v5/fork/sharp_right.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Keep sharp right at the fork onto Street Name"
+    "instruction": "Take a sharp right at the fork onto Street Name"
 }

--- a/test/fixtures/v5/fork/sharp_right_no_name.json
+++ b/test/fixtures/v5/fork/sharp_right_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Keep sharp right at the fork"
+    "instruction": "Take a sharp right at the fork"
 }

--- a/test/fixtures/v5/fork/uturn.json
+++ b/test/fixtures/v5/fork/uturn.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Keep uturn at the fork onto Street Name"
+    "instruction": "Make a U-turn  onto Street Name"
 }

--- a/test/fixtures/v5/fork/uturn_no_name.json
+++ b/test/fixtures/v5/fork/uturn_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Keep uturn at the fork"
+    "instruction": "Make a U-turn"
 }

--- a/test/fixtures/v5/merge/sharp_left.json
+++ b/test/fixtures/v5/merge/sharp_left.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Merge sharp left onto Street Name"
+    "instruction": "Merge sharply left onto Street Name"
 }

--- a/test/fixtures/v5/merge/sharp_left_no_name.json
+++ b/test/fixtures/v5/merge/sharp_left_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Merge sharp left"
+    "instruction": "Merge sharply left"
 }

--- a/test/fixtures/v5/merge/sharp_right.json
+++ b/test/fixtures/v5/merge/sharp_right.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Merge sharp right onto Street Name"
+    "instruction": "Merge sharply right onto Street Name"
 }

--- a/test/fixtures/v5/merge/sharp_right_no_name.json
+++ b/test/fixtures/v5/merge/sharp_right_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Merge sharp right"
+    "instruction": "Merge sharply right"
 }

--- a/test/fixtures/v5/new_name/sharp_left.json
+++ b/test/fixtures/v5/new_name/sharp_left.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Continue sharp left onto Street Name"
+    "instruction": "Take a sharp left onto Street Name"
 }

--- a/test/fixtures/v5/new_name/sharp_left_no_name.json
+++ b/test/fixtures/v5/new_name/sharp_left_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Continue sharp left"
+    "instruction": "Take a sharp left"
 }

--- a/test/fixtures/v5/new_name/sharp_right.json
+++ b/test/fixtures/v5/new_name/sharp_right.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Continue sharp right onto Street Name"
+    "instruction": "Take a sharp right onto Street Name"
 }

--- a/test/fixtures/v5/new_name/sharp_right_no_name.json
+++ b/test/fixtures/v5/new_name/sharp_right_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Continue sharp right"
+    "instruction": "Take a sharp right"
 }

--- a/test/fixtures/v5/new_name/uturn.json
+++ b/test/fixtures/v5/new_name/uturn.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Continue uturn onto Street Name"
+    "instruction": "Make a U-turn onto Street Name"
 }

--- a/test/fixtures/v5/new_name/uturn_no_name.json
+++ b/test/fixtures/v5/new_name/uturn_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Continue uturn"
+    "instruction": "Make a U-turn"
 }

--- a/test/fixtures/v5/on_ramp/sharp_left.json
+++ b/test/fixtures/v5/on_ramp/sharp_left.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Take the ramp on the sharp left"
+    "instruction": "Take the ramp on the left"
 }

--- a/test/fixtures/v5/on_ramp/sharp_right.json
+++ b/test/fixtures/v5/on_ramp/sharp_right.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Take the ramp on the sharp right"
+    "instruction": "Take the ramp on the right"
 }

--- a/test/fixtures/v5/on_ramp/slight_left.json
+++ b/test/fixtures/v5/on_ramp/slight_left.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Take the ramp on the slight left"
+    "instruction": "Take the ramp on the left"
 }

--- a/test/fixtures/v5/on_ramp/slight_right.json
+++ b/test/fixtures/v5/on_ramp/slight_right.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Take the ramp on the slight right"
+    "instruction": "Take the ramp on the right"
 }

--- a/test/fixtures/v5/on_ramp/straight.json
+++ b/test/fixtures/v5/on_ramp/straight.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Take the ramp on the straight"
+    "instruction": "Take the ramp"
 }

--- a/test/fixtures/v5/use_lane/all_lanes.json
+++ b/test/fixtures/v5/use_lane/all_lanes.json
@@ -15,6 +15,5 @@
             }
         ]
     },
-    "instruction": "Take any lane and continue straight",
-    "testName": "use lane straight all lanes default case"
+    "instruction": "Take any lane and continue straight"
 }

--- a/test/fixtures/v5/use_lane/left_lane.json
+++ b/test/fixtures/v5/use_lane/left_lane.json
@@ -21,6 +21,5 @@
             }
         ]
     },
-    "instruction": "Use the left lane and continue straight",
-    "testName": "use lane straight left lane default case"
+    "instruction": "Use the left lane and continue straight"
 }


### PR DESCRIPTION
Part 1 to https://github.com/Project-OSRM/osrm-text-instructions/issues/16

As it stands some obscure modifier/type combinations have very strange instructions. This fixes a few of these cases.

/cc @freenerd 