### PR TITLE
Depart/Arrive dont always have modifiers

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,10 @@ module.exports = function(_version) {
             // This switch statement is for specical cases that occur at runtime
             switch (type) {
             case 'arrive':
-                // TODO, add wayPoint argument
-                // instruction = instruction.replace('{nth}', nthWaypoint).replace('  ', ' ');
+                // TODO, add correct waypoint counting
+                var nthWaypoint = '';
+
+                instruction = instruction.replace('{nth}', nthWaypoint).replace('  ', ' ');
                 break;
             case 'depart':
                 // Always use cardinal direction for departure.

--- a/index.js
+++ b/index.js
@@ -10,13 +10,14 @@ module.exports = function(_version) {
 
     return {
         compile: function(step) {
+            if (!instructions[version]) { throw new Error('Invalid version'); }
+            if (!step.maneuver) throw new Error('No step maneuver provided');
+
             var type = step.maneuver.type;
             var modifier = step.maneuver.modifier;
 
-            if (!instructions[version]) { throw new Error('Invalid version'); }
             if (!type) { throw new Error('Missing step maneuver type'); }
-            if (!modifier) { throw new Error('Missing step maneuver modifier'); }
-            if (!step.maneuver.modifier) throw new Error('No maneuver provided');
+            if (type !== 'depart' && type !== 'arrive' && !modifier) { throw new Error('Missing step maneuver modifier'); }
 
             if (!instructions[version][type]) {
                 // osrm specification assumes turn types can be added without

--- a/instructions.json
+++ b/instructions.json
@@ -4,9 +4,10 @@
             "defaultInstruction": "You have arrived at your {nth} destination",
             "left": "You have arrived at your {nth} destination, on the left",
             "right": "You have arrived at your {nth} destination, on the right",
-            "sharp left": "You have arrived at your {nth} destination, sharply to the left",
-            "sharp right": "You have arrived at your {nth} destination, sharply to the right",
-            "slight right": "You have arrived at your {nth} destination, slightly to the right",
+            "sharp left": "You have arrived at your {nth} destination, on the left",
+            "sharp right": "You have arrived at your {nth} destination, on the right",
+            "slight right": "You have arrived at your {nth} destination, on the right",
+            "slight left": "You have arrived at your {nth} destination, on the left",
             "straight": "You have arrived at your {nth} destination, straight ahead"
         },
         "continue": {

--- a/test/fixtures/v5/arrive/left.json
+++ b/test/fixtures/v5/arrive/left.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "You have arrived at your {nth} destination, on the left"
+    "instruction": "You have arrived at your destination, on the left"
 }

--- a/test/fixtures/v5/arrive/no_modifier.json
+++ b/test/fixtures/v5/arrive/no_modifier.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "You have arrived at your {nth} destination"
+    "instruction": "You have arrived at your destination"
 }

--- a/test/fixtures/v5/arrive/no_modifier.json
+++ b/test/fixtures/v5/arrive/no_modifier.json
@@ -1,0 +1,10 @@
+{
+    "step": {
+        "maneuver": {
+            "bearing_after": 0,
+            "type": "arrive"
+        },
+        "name": "Street Name"
+    },
+    "instruction": "You have arrived at your {nth} destination"
+}

--- a/test/fixtures/v5/arrive/no_modifier_no_name.json
+++ b/test/fixtures/v5/arrive/no_modifier_no_name.json
@@ -5,5 +5,5 @@
             "type": "arrive"
         }
     },
-    "instruction": "You have arrived at your {nth} destination"
+    "instruction": "You have arrived at your destination"
 }

--- a/test/fixtures/v5/arrive/no_modifier_no_name.json
+++ b/test/fixtures/v5/arrive/no_modifier_no_name.json
@@ -1,0 +1,9 @@
+{
+    "step": {
+        "maneuver": {
+            "bearing_after": 0,
+            "type": "arrive"
+        }
+    },
+    "instruction": "You have arrived at your {nth} destination"
+}

--- a/test/fixtures/v5/arrive/right.json
+++ b/test/fixtures/v5/arrive/right.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "You have arrived at your {nth} destination, on the right"
+    "instruction": "You have arrived at your destination, on the right"
 }

--- a/test/fixtures/v5/arrive/sharp_left.json
+++ b/test/fixtures/v5/arrive/sharp_left.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "You have arrived at your {nth} destination, sharply to the left"
+    "instruction": "You have arrived at your destination, on the left"
 }

--- a/test/fixtures/v5/arrive/sharp_right.json
+++ b/test/fixtures/v5/arrive/sharp_right.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "You have arrived at your {nth} destination, sharply to the right"
+    "instruction": "You have arrived at your destination, on the right"
 }

--- a/test/fixtures/v5/arrive/slight_left.json
+++ b/test/fixtures/v5/arrive/slight_left.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "You have arrived at your {nth} destination"
+    "instruction": "You have arrived at your destination, on the left"
 }

--- a/test/fixtures/v5/arrive/slight_right.json
+++ b/test/fixtures/v5/arrive/slight_right.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "You have arrived at your {nth} destination, slightly to the right"
+    "instruction": "You have arrived at your destination, on the right"
 }

--- a/test/fixtures/v5/arrive/straight.json
+++ b/test/fixtures/v5/arrive/straight.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "You have arrived at your {nth} destination, straight ahead"
+    "instruction": "You have arrived at your destination, straight ahead"
 }

--- a/test/fixtures/v5/arrive/uturn.json
+++ b/test/fixtures/v5/arrive/uturn.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "You have arrived at your {nth} destination"
+    "instruction": "You have arrived at your destination"
 }

--- a/test/fixtures/v5/depart/no_modifier.json
+++ b/test/fixtures/v5/depart/no_modifier.json
@@ -1,0 +1,10 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "depart",
+            "bearing_after": 0
+        },
+        "name": "Street Name"
+    },
+    "instruction": "Head north on Street Name"
+}

--- a/test/fixtures/v5/depart/no_modifier_no_name.json
+++ b/test/fixtures/v5/depart/no_modifier_no_name.json
@@ -1,0 +1,9 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "depart",
+            "bearing_after": 0
+        }
+    },
+    "instruction": "Head north"
+}


### PR DESCRIPTION
From https://github.com/Project-OSRM/osrm-backend/blob/master/docs/http.md

> The list of turns without a modifier is limited to: depart/arrive. If the source/target location is close enough to the depart/arrive location, no modifier will be given.

/cc @bsudekum 