### PR TITLE
Only mention end-of-the-road on uturn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. For change 
 # Unreleased
 
 - Fix rotary names instruction `exit onto`
+- Only mention end-of-road on uturn intructions
 
 ## 0.0.2 2016-10-18
 

--- a/instructions.json
+++ b/instructions.json
@@ -91,9 +91,9 @@
         },
         "end of road": {
             "default": {
-                "default": "Turn {modifier} at the end of the road",
-                "name": "Turn {modifier} onto {way_name} at the end of the road",
-                "destination": "Turn {modifier} towards {destination} at the end of the road"
+                "default": "Turn {modifier}",
+                "name": "Turn {modifier} onto {way_name}",
+                "destination": "Turn {modifier} towards {destination}"
             },
             "straight": {
                 "default": "Continue straight",

--- a/test/fixtures/v5/end_of_road/left.json
+++ b/test/fixtures/v5/end_of_road/left.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Turn left onto Street Name at the end of the road"
+    "instruction": "Turn left onto Street Name"
 }

--- a/test/fixtures/v5/end_of_road/left_no_name.json
+++ b/test/fixtures/v5/end_of_road/left_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Turn left at the end of the road"
+    "instruction": "Turn left"
 }

--- a/test/fixtures/v5/end_of_road/right.json
+++ b/test/fixtures/v5/end_of_road/right.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Turn right onto Street Name at the end of the road"
+    "instruction": "Turn right onto Street Name"
 }

--- a/test/fixtures/v5/end_of_road/right_destinations.json
+++ b/test/fixtures/v5/end_of_road/right_destinations.json
@@ -7,5 +7,5 @@
         "name": "Street Name",
         "destinations": "City 1,City 2"
     },
-    "instruction": "Turn right towards City 1 at the end of the road"
+    "instruction": "Turn right towards City 1"
 }

--- a/test/fixtures/v5/end_of_road/right_no_name.json
+++ b/test/fixtures/v5/end_of_road/right_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Turn right at the end of the road"
+    "instruction": "Turn right"
 }

--- a/test/fixtures/v5/end_of_road/sharp_left.json
+++ b/test/fixtures/v5/end_of_road/sharp_left.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Turn sharp left onto Street Name at the end of the road"
+    "instruction": "Turn sharp left onto Street Name"
 }

--- a/test/fixtures/v5/end_of_road/sharp_left_no_name.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Turn sharp left at the end of the road"
+    "instruction": "Turn sharp left"
 }

--- a/test/fixtures/v5/end_of_road/sharp_right.json
+++ b/test/fixtures/v5/end_of_road/sharp_right.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Turn sharp right onto Street Name at the end of the road"
+    "instruction": "Turn sharp right onto Street Name"
 }

--- a/test/fixtures/v5/end_of_road/sharp_right_no_name.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Turn sharp right at the end of the road"
+    "instruction": "Turn sharp right"
 }

--- a/test/fixtures/v5/end_of_road/slight_left.json
+++ b/test/fixtures/v5/end_of_road/slight_left.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Turn slight left onto Street Name at the end of the road"
+    "instruction": "Turn slight left onto Street Name"
 }

--- a/test/fixtures/v5/end_of_road/slight_left_no_name.json
+++ b/test/fixtures/v5/end_of_road/slight_left_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Turn slight left at the end of the road"
+    "instruction": "Turn slight left"
 }

--- a/test/fixtures/v5/end_of_road/slight_right.json
+++ b/test/fixtures/v5/end_of_road/slight_right.json
@@ -6,5 +6,5 @@
         },
         "name": "Street Name"
     },
-    "instruction": "Turn slight right onto Street Name at the end of the road"
+    "instruction": "Turn slight right onto Street Name"
 }

--- a/test/fixtures/v5/end_of_road/slight_right_no_name.json
+++ b/test/fixtures/v5/end_of_road/slight_right_no_name.json
@@ -6,5 +6,5 @@
         },
         "name": ""
     },
-    "instruction": "Turn slight right at the end of the road"
+    "instruction": "Turn slight right"
 }


### PR DESCRIPTION
Let's only mention end of the road when it makes semantic a lot of change, otherwise keep it short.

We might want to revise this decision, e.g. by moving end of the road to the front of the instruction. For now I'm keeping parity with the state we had before in Mapbox Directions.