### PR TITLE
No way_name/destination with use lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. For change 
 # Unreleased
 
 - Better u-turn instructions
+- Do not use name/destination on use lane
 - Fix rotary names instruction `exit onto`
 - Only mention end-of-road on uturn intructions
 

--- a/instructions.json
+++ b/instructions.json
@@ -36,8 +36,8 @@
             "lanes": {
                 "xo": "Keep right",
                 "ox": "Keep left",
-                "xox": "Use the middle lane",
-                "oxo": "Use the left or right lane"
+                "xox": "Keep in the middle",
+                "oxo": "Keep left or right"
             }
         },
         "arrive": {
@@ -395,34 +395,19 @@
         },
         "use lane": {
             "no_lanes": {
-                "default": "Continue straight",
-                "name": "Continue straight onto {way_name}",
-                "destination": "Continue straight towards {destination}"
+                "default": "Continue straight"
             },
             "default": {
-                "default": "{lane_instruction} to make a {modifier}",
-                "name": "{lane_instruction} to make a {modifier} onto {way_name}",
-                "destination": "{lane_instruction} to make a {modifier} towards {destination}"
+                "default": "{lane_instruction} to make a {modifier}"
             },
             "straight": {
-                "default": "{lane_instruction}",
-                "name": "{lane_instruction} onto {way_name}",
-                "destination": "{lane_instruction} towards {destination}"
+                "default": "{lane_instruction}"
             },
             "left": {
-                "default": "{lane_instruction} to turn left",
-                "name": "{lane_instruction} to turn left onto {way_name}",
-                "destination": "{lane_instruction} to turn left towards {destination}"
+                "default": "{lane_instruction} to turn left"
             },
             "right": {
-                "default": "{lane_instruction} to turn right",
-                "name": "{lane_instruction} to turn right onto {way_name}",
-                "destination": "{lane_instruction} to turn right towards {way_name}"
-            },
-            "uturn": {
-                "default": "{lane_instruction} to make a U-turn",
-                "name": "{lane_instruction} to make a U-turn onto {way_name}",
-                "destination": "{lane_instruction} to make a U-turn towards {destination}"
+                "default": "{lane_instruction} to turn right"
             }
         }
     }

--- a/test/fixtures/v5/use_lane/all_lanes.json
+++ b/test/fixtures/v5/use_lane/all_lanes.json
@@ -15,5 +15,5 @@
             }
         ]
     },
-    "instruction": "Continue straight onto Street Name"
+    "instruction": "Continue straight"
 }

--- a/test/fixtures/v5/use_lane/left.json
+++ b/test/fixtures/v5/use_lane/left.json
@@ -15,5 +15,5 @@
         ],
         "name": "Street Name"
     },
-    "instruction": "Continue straight onto Street Name"
+    "instruction": "Continue straight"
 }

--- a/test/fixtures/v5/use_lane/left_lane.json
+++ b/test/fixtures/v5/use_lane/left_lane.json
@@ -30,5 +30,5 @@
             }
         ]
     },
-    "instruction": "Use the left or right lane onto Street Name"
+    "instruction": "Keep left or right"
 }

--- a/test/fixtures/v5/use_lane/left_lane_no_name.json
+++ b/test/fixtures/v5/use_lane/left_lane_no_name.json
@@ -29,5 +29,5 @@
             }
         ]
     },
-    "instruction": "Use the left or right lane"
+    "instruction": "Keep left or right"
 }

--- a/test/fixtures/v5/use_lane/oox.json
+++ b/test/fixtures/v5/use_lane/oox.json
@@ -21,5 +21,5 @@
             }
         ]
     },
-    "instruction": "Keep left to turn left onto Street Name"
+    "instruction": "Keep left to turn left"
 }

--- a/test/fixtures/v5/use_lane/oox_destinations.json
+++ b/test/fixtures/v5/use_lane/oox_destinations.json
@@ -22,5 +22,5 @@
             }
         ]
     },
-    "instruction": "Keep left to turn left towards City 1"
+    "instruction": "Keep left to turn left"
 }

--- a/test/fixtures/v5/use_lane/right.json
+++ b/test/fixtures/v5/use_lane/right.json
@@ -15,5 +15,5 @@
         ],
         "name": "Street Name"
     },
-    "instruction": "Continue straight onto Street Name"
+    "instruction": "Continue straight"
 }

--- a/test/fixtures/v5/use_lane/sharp_left.json
+++ b/test/fixtures/v5/use_lane/sharp_left.json
@@ -15,5 +15,5 @@
         ],
         "name": "Street Name"
     },
-    "instruction": "Continue straight onto Street Name"
+    "instruction": "Continue straight"
 }

--- a/test/fixtures/v5/use_lane/sharp_right.json
+++ b/test/fixtures/v5/use_lane/sharp_right.json
@@ -15,5 +15,5 @@
         ],
         "name": "Street Name"
     },
-    "instruction": "Continue straight onto Street Name"
+    "instruction": "Continue straight"
 }

--- a/test/fixtures/v5/use_lane/slight_left.json
+++ b/test/fixtures/v5/use_lane/slight_left.json
@@ -15,5 +15,5 @@
         ],
         "name": "Street Name"
     },
-    "instruction": "Continue straight onto Street Name"
+    "instruction": "Continue straight"
 }

--- a/test/fixtures/v5/use_lane/slight_right.json
+++ b/test/fixtures/v5/use_lane/slight_right.json
@@ -15,5 +15,5 @@
         ],
         "name": "Street Name"
     },
-    "instruction": "Continue straight onto Street Name"
+    "instruction": "Continue straight"
 }

--- a/test/fixtures/v5/use_lane/straight.json
+++ b/test/fixtures/v5/use_lane/straight.json
@@ -15,5 +15,5 @@
         ],
         "name": "Street Name"
     },
-    "instruction": "Continue straight onto Street Name"
+    "instruction": "Continue straight"
 }

--- a/test/fixtures/v5/use_lane/uturn.json
+++ b/test/fixtures/v5/use_lane/uturn.json
@@ -15,5 +15,5 @@
         ],
         "name": "Street Name"
     },
-    "instruction": "Continue straight onto Street Name"
+    "instruction": "Continue straight"
 }

--- a/test/fixtures/v5/use_lane/xo.json
+++ b/test/fixtures/v5/use_lane/xo.json
@@ -18,5 +18,5 @@
             }
         ]
     },
-    "instruction": "Keep right to turn left onto Street Name"
+    "instruction": "Keep right to turn left"
 }

--- a/test/fixtures/v5/use_lane/xoo.json
+++ b/test/fixtures/v5/use_lane/xoo.json
@@ -21,5 +21,5 @@
             }
         ]
     },
-    "instruction": "Keep right to turn left onto Street Name"
+    "instruction": "Keep right to turn left"
 }

--- a/test/fixtures/v5/use_lane/xxo.json
+++ b/test/fixtures/v5/use_lane/xxo.json
@@ -21,5 +21,5 @@
             }
         ]
     },
-    "instruction": "Keep right to turn left onto Street Name"
+    "instruction": "Keep right to turn left"
 }

--- a/test/fixtures/v5/use_lane/xxoo.json
+++ b/test/fixtures/v5/use_lane/xxoo.json
@@ -24,5 +24,5 @@
             }
         ]
     },
-    "instruction": "Keep right to turn left onto Street Name"
+    "instruction": "Keep right to turn left"
 }

--- a/test/fixtures/v5/use_lane/xxoxo.json
+++ b/test/fixtures/v5/use_lane/xxoxo.json
@@ -27,5 +27,5 @@
             }
         ]
     },
-    "instruction": "Continue straight onto Street Name"
+    "instruction": "Continue straight"
 }


### PR DESCRIPTION
I'm a bit unclear how `type: use lane` will actually be used.

It feels to me that `name` and `destination` only make sense, if they actually distinguish the lanes from each other. Since all lanes are on the same OSM way though, all lanes would have the same `name/destination` information. Thus we should not include that information in the text instruction, since it will be the same for all lanes.

We could re-introduce `destination` instructions if OSRM would support the [`destination:lanes` OSM tag](https://wiki.openstreetmap.org/wiki/Lanes), ticketed here https://github.com/Project-OSRM/osrm-backend/issues/2553#issuecomment-227067935 already

/cc @MoKob @daniel-j-h @bsudekum 