### PR TITLE
Allow runtime customizations of instructions.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. For change 
 - Only mention end-of-road on uturn intructions
 - Respect name and ref for way_name
 - Handle ferry mode
+- Allow for runtime customizations of instructions.json
 
 ## 0.0.2 2016-10-18
 

--- a/index.js
+++ b/index.js
@@ -6,9 +6,10 @@ module.exports = function(_version) {
     var version = _version || 'v5';
 
     var o = {
+        instructions: instructions,
         ordinalize: function(number) {
             // Transform numbers to their translated ordinalized value
-            return instructions[version].constants.ordinalize[number.toString()] || '';
+            return this.instructions[version].constants.ordinalize[number.toString()] || '';
         },
         directionFromDegree: function(degree) {
             // Transform degrees to their translated compass direction
@@ -16,23 +17,23 @@ module.exports = function(_version) {
                 // step had no bearing_after degree, ignoring
                 return '';
             } else if (degree >= 0 && degree <= 20) {
-                return instructions[version].constants.direction.north;
+                return this.instructions[version].constants.direction.north;
             } else if (degree > 20 && degree < 70) {
-                return instructions[version].constants.direction.northeast;
+                return this.instructions[version].constants.direction.northeast;
             } else if (degree >= 70 && degree < 110) {
-                return instructions[version].constants.direction.east;
+                return this.instructions[version].constants.direction.east;
             } else if (degree >= 110 && degree <= 160) {
-                return instructions[version].constants.direction.southeast;
+                return this.instructions[version].constants.direction.southeast;
             } else if (degree > 160 && degree <= 200) {
-                return instructions[version].constants.direction.south;
+                return this.instructions[version].constants.direction.south;
             } else if (degree > 200 && degree < 250) {
-                return instructions[version].constants.direction.southwest;
+                return this.instructions[version].constants.direction.southwest;
             } else if (degree >= 250 && degree <= 290) {
-                return instructions[version].constants.direction.west;
+                return this.instructions[version].constants.direction.west;
             } else if (degree > 290 && degree < 340) {
-                return instructions[version].constants.direction.northwest;
+                return this.instructions[version].constants.direction.northwest;
             } else if (degree >= 340 && degree <= 360) {
-                return instructions[version].constants.direction.north;
+                return this.instructions[version].constants.direction.north;
             } else {
                 throw new Error('Degree ' + degree + ' invalid');
             }
@@ -58,7 +59,7 @@ module.exports = function(_version) {
             return config.join('');
         },
         compile: function(step) {
-            if (!instructions[version]) { throw new Error('Invalid version'); }
+            if (!this.instructions[version]) { throw new Error('Invalid version'); }
             if (!step.maneuver) throw new Error('No step maneuver provided');
 
             var type = step.maneuver.type;
@@ -68,7 +69,7 @@ module.exports = function(_version) {
             if (!type) { throw new Error('Missing step maneuver type'); }
             if (type !== 'depart' && type !== 'arrive' && !modifier) { throw new Error('Missing step maneuver modifier'); }
 
-            if (!instructions[version][type]) {
+            if (!this.instructions[version][type]) {
                 // Log for debugging
                 console.log('Encountered unknown instruction type: ' + type); // eslint-disable-line no-console
                 // OSRM specification assumes turn types can be added without
@@ -77,25 +78,25 @@ module.exports = function(_version) {
                 type = 'turn';
             }
 
-            // Use special instructions if available, otherwise `defaultinstruction`
+            // Use special this.instructions if available, otherwise `defaultinstruction`
             var instructionObject;
-            if (instructions[version].modes[mode]) {
-                instructionObject = instructions[version].modes[mode];
-            } else if (instructions[version][type][modifier]) {
-                instructionObject = instructions[version][type][modifier];
+            if (this.instructions[version].modes[mode]) {
+                instructionObject = this.instructions[version].modes[mode];
+            } else if (this.instructions[version][type][modifier]) {
+                instructionObject = this.instructions[version][type][modifier];
             } else {
-                instructionObject = instructions[version][type].default;
+                instructionObject = this.instructions[version][type].default;
             }
 
             // Special case handling
             var laneInstruction;
             switch (type) {
             case 'use lane':
-                laneInstruction = instructions[version].constants.lanes[this.laneConfig(step)];
+                laneInstruction = this.instructions[version].constants.lanes[this.laneConfig(step)];
 
                 if (!laneInstruction) {
                     // If the lane combination is not found, default to continue
-                    instructionObject = instructions[version]['use lane'].no_lanes;
+                    instructionObject = this.instructions[version]['use lane'].no_lanes;
                 }
                 break;
             case 'rotary':
@@ -146,7 +147,7 @@ module.exports = function(_version) {
                 .replace('{exit_number}', this.ordinalize(step.maneuver.exit || 1))
                 .replace('{rotary_name}', step.rotary_name)
                 .replace('{lane_instruction}', laneInstruction)
-                .replace('{modifier}', instructions[version].constants.modifier[modifier])
+                .replace('{modifier}', this.instructions[version].constants.modifier[modifier])
                 .replace('{direction}', this.directionFromDegree(step.maneuver.bearing_after))
                 .replace('{nth}', nthWaypoint)
                 .replace(/ {2}/g, ' '); // remove excess spaces


### PR DESCRIPTION
This allows clients to customize instructions.json in-code. I've successfully used this in a project to add html tags like this:

```js
traverse(osrmTextInstructions.instructions).forEach(function (node) {
    if (node.constructor === String) {
        this.update(node.
            replace('{way_name}', '<span class="way-name">{way_name}</span>').
            replace('{destination}', '<span class="destination">{destination}</span>'),
            true
        );
    }
});
```

