### PR TITLE
Standardize on capitalizeFirstLetter meta key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. For change 
 
 - put future changes here
 - Improve chinese translation
+- Standardize on capitalizeFirstLetter meta key
 
 # 0.0.7 2016-11-10
 

--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ module.exports = function(version, language) {
                 .replace('{nth}', nthWaypoint)
                 .replace(/ {2}/g, ' '); // remove excess spaces
 
-            if (this.instructions.meta.capitalize_first_letter) {
+            if (this.instructions.meta.capitalizeFirstLetter) {
                 instruction = this.capitalizeFirstLetter(instruction);
             }
 

--- a/instructions/de.json
+++ b/instructions/de.json
@@ -1,6 +1,6 @@
 {
     "meta": {
-        "capitalize_first_letter": true
+        "capitalizeFirstLetter": true
     },
     "v5": {
         "constants": {


### PR DESCRIPTION
This was inconsistent and only worked in the `de` version so far, now all translations use the same key.