### PR TITLE
Spanish

### DIFF
--- a/languages.js
+++ b/languages.js
@@ -2,6 +2,7 @@
 // with bundling tools like webpack and browserify
 var instructionsDe = require('./languages/translations/de.json');
 var instructionsEn = require('./languages/translations/en.json');
+var instructionsEs = require('./languages/translations/es.json');
 var instructionsFr = require('./languages/translations/fr.json');
 var instructionsNl = require('./languages/translations/nl.json');
 var instructionsRu = require('./languages/translations/ru.json');
@@ -13,6 +14,7 @@ var instructionsZhHans = require('./languages/translations/zh-Hans.json');
 var tags = {
     'de': instructionsDe,
     'en': instructionsEn,
+    'es': instructionsEs,
     'fr': instructionsFr,
     'nl': instructionsNl,
     'ru': instructionsRu,

--- a/languages/translations/es.json
+++ b/languages/translations/es.json
@@ -1,0 +1,402 @@
+{
+    "meta": {
+        "capitalizeFirstLetter": true
+    },
+    "v5": {
+        "constants": {
+            "ordinalize": {
+                "1": "1ª",
+                "2": "2ª",
+                "3": "3ª",
+                "4": "4ª",
+                "5": "5ª",
+                "6": "6ª",
+                "7": "7ª",
+                "8": "8ª",
+                "9": "9ª",
+                "10": "10ª"
+            },
+            "direction": {
+                "north": "norte",
+                "northeast": "noreste",
+                "east": "este",
+                "southeast": "sureste",
+                "south": "sur",
+                "southwest": "suroeste",
+                "west": "oeste",
+                "northwest": "noroeste"
+            },
+            "modifier": {
+                "left": "izquierda",
+                "right": "derecha",
+                "sharp left": "cerrada a la izquierda",
+                "sharp right": "cerrada a la derecha",
+                "slight left": "ligeramente a la izquierda",
+                "slight right": "ligeramente a la derecha",
+                "straight": "recto",
+                "uturn": "cambio de sentido"
+            },
+            "lanes": {
+                "xo": "Mantengase a la derecha",
+                "ox": "Mantengase a la izquierda",
+                "xox": "Mantengase en el medio",
+                "oxo": "Mantengase a la izquierda o derecha"
+            }
+        },
+        "modes": {
+            "ferry": {
+                "default": "Coge el ferry",
+                "name": "Coge el ferry {way_name}",
+                "destination": "Coge el ferry a  {destination}"
+            }
+        },
+        "arrive": {
+            "default": {
+                "default": "Has llegado a tu  {nth} destino"
+            },
+            "left": {
+                "default": "Has llegado a tu  {nth} destino, a la izquierda"
+            },
+            "right": {
+                "default": "Has llegado a tu  {nth} destino, a la derecha"
+            },
+            "sharp left": {
+                "default": "Has llegado a tu  {nth} destino, a la izquierda"
+            },
+            "sharp right": {
+                "default": "Has llegado a tu  {nth} destino, a la derecha"
+            },
+            "slight right": {
+                "default": "Has llegado a tu  {nth} destino, a la derecha"
+            },
+            "slight left": {
+                "default": "Has llegado a tu  {nth} destino, a la izquierda"
+            },
+            "straight": {
+                "default": "Has llegado a tu  {nth} destino, en frente"
+            }
+        },
+        "continue": {
+            "default": {
+                "default": "Continua  {modifier}",
+                "name": "Continua  {modifier} en  {way_name}",
+                "destination": "Continua  {modifier} hacia  {destination}"
+            },
+            "straight": {
+                "default": "Continua recto",
+                "name": "Continua en  {way_name}",
+                "destination": "Continua hacia  {destination}"
+            },
+            "slight left": {
+                "default": "Continua ligeramente a la izquierda",
+                "name": "Continua ligeramente a la izquierda en  {way_name}",
+                "destination": "Continua ligeramente a la izquierda hacia  {destination}"
+            },
+            "slight right": {
+                "default": "Continua ligeramente a la derecha",
+                "name": "Continua ligeramente a la derecha en  {way_name}",
+                "destination": "Continua ligeramente a la derecha hacia  {destination}"
+            },
+            "uturn": {
+                "default": "Haz un cambio de sentido",
+                "name": "Haz un cambio de sentido en  {way_name}",
+                "destination": "Haz un cambio de sentido hacia  {destination}"
+            }
+        },
+        "depart": {
+            "default": {
+                "default": "Ve a  {direction}",
+                "name": "Ve a  {direction} en  {way_name}"
+            }
+        },
+        "end of road": {
+            "default": {
+                "default": "Gire  a  {modifier}",
+                "name": "Gire a  {modifier} en  {way_name}",
+                "destination": "Gire a  {modifier} hacia  {destination}"
+            },
+            "straight": {
+                "default": "Continua recto",
+                "name": "Continua recto en  {way_name}",
+                "destination": "Continua recto hacia  {destination}"
+            },
+            "uturn": {
+                "default": "Haz un cambio de sentido al final de la via",
+                "name": "Haz un cambio de sentido en  {way_name} al final de la via",
+                "destination": "Haz un cambio de sentido hacia  {destination} al final de la via"
+            }
+        },
+        "fork": {
+            "default": {
+                "default": "Mantengase  {modifier} en el cruce",
+                "name": "Mantengase  {modifier} en el cruce en  {way_name}",
+                "destination": "Mantengase  {modifier} en el cruce hacia  {destination}"
+            },
+            "slight left": {
+                "default": "Mantengase a la izquierda en el cruce",
+                "name": "Mantengase a la izquierda en el cruce en  {way_name}",
+                "destination": "Mantengase a la izquierda en el cruce hacia  {destination}"
+            },
+            "slight right": {
+                "default": "Mantengase a la derecha en el cruce",
+                "name": "Mantengase a la derecha en el cruce en {way_name}",
+                "destination": "Mantengase a la derecha en el cruce hacia  {destination}"
+            },
+            "sharp left": {
+                "default": "Gire a la izquierda en el cruce",
+                "name": "Gire a la izquierda en el cruce en {way_name}",
+                "destination": "Gire a la izquierda en el cruce hacia {destination}"
+            },
+            "sharp right": {
+                "default": "Gire a la derecha en el cruce",
+                "name": "Gire a la derecha en el cruce en {way_name}",
+                "destination": "Gire a la derecha en el cruce hacia {destination}"
+            },
+            "uturn": {
+                "default": "Haz un cambio de sentido",
+                "name": "Haz un cambio de sentido en  {way_name}",
+                "destination": "Haz un cambio de sentido hacia  {destination}"
+            }
+        },
+        "merge": {
+            "default": {
+                "default": "Gire  a  {modifier}",
+                "name": "Gire a  {modifier} en  {way_name}",
+                "destination": "Gire a  {modifier} hacia  {destination}"
+            },
+            "slight left": {
+                "default": "Gire a la izquierda",
+                "name": "Gire a la izquierda en  {way_name}",
+                "destination": "Gire a la izquierda hacia  {destination}"
+            },
+            "slight right": {
+                "default": "Gire a la derecha",
+                "name": "Gire a la derecha en  {way_name}",
+                "destination": "Gire a la derecha hacia  {destination}"
+            },
+            "sharp left": {
+                "default": "Gire a la izquierda",
+                "name": "Gire a la izquierda en  {way_name}",
+                "destination": "Gire a la izquierda hacia  {destination}"
+            },
+            "sharp right": {
+                "default": "Gire a la derecha",
+                "name": "Gire a la derecha en  {way_name}",
+                "destination": "Gire a la derecha hacia  {destination}"
+            },
+            "uturn": {
+                "default": "Haz un cambio de sentido",
+                "name": "Haz un cambio de sentido en  {way_name}",
+                "destination": "Haz un cambio de sentido hacia  {destination}"
+            }
+        },
+        "new name": {
+            "default": {
+                "default": "Continua  {modifier}",
+                "name": "Continua  {modifier} en  {way_name}",
+                "destination": "Continua  {modifier} hacia  {destination}"
+            },
+            "sharp left": {
+                "default": "Gire a la izquierda",
+                "name": "Gire a la izquierda en {way_name}",
+                "destination": "Gire a la izquierda hacia {destination}"
+            },
+            "sharp right": {
+                "default": "Gire a la derecha",
+                "name": "Gire a la derecha en {way_name}",
+                "destination": "Gire a la derecha hacia {destination}"
+            },
+            "slight left": {
+                "default": "Continua ligeramente a la izquierda",
+                "name": "Continua ligeramente a la izquierda en  {way_name}",
+                "destination": "Continua ligeramente a la izquierda hacia  {destination}"
+            },
+            "slight right": {
+                "default": "Continua ligeramente a la derecha",
+                "name": "Continua ligeramente a la derecha en  {way_name}",
+                "destination": "Continua ligeramente a la derecha hacia  {destination}"
+            },
+            "uturn": {
+                "default": "Haz un cambio de sentido",
+                "name": "Haz un cambio de sentido en  {way_name}",
+                "destination": "Haz un cambio de sentido hacia  {destination}"
+            }
+        },
+        "notification": {
+            "default": {
+                "default": "Continua  {modifier}",
+                "name": "Continua  {modifier} en  {way_name}",
+                "destination": "Continua  {modifier} hacia  {destination}"
+            },
+            "uturn": {
+                "default": "Haz un cambio de sentido",
+                "name": "Haz un cambio de sentido en  {way_name}",
+                "destination": "Haz un cambio de sentido hacia  {destination}"
+            }
+        },
+        "off ramp": {
+            "default": {
+                "default": "Ve cuesta abajo",
+                "name": "Ve cuesta abajo en {way_name}",
+                "destination": "Ve cuesta abajo hacia {destination}"
+            },
+            "left": {
+                "default": "Ve cuesta abajo en la izquierda",
+                "name": "Ve cuesta abajo en la izquierda en {way_name}",
+                "destination": "Ve cuesta abajo en la izquierda hacia {destination}"
+            },
+            "right": {
+                "default": "Ve cuesta abajo en la derecha",
+                "name": "Ve cuesta abajo en la derecha en {way_name}",
+                "destination": "Ve cuesta abajo en la derecha hacia {destination}"
+            },
+            "sharp left": {
+                "default": "Ve cuesta abajo en la izquierda",
+                "name": "Ve cuesta abajo en la izquierda en {way_name}",
+                "destination": "Ve cuesta abajo en la izquierda hacia {destination}"
+            },
+            "sharp right": {
+                "default": "Ve cuesta abajo en la derecha",
+                "name": "Ve cuesta abajo en la derecha en {way_name}",
+                "destination": "Ve cuesta abajo en la derecha hacia {destination}"
+            },
+            "slight left": {
+                "default": "Ve cuesta abajo en la izquierda",
+                "name": "Ve cuesta abajo en la izquierda en {way_name}",
+                "destination": "Ve cuesta abajo en la izquierda hacia {destination}"
+            },
+            "slight right": {
+                "default": "Ve cuesta abajo en la derecha",
+                "name": "Ve cuesta abajo en la derecha en {way_name}",
+                "destination": "Ve cuesta abajo en la derecha hacia {destination}"
+            }
+        },
+        "on ramp": {
+            "default": {
+                "default": "Ve cuesta abajo",
+                "name": "Ve cuesta abajo en {way_name}",
+                "destination": "Ve cuesta abajo hacia {destination}"
+            },
+            "left": {
+                "default": "Ve cuesta abajo en la izquierda",
+                "name": "Ve cuesta abajo en la izquierda en {way_name}",
+                "destination": "Ve cuesta abajo en la izquierda hacia {destination}"
+            },
+            "right": {
+                "default": "Ve cuesta abajo en la derecha",
+                "name": "Ve cuesta abajo en la derecha en {way_name}",
+                "destination": "Ve cuesta abajo en la derecha hacia {destination}"
+            },
+            "sharp left": {
+                "default": "Ve cuesta abajo en la izquierda",
+                "name": "Ve cuesta abajo en la izquierda en {way_name}",
+                "destination": "Ve cuesta abajo en la izquierda hacia {destination}"
+            },
+            "sharp right": {
+                "default": "Ve cuesta abajo en la derecha",
+                "name": "Ve cuesta abajo en la derecha en {way_name}",
+                "destination": "Ve cuesta abajo en la derecha hacia {destination}"
+            },
+            "slight left": {
+                "default": "Ve cuesta abajo en la izquierda",
+                "name": "Ve cuesta abajo en la izquierda en {way_name}",
+                "destination": "Ve cuesta abajo en la izquierda hacia {destination}"
+            },
+            "slight right": {
+                "default": "Ve cuesta abajo en la derecha",
+                "name": "Ve cuesta abajo en la derecha en {way_name}",
+                "destination": "Ve cuesta abajo en la derecha hacia {destination}"
+            }
+        },
+        "rotary": {
+            "default": {
+                "default": {
+                    "default": "Entra en la rotonda",
+                    "name": "Entra en la rotonda y sal en {way_name}",
+                    "destination": "Entra en la rotonda y sal hacia {destination}"
+                },
+                "name": {
+                    "default": "Entra en {rotary_name}",
+                    "name": "Entra en {rotary_name} y sal en {way_name}",
+                    "destination": "Entra en {rotary_name} y sal hacia {destination}"
+                },
+                "exit": {
+                    "default": "Entra en la rotonda y toma la {exit_number} salida",
+                    "name": "Entra en la rotonda y toma la {exit_number} salida a {way_name}",
+                    "destination": "Entra en la rotonda y toma la {exit_number} salida hacia {destination}"
+                },
+                "name_exit": {
+                    "default": "Entra en {rotary_name} y coge la {exit_number} salida",
+                    "name": "Entra en {rotary_name} y coge la {exit_number} salida en {way_name}",
+                    "destination": "Entra en {rotary_name} y coge la {exit_number} salida hacia {destination}"
+                }
+            }
+        },
+        "roundabout": {
+            "default": {
+                "exit": {
+                    "default": "Entra en la rotonda y toma la {exit_number} salida",
+                    "name": "Entra en la rotonda y toma la {exit_number} salida a {way_name}",
+                    "destination": "Entra en la rotonda y toma la {exit_number} salida hacia {destination}"
+                },
+                "default": {
+                    "default": "Entra en la rotonda",
+                    "name": "Entra en la rotonda y sal en {way_name}",
+                    "destination": "Entra en la rotonda y sal hacia {destination}"
+                }
+            }
+        },
+        "roundabout turn": {
+            "default": {
+                "default": "En la rotonda siga {modifier}",
+                "name": "En la rotonda siga {modifier} en {way_name}",
+                "destination": "En la rotonda siga {modifier} hacia {destination}"
+            },
+            "left": {
+                "default": "En la rotonda gira a la izquierda",
+                "name": "En la rotonda gira a la izquierda en {way_name}",
+                "destination": "En la rotonda gira a la izquierda hacia {destination}"
+            },
+            "right": {
+                "default": "En la rotonda gira a la derecha",
+                "name": "En la rotonda gira a la derecha en {way_name}",
+                "destination": "En la rotonda gira a la derecha hacia {destination}"
+            },
+            "straight": {
+                "default": "En la rotonda continua recto",
+                "name": "En la rotonda continua recto en {way_name}",
+                "destination": "En la rotonda continua recto hacia {destination}"
+            }
+        },
+        "turn": {
+            "default": {
+                "default": "Siga {modifier}",
+                "name": "Siga {modifier} en {way_name}",
+                "destination": "Siga {modifier} hacia {destination}"
+            },
+            "left": {
+                "default": "Gire a la izquierda",
+                "name": "Gire a la izquierda en  {way_name}",
+                "destination": "Gire a la izquierda hacia  {destination}"
+            },
+            "right": {
+                "default": "Gire a la derecha",
+                "name": "Gire a la derecha en  {way_name}",
+                "destination": "Gire a la derecha hacia  {destination}"
+            },
+            "straight": {
+                "default": "Ve recto",
+                "name": "Ve recto en  {way_name}",
+                "destination": "Ve recto hacia  {destination}"
+            }
+        },
+        "use lane": {
+            "no_lanes": {
+                "default": "Continua recto"
+            },
+            "default": {
+                "default": "{lane_instruction}"
+            }
+        }
+    }
+}

--- a/languages/translations/es.json
+++ b/languages/translations/es.json
@@ -52,28 +52,28 @@
         },
         "arrive": {
             "default": {
-                "default": "Has llegado a tu  {nth} destino"
+                "default": "Has llegado a tu {nth} destino"
             },
             "left": {
-                "default": "Has llegado a tu  {nth} destino, a la izquierda"
+                "default": "Has llegado a tu {nth} destino, a la izquierda"
             },
             "right": {
-                "default": "Has llegado a tu  {nth} destino, a la derecha"
+                "default": "Has llegado a tu {nth} destino, a la derecha"
             },
             "sharp left": {
-                "default": "Has llegado a tu  {nth} destino, a la izquierda"
+                "default": "Has llegado a tu {nth} destino, a la izquierda"
             },
             "sharp right": {
-                "default": "Has llegado a tu  {nth} destino, a la derecha"
+                "default": "Has llegado a tu {nth} destino, a la derecha"
             },
             "slight right": {
-                "default": "Has llegado a tu  {nth} destino, a la derecha"
+                "default": "Has llegado a tu {nth} destino, a la derecha"
             },
             "slight left": {
-                "default": "Has llegado a tu  {nth} destino, a la izquierda"
+                "default": "Has llegado a tu {nth} destino, a la izquierda"
             },
             "straight": {
-                "default": "Has llegado a tu  {nth} destino, en frente"
+                "default": "Has llegado a tu {nth} destino, en frente"
             }
         },
         "continue": {

--- a/test/fixtures/v5/arrive/left.json
+++ b/test/fixtures/v5/arrive/left.json
@@ -9,7 +9,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich links von Ihnen",
         "en": "You have arrived at your destination, on the left",
-        "es": "Has llegado a tu  destino, a la izquierda",
+        "es": "Has llegado a tu destino, a la izquierda",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "nl": "Je bent gearriveerd. De bestemming bevindt zich links.",
         "ru": "Вы прибыли в пункт назначения, он находится слева",

--- a/test/fixtures/v5/arrive/left.json
+++ b/test/fixtures/v5/arrive/left.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich links von Ihnen",
         "en": "You have arrived at your destination, on the left",
+        "es": "Has llegado a tu  destino, a la izquierda",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "nl": "Je bent gearriveerd. De bestemming bevindt zich links.",
         "ru": "Вы прибыли в пункт назначения, он находится слева",

--- a/test/fixtures/v5/arrive/no_modifier.json
+++ b/test/fixtures/v5/arrive/no_modifier.json
@@ -8,7 +8,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht",
         "en": "You have arrived at your destination",
-        "es": "Has llegado a tu  destino",
+        "es": "Has llegado a tu destino",
         "fr": "Vous êtes arrivés à votre destination",
         "nl": "Je bent gearriveerd op de bestemming.",
         "ru": "Вы прибыли в пункт назначения",

--- a/test/fixtures/v5/arrive/no_modifier.json
+++ b/test/fixtures/v5/arrive/no_modifier.json
@@ -8,6 +8,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht",
         "en": "You have arrived at your destination",
+        "es": "Has llegado a tu  destino",
         "fr": "Vous êtes arrivés à votre destination",
         "nl": "Je bent gearriveerd op de bestemming.",
         "ru": "Вы прибыли в пункт назначения",

--- a/test/fixtures/v5/arrive/right.json
+++ b/test/fixtures/v5/arrive/right.json
@@ -9,7 +9,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich rechts von Ihnen",
         "en": "You have arrived at your destination, on the right",
-        "es": "Has llegado a tu  destino, a la derecha",
+        "es": "Has llegado a tu destino, a la derecha",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "nl": "Je bent gearriveerd. De bestemming bevindt zich rechts.",
         "ru": "Вы прибыли в пункт назначения, он находится справа",

--- a/test/fixtures/v5/arrive/right.json
+++ b/test/fixtures/v5/arrive/right.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich rechts von Ihnen",
         "en": "You have arrived at your destination, on the right",
+        "es": "Has llegado a tu  destino, a la derecha",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "nl": "Je bent gearriveerd. De bestemming bevindt zich rechts.",
         "ru": "Вы прибыли в пункт назначения, он находится справа",

--- a/test/fixtures/v5/arrive/sharp_left.json
+++ b/test/fixtures/v5/arrive/sharp_left.json
@@ -9,7 +9,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich links von Ihnen",
         "en": "You have arrived at your destination, on the left",
-        "es": "Has llegado a tu  destino, a la izquierda",
+        "es": "Has llegado a tu destino, a la izquierda",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "nl": "Je bent gearriveerd. De bestemming bevindt zich links.",
         "ru": "Вы прибыли в пункт назначения, он находится слева",

--- a/test/fixtures/v5/arrive/sharp_left.json
+++ b/test/fixtures/v5/arrive/sharp_left.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich links von Ihnen",
         "en": "You have arrived at your destination, on the left",
+        "es": "Has llegado a tu  destino, a la izquierda",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "nl": "Je bent gearriveerd. De bestemming bevindt zich links.",
         "ru": "Вы прибыли в пункт назначения, он находится слева",

--- a/test/fixtures/v5/arrive/sharp_right.json
+++ b/test/fixtures/v5/arrive/sharp_right.json
@@ -9,7 +9,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich rechts von Ihnen",
         "en": "You have arrived at your destination, on the right",
-        "es": "Has llegado a tu  destino, a la derecha",
+        "es": "Has llegado a tu destino, a la derecha",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "nl": "Je bent gearriveerd. De bestemming bevindt zich rechts.",
         "ru": "Вы прибыли в пункт назначения, он находится справа",

--- a/test/fixtures/v5/arrive/sharp_right.json
+++ b/test/fixtures/v5/arrive/sharp_right.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich rechts von Ihnen",
         "en": "You have arrived at your destination, on the right",
+        "es": "Has llegado a tu  destino, a la derecha",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "nl": "Je bent gearriveerd. De bestemming bevindt zich rechts.",
         "ru": "Вы прибыли в пункт назначения, он находится справа",

--- a/test/fixtures/v5/arrive/slight_left.json
+++ b/test/fixtures/v5/arrive/slight_left.json
@@ -9,7 +9,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich links von Ihnen",
         "en": "You have arrived at your destination, on the left",
-        "es": "Has llegado a tu  destino, a la izquierda",
+        "es": "Has llegado a tu destino, a la izquierda",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "nl": "Je bent gearriveerd. De bestemming bevindt zich links.",
         "ru": "Вы прибыли в пункт назначения, он находится слева",

--- a/test/fixtures/v5/arrive/slight_left.json
+++ b/test/fixtures/v5/arrive/slight_left.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich links von Ihnen",
         "en": "You have arrived at your destination, on the left",
+        "es": "Has llegado a tu  destino, a la izquierda",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "nl": "Je bent gearriveerd. De bestemming bevindt zich links.",
         "ru": "Вы прибыли в пункт назначения, он находится слева",

--- a/test/fixtures/v5/arrive/slight_right.json
+++ b/test/fixtures/v5/arrive/slight_right.json
@@ -9,7 +9,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich rechts von Ihnen",
         "en": "You have arrived at your destination, on the right",
-        "es": "Has llegado a tu  destino, a la derecha",
+        "es": "Has llegado a tu destino, a la derecha",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "nl": "Je bent gearriveerd. De bestemming bevindt zich rechts.",
         "ru": "Вы прибыли в пункт назначения, он находится справа",

--- a/test/fixtures/v5/arrive/slight_right.json
+++ b/test/fixtures/v5/arrive/slight_right.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich rechts von Ihnen",
         "en": "You have arrived at your destination, on the right",
+        "es": "Has llegado a tu  destino, a la derecha",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "nl": "Je bent gearriveerd. De bestemming bevindt zich rechts.",
         "ru": "Вы прибыли в пункт назначения, он находится справа",

--- a/test/fixtures/v5/arrive/straight.json
+++ b/test/fixtures/v5/arrive/straight.json
@@ -9,7 +9,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich direkt vor Ihnen",
         "en": "You have arrived at your destination, straight ahead",
-        "es": "Has llegado a tu  destino, en frente",
+        "es": "Has llegado a tu destino, en frente",
         "fr": "Vous êtes arrivés à votre destination, droit devant",
         "nl": "Je bent gearriveerd. De bestemming bevindt zich voor je.",
         "ru": "Вы прибыли в пункт назначения, он находится перед вами",

--- a/test/fixtures/v5/arrive/straight.json
+++ b/test/fixtures/v5/arrive/straight.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich direkt vor Ihnen",
         "en": "You have arrived at your destination, straight ahead",
+        "es": "Has llegado a tu  destino, en frente",
         "fr": "Vous êtes arrivés à votre destination, droit devant",
         "nl": "Je bent gearriveerd. De bestemming bevindt zich voor je.",
         "ru": "Вы прибыли в пункт назначения, он находится перед вами",

--- a/test/fixtures/v5/arrive/uturn.json
+++ b/test/fixtures/v5/arrive/uturn.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht",
         "en": "You have arrived at your destination",
+        "es": "Has llegado a tu  destino",
         "fr": "Vous êtes arrivés à votre destination",
         "nl": "Je bent gearriveerd op de bestemming.",
         "ru": "Вы прибыли в пункт назначения",

--- a/test/fixtures/v5/arrive/uturn.json
+++ b/test/fixtures/v5/arrive/uturn.json
@@ -9,7 +9,7 @@
     "instructions": {
         "de": "Sie haben Ihr Ziel erreicht",
         "en": "You have arrived at your destination",
-        "es": "Has llegado a tu  destino",
+        "es": "Has llegado a tu destino",
         "fr": "Vous êtes arrivés à votre destination",
         "nl": "Je bent gearriveerd op de bestemming.",
         "ru": "Вы прибыли в пункт назначения",

--- a/test/fixtures/v5/continue/left_default.json
+++ b/test/fixtures/v5/continue/left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Links weiterfahren",
         "en": "Continue left",
+        "es": "Continua izquierda",
         "fr": "Continuer à gauche",
         "nl": "Ga links",
         "ru": "Двигайтесь налево",

--- a/test/fixtures/v5/continue/left_destination.json
+++ b/test/fixtures/v5/continue/left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Links weiterfahren Richtung Destination 1",
         "en": "Continue left towards Destination 1",
+        "es": "Continua izquierda hacia Destination 1",
         "fr": "Continuer à gauche en direction de Destination 1",
         "nl": "Ga links richting Destination 1",
         "ru": "Двигайтесь налево в направлении Destination 1",

--- a/test/fixtures/v5/continue/left_name.json
+++ b/test/fixtures/v5/continue/left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Links weiterfahren auf Way Name",
         "en": "Continue left onto Way Name",
+        "es": "Continua izquierda en Way Name",
         "fr": "Continuer à gauche sur Way Name",
         "nl": "Ga links naar Way Name",
         "ru": "Двигайтесь налево по Way Name",

--- a/test/fixtures/v5/continue/right_default.json
+++ b/test/fixtures/v5/continue/right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rechts weiterfahren",
         "en": "Continue right",
+        "es": "Continua derecha",
         "fr": "Continuer à droite",
         "nl": "Ga rechts",
         "ru": "Двигайтесь направо",

--- a/test/fixtures/v5/continue/right_destination.json
+++ b/test/fixtures/v5/continue/right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rechts weiterfahren Richtung Destination 1",
         "en": "Continue right towards Destination 1",
+        "es": "Continua derecha hacia Destination 1",
         "fr": "Continuer à droite en direction de Destination 1",
         "nl": "Ga rechts richting Destination 1",
         "ru": "Двигайтесь направо в направлении Destination 1",

--- a/test/fixtures/v5/continue/right_name.json
+++ b/test/fixtures/v5/continue/right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rechts weiterfahren auf Way Name",
         "en": "Continue right onto Way Name",
+        "es": "Continua derecha en Way Name",
         "fr": "Continuer à droite sur Way Name",
         "nl": "Ga rechts naar Way Name",
         "ru": "Двигайтесь направо по Way Name",

--- a/test/fixtures/v5/continue/sharp_left_default.json
+++ b/test/fixtures/v5/continue/sharp_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf links weiterfahren",
         "en": "Continue sharp left",
+        "es": "Continua cerrada a la izquierda",
         "fr": "Continuer franchement à gauche",
         "nl": "Ga linksaf",
         "ru": "Двигайтесь налево",

--- a/test/fixtures/v5/continue/sharp_left_destination.json
+++ b/test/fixtures/v5/continue/sharp_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Scharf links weiterfahren Richtung Destination 1",
         "en": "Continue sharp left towards Destination 1",
+        "es": "Continua cerrada a la izquierda hacia Destination 1",
         "fr": "Continuer franchement à gauche en direction de Destination 1",
         "nl": "Ga linksaf richting Destination 1",
         "ru": "Двигайтесь налево в направлении Destination 1",

--- a/test/fixtures/v5/continue/sharp_left_name.json
+++ b/test/fixtures/v5/continue/sharp_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf links weiterfahren auf Way Name",
         "en": "Continue sharp left onto Way Name",
+        "es": "Continua cerrada a la izquierda en Way Name",
         "fr": "Continuer franchement à gauche sur Way Name",
         "nl": "Ga linksaf naar Way Name",
         "ru": "Двигайтесь налево по Way Name",

--- a/test/fixtures/v5/continue/sharp_right_default.json
+++ b/test/fixtures/v5/continue/sharp_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf rechts weiterfahren",
         "en": "Continue sharp right",
+        "es": "Continua cerrada a la derecha",
         "fr": "Continuer franchement à droite",
         "nl": "Ga rechtsaf",
         "ru": "Двигайтесь направо",

--- a/test/fixtures/v5/continue/sharp_right_destination.json
+++ b/test/fixtures/v5/continue/sharp_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Scharf rechts weiterfahren Richtung Destination 1",
         "en": "Continue sharp right towards Destination 1",
+        "es": "Continua cerrada a la derecha hacia Destination 1",
         "fr": "Continuer franchement à droite en direction de Destination 1",
         "nl": "Ga rechtsaf richting Destination 1",
         "ru": "Двигайтесь направо в направлении Destination 1",

--- a/test/fixtures/v5/continue/sharp_right_name.json
+++ b/test/fixtures/v5/continue/sharp_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf rechts weiterfahren auf Way Name",
         "en": "Continue sharp right onto Way Name",
+        "es": "Continua cerrada a la derecha en Way Name",
         "fr": "Continuer franchement à droite sur Way Name",
         "nl": "Ga rechtsaf naar Way Name",
         "ru": "Двигайтесь направо по Way Name",

--- a/test/fixtures/v5/continue/slight_left_default.json
+++ b/test/fixtures/v5/continue/slight_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht links weiter",
         "en": "Continue slightly left",
+        "es": "Continua ligeramente a la izquierda",
         "fr": "Continuer légèrement à gauche",
         "nl": "Links aanhouden",
         "ru": "Плавно поверните налево",

--- a/test/fixtures/v5/continue/slight_left_destination.json
+++ b/test/fixtures/v5/continue/slight_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Leicht links weiter Richtung Destination 1",
         "en": "Continue slightly left towards Destination 1",
+        "es": "Continua ligeramente a la izquierda hacia Destination 1",
         "fr": "Continuer légèrement à gauche en direction de Destination 1",
         "nl": "Links aanhouden richting Destination 1",
         "ru": "Плавно поверните налево в направлении Destination 1",

--- a/test/fixtures/v5/continue/slight_left_name.json
+++ b/test/fixtures/v5/continue/slight_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht links weiter auf Way Name",
         "en": "Continue slightly left onto Way Name",
+        "es": "Continua ligeramente a la izquierda en Way Name",
         "fr": "Continuer légèrement à gauche sur Way Name",
         "nl": "Links aanhouden naar Way Name",
         "ru": "Плавно поверните налево на Way Name",

--- a/test/fixtures/v5/continue/slight_right_default.json
+++ b/test/fixtures/v5/continue/slight_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht rechts weiter",
         "en": "Continue slightly right",
+        "es": "Continua ligeramente a la derecha",
         "fr": "Continuer légèrement à droite",
         "nl": "Rechts aanhouden",
         "ru": "Плавно поверните направо",

--- a/test/fixtures/v5/continue/slight_right_destination.json
+++ b/test/fixtures/v5/continue/slight_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Leicht rechts weiter Richtung Destination 1",
         "en": "Continue slightly right towards Destination 1",
+        "es": "Continua ligeramente a la derecha hacia Destination 1",
         "fr": "Continuer légèrement à droite en direction de Destination 1",
         "nl": "Rechts aanhouden richting Destination 1",
         "ru": "Плавно поверните направо в направлении Destination 1",

--- a/test/fixtures/v5/continue/slight_right_name.json
+++ b/test/fixtures/v5/continue/slight_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht rechts weiter auf Way Name",
         "en": "Continue slightly right onto Way Name",
+        "es": "Continua ligeramente a la derecha en Way Name",
         "fr": "Continuer légèrement à droite sur Way Name",
         "nl": "Rechts aanhouden naar Way Name",
         "ru": "Плавно поверните направо на Way Name",

--- a/test/fixtures/v5/continue/straight_default.json
+++ b/test/fixtures/v5/continue/straight_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren",
         "en": "Continue straight",
+        "es": "Continua recto",
         "fr": "Continuer tout droit",
         "nl": "Ga rechtdoor",
         "ru": "Двигайтесь прямо",

--- a/test/fixtures/v5/continue/straight_destination.json
+++ b/test/fixtures/v5/continue/straight_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren Richtung Destination 1",
         "en": "Continue towards Destination 1",
+        "es": "Continua hacia Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "nl": "Ga rechtdoor richting Destination 1",
         "ru": "Продолжите движение в направлении Destination 1",

--- a/test/fixtures/v5/continue/straight_name.json
+++ b/test/fixtures/v5/continue/straight_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren auf Way Name",
         "en": "Continue onto Way Name",
+        "es": "Continua en Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "nl": "Ga rechtdoor naar Way Name",
         "ru": "Продолжите движение по Way Name",

--- a/test/fixtures/v5/continue/uturn_default.json
+++ b/test/fixtures/v5/continue/uturn_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "180°-Wendung",
         "en": "Make a U-turn",
+        "es": "Haz un cambio de sentido",
         "fr": "Faire demi-tour",
         "nl": "Keer om",
         "ru": "Развернитесь",

--- a/test/fixtures/v5/continue/uturn_destination.json
+++ b/test/fixtures/v5/continue/uturn_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "180°-Wendung Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
+        "es": "Haz un cambio de sentido hacia Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "nl": "Keer om richting Destination 1",
         "ru": "Развернитесь в направлении Destination 1",

--- a/test/fixtures/v5/continue/uturn_name.json
+++ b/test/fixtures/v5/continue/uturn_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "180°-Wendung auf Way Name",
         "en": "Make a U-turn onto Way Name",
+        "es": "Haz un cambio de sentido en Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "nl": "Keer om naar Way Name",
         "ru": "Развернитесь на Way Name",

--- a/test/fixtures/v5/depart/east_110.json
+++ b/test/fixtures/v5/depart/east_110.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Osten",
         "en": "Head east",
+        "es": "Ve a este",
         "fr": "Rouler vers l'est",
         "nl": "Vertrek in oostelijke richting",
         "ru": "Двигайтесь в восточном направлении",

--- a/test/fixtures/v5/depart/east_70.json
+++ b/test/fixtures/v5/depart/east_70.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Osten",
         "en": "Head east",
+        "es": "Ve a este",
         "fr": "Rouler vers l'est",
         "nl": "Vertrek in oostelijke richting",
         "ru": "Двигайтесь в восточном направлении",

--- a/test/fixtures/v5/depart/modifier_default.json
+++ b/test/fixtures/v5/depart/modifier_default.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Norden",
         "en": "Head north",
+        "es": "Ve a norte",
         "fr": "Rouler vers le nord",
         "nl": "Vertrek in noordelijke richting",
         "ru": "Двигайтесь в северном направлении",

--- a/test/fixtures/v5/depart/modifier_destination.json
+++ b/test/fixtures/v5/depart/modifier_destination.json
@@ -11,6 +11,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Norden auf Way Name",
         "en": "Head north on Way Name",
+        "es": "Ve a norte en Way Name",
         "fr": "Rouler vers le nord sur Way Name",
         "nl": "Neem Way Name in noordelijke richting",
         "ru": "Двигайтесь в северном направлении по Way Name",

--- a/test/fixtures/v5/depart/modifier_name.json
+++ b/test/fixtures/v5/depart/modifier_name.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Norden auf Way Name",
         "en": "Head north on Way Name",
+        "es": "Ve a norte en Way Name",
         "fr": "Rouler vers le nord sur Way Name",
         "nl": "Neem Way Name in noordelijke richting",
         "ru": "Двигайтесь в северном направлении по Way Name",

--- a/test/fixtures/v5/depart/north_20.json
+++ b/test/fixtures/v5/depart/north_20.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Norden",
         "en": "Head north",
+        "es": "Ve a norte",
         "fr": "Rouler vers le nord",
         "nl": "Vertrek in noordelijke richting",
         "ru": "Двигайтесь в северном направлении",

--- a/test/fixtures/v5/depart/north_340.json
+++ b/test/fixtures/v5/depart/north_340.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Norden",
         "en": "Head north",
+        "es": "Ve a norte",
         "fr": "Rouler vers le nord",
         "nl": "Vertrek in noordelijke richting",
         "ru": "Двигайтесь в северном направлении",

--- a/test/fixtures/v5/depart/northeast_21.json
+++ b/test/fixtures/v5/depart/northeast_21.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Nordosten",
         "en": "Head northeast",
+        "es": "Ve a noreste",
         "fr": "Rouler vers le nord-est",
         "nl": "Vertrek in noordoostelijke richting",
         "ru": "Двигайтесь в северо-восточном направлении",

--- a/test/fixtures/v5/depart/northeast_69.json
+++ b/test/fixtures/v5/depart/northeast_69.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Nordosten",
         "en": "Head northeast",
+        "es": "Ve a noreste",
         "fr": "Rouler vers le nord-est",
         "nl": "Vertrek in noordoostelijke richting",
         "ru": "Двигайтесь в северо-восточном направлении",

--- a/test/fixtures/v5/depart/northwest_291.json
+++ b/test/fixtures/v5/depart/northwest_291.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Nordwesten",
         "en": "Head northwest",
+        "es": "Ve a noroeste",
         "fr": "Rouler vers le nord-ouest",
         "nl": "Vertrek in noordwestelijke richting",
         "ru": "Двигайтесь в северо-западном направлении",

--- a/test/fixtures/v5/depart/northwest_339.json
+++ b/test/fixtures/v5/depart/northwest_339.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Nordwesten",
         "en": "Head northwest",
+        "es": "Ve a noroeste",
         "fr": "Rouler vers le nord-ouest",
         "nl": "Vertrek in noordwestelijke richting",
         "ru": "Двигайтесь в северо-западном направлении",

--- a/test/fixtures/v5/depart/south_160.json
+++ b/test/fixtures/v5/depart/south_160.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Süden",
         "en": "Head south",
+        "es": "Ve a sur",
         "fr": "Rouler vers le sud",
         "nl": "Vertrek in zuidelijke richting",
         "ru": "Двигайтесь в южном направлении",

--- a/test/fixtures/v5/depart/south_200.json
+++ b/test/fixtures/v5/depart/south_200.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Süden",
         "en": "Head south",
+        "es": "Ve a sur",
         "fr": "Rouler vers le sud",
         "nl": "Vertrek in zuidelijke richting",
         "ru": "Двигайтесь в южном направлении",

--- a/test/fixtures/v5/depart/southeast_111.json
+++ b/test/fixtures/v5/depart/southeast_111.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Südosten",
         "en": "Head southeast",
+        "es": "Ve a sureste",
         "fr": "Rouler vers le sud-est",
         "nl": "Vertrek in zuidoostelijke richting",
         "ru": "Двигайтесь в юго-восточном направлении",

--- a/test/fixtures/v5/depart/southeast_159.json
+++ b/test/fixtures/v5/depart/southeast_159.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Südosten",
         "en": "Head southeast",
+        "es": "Ve a sureste",
         "fr": "Rouler vers le sud-est",
         "nl": "Vertrek in zuidoostelijke richting",
         "ru": "Двигайтесь в юго-восточном направлении",

--- a/test/fixtures/v5/depart/southwest_201.json
+++ b/test/fixtures/v5/depart/southwest_201.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Südwesten",
         "en": "Head southwest",
+        "es": "Ve a suroeste",
         "fr": "Rouler vers le sud-ouest",
         "nl": "Vertrek in zuidwestelijke richting",
         "ru": "Двигайтесь в юго-западном направлении",

--- a/test/fixtures/v5/depart/southwest_249.json
+++ b/test/fixtures/v5/depart/southwest_249.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Südwesten",
         "en": "Head southwest",
+        "es": "Ve a suroeste",
         "fr": "Rouler vers le sud-ouest",
         "nl": "Vertrek in zuidwestelijke richting",
         "ru": "Двигайтесь в юго-западном направлении",

--- a/test/fixtures/v5/depart/west_250.json
+++ b/test/fixtures/v5/depart/west_250.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Westen",
         "en": "Head west",
+        "es": "Ve a oeste",
         "fr": "Rouler vers l'ouest",
         "nl": "Vertrek in westelijke richting",
         "ru": "Двигайтесь в западном направлении",

--- a/test/fixtures/v5/depart/west_290.json
+++ b/test/fixtures/v5/depart/west_290.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Fahren Sie Richtung Westen",
         "en": "Head west",
+        "es": "Ve a oeste",
         "fr": "Rouler vers l'ouest",
         "nl": "Vertrek in westelijke richting",
         "ru": "Двигайтесь в западном направлении",

--- a/test/fixtures/v5/end_of_road/left_default.json
+++ b/test/fixtures/v5/end_of_road/left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Links abbiegen",
         "en": "Turn left",
+        "es": "Gire a izquierda",
         "fr": "Tourner à gauche",
         "nl": "Ga links",
         "ru": "Поверните налево",

--- a/test/fixtures/v5/end_of_road/left_destination.json
+++ b/test/fixtures/v5/end_of_road/left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Links abbiegen Richtung Destination 1",
         "en": "Turn left towards Destination 1",
+        "es": "Gire a izquierda hacia Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "nl": "Ga links richting Destination 1",
         "ru": "Двигайтесь налево в направлении Destination 1",

--- a/test/fixtures/v5/end_of_road/left_name.json
+++ b/test/fixtures/v5/end_of_road/left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Links abbiegen auf Way Name",
         "en": "Turn left onto Way Name",
+        "es": "Gire a izquierda en Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "nl": "Ga links naar Way Name",
         "ru": "Двигайтесь налево на Way Name",

--- a/test/fixtures/v5/end_of_road/right_default.json
+++ b/test/fixtures/v5/end_of_road/right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rechts abbiegen",
         "en": "Turn right",
+        "es": "Gire a derecha",
         "fr": "Tourner à droite",
         "nl": "Ga rechts",
         "ru": "Поверните направо",

--- a/test/fixtures/v5/end_of_road/right_destination.json
+++ b/test/fixtures/v5/end_of_road/right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rechts abbiegen Richtung Destination 1",
         "en": "Turn right towards Destination 1",
+        "es": "Gire a derecha hacia Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "nl": "Ga rechts richting Destination 1",
         "ru": "Двигайтесь направо в направлении Destination 1",

--- a/test/fixtures/v5/end_of_road/right_name.json
+++ b/test/fixtures/v5/end_of_road/right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rechts abbiegen auf Way Name",
         "en": "Turn right onto Way Name",
+        "es": "Gire a derecha en Way Name",
         "fr": "Tourner à droite sur Way Name",
         "nl": "Ga rechts naar Way Name",
         "ru": "Двигайтесь направо на Way Name",

--- a/test/fixtures/v5/end_of_road/sharp_left_default.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf links abbiegen",
         "en": "Turn sharp left",
+        "es": "Gire a cerrada a la izquierda",
         "fr": "Tourner franchement à gauche",
         "nl": "Ga linksaf",
         "ru": "Поверните налево",

--- a/test/fixtures/v5/end_of_road/sharp_left_destination.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Scharf links abbiegen Richtung Destination 1",
         "en": "Turn sharp left towards Destination 1",
+        "es": "Gire a cerrada a la izquierda hacia Destination 1",
         "fr": "Tourner franchement à gauche en direction de Destination 1",
         "nl": "Ga linksaf richting Destination 1",
         "ru": "Двигайтесь налево в направлении Destination 1",

--- a/test/fixtures/v5/end_of_road/sharp_left_name.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf links abbiegen auf Way Name",
         "en": "Turn sharp left onto Way Name",
+        "es": "Gire a cerrada a la izquierda en Way Name",
         "fr": "Tourner franchement à gauche sur Way Name",
         "nl": "Ga linksaf naar Way Name",
         "ru": "Двигайтесь налево на Way Name",

--- a/test/fixtures/v5/end_of_road/sharp_right_default.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf rechts abbiegen",
         "en": "Turn sharp right",
+        "es": "Gire a cerrada a la derecha",
         "fr": "Tourner franchement à droite",
         "nl": "Ga rechtsaf",
         "ru": "Поверните направо",

--- a/test/fixtures/v5/end_of_road/sharp_right_destination.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Scharf rechts abbiegen Richtung Destination 1",
         "en": "Turn sharp right towards Destination 1",
+        "es": "Gire a cerrada a la derecha hacia Destination 1",
         "fr": "Tourner franchement à droite en direction de Destination 1",
         "nl": "Ga rechtsaf richting Destination 1",
         "ru": "Двигайтесь направо в направлении Destination 1",

--- a/test/fixtures/v5/end_of_road/sharp_right_name.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf rechts abbiegen auf Way Name",
         "en": "Turn sharp right onto Way Name",
+        "es": "Gire a cerrada a la derecha en Way Name",
         "fr": "Tourner franchement à droite sur Way Name",
         "nl": "Ga rechtsaf naar Way Name",
         "ru": "Двигайтесь направо на Way Name",

--- a/test/fixtures/v5/end_of_road/slight_left_default.json
+++ b/test/fixtures/v5/end_of_road/slight_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht links abbiegen",
         "en": "Turn slight left",
+        "es": "Gire a ligeramente a la izquierda",
         "fr": "Tourner légèrement à gauche",
         "nl": "Ga links",
         "ru": "Поверните левее",

--- a/test/fixtures/v5/end_of_road/slight_left_destination.json
+++ b/test/fixtures/v5/end_of_road/slight_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Leicht links abbiegen Richtung Destination 1",
         "en": "Turn slight left towards Destination 1",
+        "es": "Gire a ligeramente a la izquierda hacia Destination 1",
         "fr": "Tourner légèrement à gauche en direction de Destination 1",
         "nl": "Ga links richting Destination 1",
         "ru": "Двигайтесь левее в направлении Destination 1",

--- a/test/fixtures/v5/end_of_road/slight_left_name.json
+++ b/test/fixtures/v5/end_of_road/slight_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht links abbiegen auf Way Name",
         "en": "Turn slight left onto Way Name",
+        "es": "Gire a ligeramente a la izquierda en Way Name",
         "fr": "Tourner légèrement à gauche sur Way Name",
         "nl": "Ga links naar Way Name",
         "ru": "Двигайтесь левее на Way Name",

--- a/test/fixtures/v5/end_of_road/slight_right_default.json
+++ b/test/fixtures/v5/end_of_road/slight_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht rechts abbiegen",
         "en": "Turn slight right",
+        "es": "Gire a ligeramente a la derecha",
         "fr": "Tourner légèrement à droite",
         "nl": "Ga rechts",
         "ru": "Поверните правее",

--- a/test/fixtures/v5/end_of_road/slight_right_destination.json
+++ b/test/fixtures/v5/end_of_road/slight_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Leicht rechts abbiegen Richtung Destination 1",
         "en": "Turn slight right towards Destination 1",
+        "es": "Gire a ligeramente a la derecha hacia Destination 1",
         "fr": "Tourner légèrement à droite en direction de Destination 1",
         "nl": "Ga rechts richting Destination 1",
         "ru": "Двигайтесь правее в направлении Destination 1",

--- a/test/fixtures/v5/end_of_road/slight_right_name.json
+++ b/test/fixtures/v5/end_of_road/slight_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht rechts abbiegen auf Way Name",
         "en": "Turn slight right onto Way Name",
+        "es": "Gire a ligeramente a la derecha en Way Name",
         "fr": "Tourner légèrement à droite sur Way Name",
         "nl": "Ga rechts naar Way Name",
         "ru": "Двигайтесь правее на Way Name",

--- a/test/fixtures/v5/end_of_road/straight_default.json
+++ b/test/fixtures/v5/end_of_road/straight_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren",
         "en": "Continue straight",
+        "es": "Continua recto",
         "fr": "Continuer tout droit",
         "nl": "Ga in de aangegeven richting",
         "ru": "Двигайтесь прямо",

--- a/test/fixtures/v5/end_of_road/straight_destination.json
+++ b/test/fixtures/v5/end_of_road/straight_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren Richtung Destination 1",
         "en": "Continue straight towards Destination 1",
+        "es": "Continua recto hacia Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "nl": "Ga richting Destination 1",
         "ru": "Двигайтесь прямо в направлении Destination 1",

--- a/test/fixtures/v5/end_of_road/straight_name.json
+++ b/test/fixtures/v5/end_of_road/straight_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren auf Way Name",
         "en": "Continue straight onto Way Name",
+        "es": "Continua recto en Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "nl": "Ga naar Way Name",
         "ru": "Двигайтесь прямо по Way Name",

--- a/test/fixtures/v5/end_of_road/uturn_default.json
+++ b/test/fixtures/v5/end_of_road/uturn_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "180°-Wendung am Ende der Straße",
         "en": "Make a U-turn at the end of the road",
+        "es": "Haz un cambio de sentido al final de la via",
         "fr": "Faire demi-tour à la fin de la route",
         "nl": "Keer om",
         "ru": "В конце дороги развернитесь",

--- a/test/fixtures/v5/end_of_road/uturn_destination.json
+++ b/test/fixtures/v5/end_of_road/uturn_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "180°-Wendung Richtung Destination 1 am Ende der Straße",
         "en": "Make a U-turn towards Destination 1 at the end of the road",
+        "es": "Haz un cambio de sentido hacia Destination 1 al final de la via",
         "fr": "Faire demi-tour à la fin de la route en direction de Destination 1",
         "nl": "Keer om richting Destination 1",
         "ru": "В конце дороги развернитесь в направлении Destination 1",

--- a/test/fixtures/v5/end_of_road/uturn_name.json
+++ b/test/fixtures/v5/end_of_road/uturn_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "180°-Wendung auf Way Name am Ende der Straße",
         "en": "Make a U-turn onto Way Name at the end of the road",
+        "es": "Haz un cambio de sentido en Way Name al final de la via",
         "fr": "Faire demi-tour à la fin de la route Way Name",
         "nl": "Keer om naar Way Name",
         "ru": "В конце дороги развернитесь на Way Name",

--- a/test/fixtures/v5/fork/left_default.json
+++ b/test/fixtures/v5/fork/left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Links halten an der Gabelung",
         "en": "Keep left at the fork",
+        "es": "Mantengase izquierda en el cruce",
         "fr": "Rester à gauche à l'embranchement",
         "nl": "Ga links op de splitsing",
         "ru": "На развилке двигайтесь налево",

--- a/test/fixtures/v5/fork/left_destination.json
+++ b/test/fixtures/v5/fork/left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Links halten an der Gabelung Richtung Destination 1",
         "en": "Keep left at the fork towards Destination 1",
+        "es": "Mantengase izquierda en el cruce hacia Destination 1",
         "fr": "Rester à gauche à l'embranchement en direction de Destination 1",
         "nl": "Ga links op de splitsing richting Destination 1",
         "ru": "На развилке двигайтесь налево в направлении Destination 1",

--- a/test/fixtures/v5/fork/left_name.json
+++ b/test/fixtures/v5/fork/left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Links halten an der Gabelung auf Way Name",
         "en": "Keep left at the fork onto Way Name",
+        "es": "Mantengase izquierda en el cruce en Way Name",
         "fr": "Rester à gauche à l'embranchement sur Way Name",
         "nl": "Ga links op de splitsing naar Way Name",
         "ru": "На развилке двигайтесь налево на Way Name",

--- a/test/fixtures/v5/fork/right_default.json
+++ b/test/fixtures/v5/fork/right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rechts halten an der Gabelung",
         "en": "Keep right at the fork",
+        "es": "Mantengase derecha en el cruce",
         "fr": "Rester à droite à l'embranchement",
         "nl": "Ga rechts op de splitsing",
         "ru": "На развилке двигайтесь направо",

--- a/test/fixtures/v5/fork/right_destination.json
+++ b/test/fixtures/v5/fork/right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rechts halten an der Gabelung Richtung Destination 1",
         "en": "Keep right at the fork towards Destination 1",
+        "es": "Mantengase derecha en el cruce hacia Destination 1",
         "fr": "Rester à droite à l'embranchement en direction de Destination 1",
         "nl": "Ga rechts op de splitsing richting Destination 1",
         "ru": "На развилке двигайтесь направо в направлении Destination 1",

--- a/test/fixtures/v5/fork/right_name.json
+++ b/test/fixtures/v5/fork/right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rechts halten an der Gabelung auf Way Name",
         "en": "Keep right at the fork onto Way Name",
+        "es": "Mantengase derecha en el cruce en Way Name",
         "fr": "Rester à droite à l'embranchement sur Way Name",
         "nl": "Ga rechts op de splitsing naar Way Name",
         "ru": "На развилке двигайтесь направо на Way Name",

--- a/test/fixtures/v5/fork/sharp_left_default.json
+++ b/test/fixtures/v5/fork/sharp_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf links abbiegen an der Gabelung",
         "en": "Take a sharp left at the fork",
+        "es": "Gire a la izquierda en el cruce",
         "fr": "Prendre à gauche à l'embranchement",
         "nl": "Linksaf op de splitsing",
         "ru": "На развилке резко поверните налево",

--- a/test/fixtures/v5/fork/sharp_left_destination.json
+++ b/test/fixtures/v5/fork/sharp_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Scharf links abbiegen an der Gabelung Richtung Destination 1",
         "en": "Take a sharp left at the fork towards Destination 1",
+        "es": "Gire a la izquierda en el cruce hacia Destination 1",
         "fr": "Prendre à gauche à l'embranchement en direction de Destination 1",
         "nl": "Linksaf op de splitsing richting Destination 1",
         "ru": "На развилке резко поверните налево и продолжите движение в направлении Destination 1",

--- a/test/fixtures/v5/fork/sharp_left_name.json
+++ b/test/fixtures/v5/fork/sharp_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf links abbiegen an der Gabelung auf Way Name",
         "en": "Take a sharp left at the fork onto Way Name",
+        "es": "Gire a la izquierda en el cruce en Way Name",
         "fr": "Prendre à gauche à l'embranchement sur Way Name",
         "nl": "Linksaf op de splitsing naar Way Name",
         "ru": "На развилке резко поверните налево на Way Name",

--- a/test/fixtures/v5/fork/sharp_right_default.json
+++ b/test/fixtures/v5/fork/sharp_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf rechts abbiegen an der Gabelung",
         "en": "Take a sharp right at the fork",
+        "es": "Gire a la derecha en el cruce",
         "fr": "Prendre à droite à l'embranchement",
         "nl": "Rechtsaf op de splitsing",
         "ru": "На развилке резко поверните направо",

--- a/test/fixtures/v5/fork/sharp_right_destination.json
+++ b/test/fixtures/v5/fork/sharp_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Scharf rechts abbiegen an der Gabelung Richtung Destination 1",
         "en": "Take a sharp right at the fork towards Destination 1",
+        "es": "Gire a la derecha en el cruce hacia Destination 1",
         "fr": "Prendre à droite à l'embranchement en direction de Destination 1",
         "nl": "Rechtsaf op de splitsing richting Destination 1",
         "ru": "На развилке резко поверните направо и продолжите движение в направлении Destination 1",

--- a/test/fixtures/v5/fork/sharp_right_name.json
+++ b/test/fixtures/v5/fork/sharp_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf rechts abbiegen an der Gabelung auf Way Name",
         "en": "Take a sharp right at the fork onto Way Name",
+        "es": "Gire a la derecha en el cruce en Way Name",
         "fr": "Prendre à droite à l'embranchement sur Way Name",
         "nl": "Rechtsaf op de splitsing naar Way Name",
         "ru": "На развилке резко поверните направо на Way Name",

--- a/test/fixtures/v5/fork/slight_left_default.json
+++ b/test/fixtures/v5/fork/slight_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Links halten an der Gabelung",
         "en": "Keep left at the fork",
+        "es": "Mantengase a la izquierda en el cruce",
         "fr": "Rester à gauche à l'embranchement",
         "nl": "Links aanhouden op de splitsing",
         "ru": "На развилке держитесь левее",

--- a/test/fixtures/v5/fork/slight_left_destination.json
+++ b/test/fixtures/v5/fork/slight_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Links halten an der Gabelung Richtung Destination 1",
         "en": "Keep left at the fork towards Destination 1",
+        "es": "Mantengase a la izquierda en el cruce hacia Destination 1",
         "fr": "Rester à gauche à l'embranchement en direction de Destination 1",
         "nl": "Links aanhouden op de splitsing richting Destination 1",
         "ru": "На развилке держитесь левее и продолжите движение в направлении Destination 1",

--- a/test/fixtures/v5/fork/slight_left_name.json
+++ b/test/fixtures/v5/fork/slight_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Links halten an der Gabelung auf Way Name",
         "en": "Keep left at the fork onto Way Name",
+        "es": "Mantengase a la izquierda en el cruce en Way Name",
         "fr": "Rester à gauche à l'embranchement sur Way Name",
         "nl": "Links aanhouden op de splitsing naar Way Name",
         "ru": "На развилке держитесь левее на Way Name",

--- a/test/fixtures/v5/fork/slight_right_default.json
+++ b/test/fixtures/v5/fork/slight_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rechts halten an der Gabelung",
         "en": "Keep right at the fork",
+        "es": "Mantengase a la derecha en el cruce",
         "fr": "Rester à droite à l'embranchement",
         "nl": "Rechts aanhouden op de splitsing",
         "ru": "На развилке держитесь правее",

--- a/test/fixtures/v5/fork/slight_right_destination.json
+++ b/test/fixtures/v5/fork/slight_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rechts halten an der Gabelung Richtung Destination 1",
         "en": "Keep right at the fork towards Destination 1",
+        "es": "Mantengase a la derecha en el cruce hacia Destination 1",
         "fr": "Rester à droite à l'embranchement en direction de Destination 1",
         "nl": "Rechts aanhouden op de splitsing richting Destination 1",
         "ru": "На развилке держитесь правее и продолжите движение в направлении Destination 1",

--- a/test/fixtures/v5/fork/slight_right_name.json
+++ b/test/fixtures/v5/fork/slight_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rechts halten an der Gabelung auf Way Name",
         "en": "Keep right at the fork onto Way Name",
+        "es": "Mantengase a la derecha en el cruce en Way Name",
         "fr": "Rester à droite à l'embranchement sur Way Name",
         "nl": "Rechts aanhouden op de splitsing naar Way Name",
         "ru": "На развилке держитесь правее на Way Name",

--- a/test/fixtures/v5/fork/straight_default.json
+++ b/test/fixtures/v5/fork/straight_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Geradeaus halten an der Gabelung",
         "en": "Keep straight at the fork",
+        "es": "Mantengase recto en el cruce",
         "fr": "Rester tout droit à l'embranchement",
         "nl": "Ga rechtdoor op de splitsing",
         "ru": "На развилке двигайтесь прямо",

--- a/test/fixtures/v5/fork/straight_destination.json
+++ b/test/fixtures/v5/fork/straight_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Geradeaus halten an der Gabelung Richtung Destination 1",
         "en": "Keep straight at the fork towards Destination 1",
+        "es": "Mantengase recto en el cruce hacia Destination 1",
         "fr": "Rester tout droit à l'embranchement en direction de Destination 1",
         "nl": "Ga rechtdoor op de splitsing richting Destination 1",
         "ru": "На развилке двигайтесь прямо в направлении Destination 1",

--- a/test/fixtures/v5/fork/straight_name.json
+++ b/test/fixtures/v5/fork/straight_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Geradeaus halten an der Gabelung auf Way Name",
         "en": "Keep straight at the fork onto Way Name",
+        "es": "Mantengase recto en el cruce en Way Name",
         "fr": "Rester tout droit à l'embranchement sur Way Name",
         "nl": "Ga rechtdoor op de splitsing naar Way Name",
         "ru": "На развилке двигайтесь прямо на Way Name",

--- a/test/fixtures/v5/fork/uturn_default.json
+++ b/test/fixtures/v5/fork/uturn_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "180°-Wendung",
         "en": "Make a U-turn",
+        "es": "Haz un cambio de sentido",
         "fr": "Faire demi-tour",
         "nl": "Keer om",
         "ru": "На развилке развернитесь",

--- a/test/fixtures/v5/fork/uturn_destination.json
+++ b/test/fixtures/v5/fork/uturn_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "180°-Wendung Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
+        "es": "Haz un cambio de sentido hacia Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "nl": "Keer om richting Destination 1",
         "ru": "На развилке развернитесь и продолжите движение в направлении Destination 1",

--- a/test/fixtures/v5/fork/uturn_name.json
+++ b/test/fixtures/v5/fork/uturn_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "180°-Wendung auf Way Name",
         "en": "Make a U-turn onto Way Name",
+        "es": "Haz un cambio de sentido en Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "nl": "Keer om naar Way Name",
         "ru": "На развилке развернитесь на Way Name",

--- a/test/fixtures/v5/merge/left_default.json
+++ b/test/fixtures/v5/merge/left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Links auffahren",
         "en": "Merge left",
+        "es": "Gire a izquierda",
         "fr": "Rejoindre à gauche",
         "nl": "Bij de splitsing links",
         "ru": "Перестройтесь налево",

--- a/test/fixtures/v5/merge/left_destination.json
+++ b/test/fixtures/v5/merge/left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Links auffahren Richtung Destination 1",
         "en": "Merge left towards Destination 1",
+        "es": "Gire a izquierda hacia Destination 1",
         "fr": "Rejoindre à gauche en direction de Destination 1",
         "nl": "Bij de splitsing links richting Destination 1",
         "ru": "Перестройтесь налево в направлении Destination 1",

--- a/test/fixtures/v5/merge/left_name.json
+++ b/test/fixtures/v5/merge/left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Links auffahren auf Way Name",
         "en": "Merge left onto Way Name",
+        "es": "Gire a izquierda en Way Name",
         "fr": "Rejoindre à gauche sur Way Name",
         "nl": "Bij de splitsing links naar Way Name",
         "ru": "Перестройтесь налево на Way Name",

--- a/test/fixtures/v5/merge/right_default.json
+++ b/test/fixtures/v5/merge/right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rechts auffahren",
         "en": "Merge right",
+        "es": "Gire a derecha",
         "fr": "Rejoindre à droite",
         "nl": "Bij de splitsing rechts",
         "ru": "Перестройтесь направо",

--- a/test/fixtures/v5/merge/right_destination.json
+++ b/test/fixtures/v5/merge/right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rechts auffahren Richtung Destination 1",
         "en": "Merge right towards Destination 1",
+        "es": "Gire a derecha hacia Destination 1",
         "fr": "Rejoindre à droite en direction de Destination 1",
         "nl": "Bij de splitsing rechts richting Destination 1",
         "ru": "Перестройтесь направо в направлении Destination 1",

--- a/test/fixtures/v5/merge/right_name.json
+++ b/test/fixtures/v5/merge/right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rechts auffahren auf Way Name",
         "en": "Merge right onto Way Name",
+        "es": "Gire a derecha en Way Name",
         "fr": "Rejoindre à droite sur Way Name",
         "nl": "Bij de splitsing rechts naar Way Name",
         "ru": "Перестройтесь направо на Way Name",

--- a/test/fixtures/v5/merge/sharp_left_default.json
+++ b/test/fixtures/v5/merge/sharp_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf links auffahren",
         "en": "Merge left",
+        "es": "Gire a la izquierda",
         "fr": "Rejoindre par la gauche",
         "nl": "Bij de splitsing linksaf",
         "ru": "Перестраивайтесь левее",

--- a/test/fixtures/v5/merge/sharp_left_destination.json
+++ b/test/fixtures/v5/merge/sharp_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Scharf links auffahren Richtung Destination 1",
         "en": "Merge left towards Destination 1",
+        "es": "Gire a la izquierda hacia Destination 1",
         "fr": "Rejoindre par la gauche la route en direction de Destination 1",
         "nl": "Bij de splitsing linksaf richting Destination 1",
         "ru": "Перестраивайтесь левее в направлении Destination 1",

--- a/test/fixtures/v5/merge/sharp_left_name.json
+++ b/test/fixtures/v5/merge/sharp_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf links auffahren auf Way Name",
         "en": "Merge left onto Way Name",
+        "es": "Gire a la izquierda en Way Name",
         "fr": "Rejoindre Way Name par la gauche",
         "nl": "Bij de splitsing linksaf naar Way Name",
         "ru": "Перестраивайтесь левее на Way Name",

--- a/test/fixtures/v5/merge/sharp_right_default.json
+++ b/test/fixtures/v5/merge/sharp_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf rechts auffahren",
         "en": "Merge right",
+        "es": "Gire a la derecha",
         "fr": "Rejoindre par la droite",
         "nl": "Bij de splitsing rechtsaf",
         "ru": "Перестраивайтесь правее",

--- a/test/fixtures/v5/merge/sharp_right_destination.json
+++ b/test/fixtures/v5/merge/sharp_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Scharf rechts auffahren Richtung Destination 1",
         "en": "Merge right towards Destination 1",
+        "es": "Gire a la derecha hacia Destination 1",
         "fr": "Rejoindre par la droite la route en direction de Destination 1",
         "nl": "Bij de splitsing rechtsaf richting Destination 1",
         "ru": "Перестраивайтесь правее в направлении Destination 1",

--- a/test/fixtures/v5/merge/sharp_right_name.json
+++ b/test/fixtures/v5/merge/sharp_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf rechts auffahren auf Way Name",
         "en": "Merge right onto Way Name",
+        "es": "Gire a la derecha en Way Name",
         "fr": "Rejoindre Way Name par la droite",
         "nl": "Bij de splitsing rechtsaf naar Way Name",
         "ru": "Перестраивайтесь правее на Way Name",

--- a/test/fixtures/v5/merge/slight_left_default.json
+++ b/test/fixtures/v5/merge/slight_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht links auffahren",
         "en": "Merge left",
+        "es": "Gire a la izquierda",
         "fr": "Rejoindre légèrement par la gauche",
         "nl": "Bij de splitsing links aanhouden",
         "ru": "Перестройтесь левее",

--- a/test/fixtures/v5/merge/slight_left_destination.json
+++ b/test/fixtures/v5/merge/slight_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Leicht links auffahren Richtung Destination 1",
         "en": "Merge left towards Destination 1",
+        "es": "Gire a la izquierda hacia Destination 1",
         "fr": "Rejoindre légèrement par la gauche la route en direction de Destination 1",
         "nl": "Bij de splitsing links aanhouden richting Destination 1",
         "ru": "Перестройтесь левее в направлении Destination 1",

--- a/test/fixtures/v5/merge/slight_left_name.json
+++ b/test/fixtures/v5/merge/slight_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht links auffahren auf Way Name",
         "en": "Merge left onto Way Name",
+        "es": "Gire a la izquierda en Way Name",
         "fr": "Rejoindre Way Name légèrement par la gauche",
         "nl": "Bij de splitsing links aanhouden naar Way Name",
         "ru": "Перестройтесь левее на Way Name",

--- a/test/fixtures/v5/merge/slight_right_default.json
+++ b/test/fixtures/v5/merge/slight_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht rechts auffahren",
         "en": "Merge right",
+        "es": "Gire a la derecha",
         "fr": "Rejoindre légèrement par la droite",
         "nl": "Bij de splitsing rechts aanhouden",
         "ru": "Перестройтесь правее",

--- a/test/fixtures/v5/merge/slight_right_destination.json
+++ b/test/fixtures/v5/merge/slight_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Leicht rechts auffahren Richtung Destination 1",
         "en": "Merge right towards Destination 1",
+        "es": "Gire a la derecha hacia Destination 1",
         "fr": "Rejoindre légèrement par la droite la route en direction de Destination 1",
         "nl": "Bij de splitsing rechts aanhouden richting Destination 1",
         "ru": "Перестройтесь правее в направлении Destination 1",

--- a/test/fixtures/v5/merge/slight_right_name.json
+++ b/test/fixtures/v5/merge/slight_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht rechts auffahren auf Way Name",
         "en": "Merge right onto Way Name",
+        "es": "Gire a la derecha en Way Name",
         "fr": "Rejoindre Way Name légèrement par la droite",
         "nl": "Bij de splitsing rechts aanhouden naar Way Name",
         "ru": "Перестройтесь правее на Way Name",

--- a/test/fixtures/v5/merge/straight_default.json
+++ b/test/fixtures/v5/merge/straight_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Geradeaus auffahren",
         "en": "Merge straight",
+        "es": "Gire a recto",
         "fr": "Rejoindre tout droit",
         "nl": "Bij de splitsing rechtdoor",
         "ru": "Перестройтесь прямо",

--- a/test/fixtures/v5/merge/straight_destination.json
+++ b/test/fixtures/v5/merge/straight_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Geradeaus auffahren Richtung Destination 1",
         "en": "Merge straight towards Destination 1",
+        "es": "Gire a recto hacia Destination 1",
         "fr": "Rejoindre tout droit en direction de Destination 1",
         "nl": "Bij de splitsing rechtdoor richting Destination 1",
         "ru": "Перестройтесь прямо в направлении Destination 1",

--- a/test/fixtures/v5/merge/straight_name.json
+++ b/test/fixtures/v5/merge/straight_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Geradeaus auffahren auf Way Name",
         "en": "Merge straight onto Way Name",
+        "es": "Gire a recto en Way Name",
         "fr": "Rejoindre tout droit sur Way Name",
         "nl": "Bij de splitsing rechtdoor naar Way Name",
         "ru": "Перестройтесь прямо на Way Name",

--- a/test/fixtures/v5/merge/uturn_default.json
+++ b/test/fixtures/v5/merge/uturn_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "180°-Wendung",
         "en": "Make a U-turn",
+        "es": "Haz un cambio de sentido",
         "fr": "Fair demi-tour",
         "nl": "Keer om",
         "ru": "Развернитесь",

--- a/test/fixtures/v5/merge/uturn_destination.json
+++ b/test/fixtures/v5/merge/uturn_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "180°-Wendung Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
+        "es": "Haz un cambio de sentido hacia Destination 1",
         "fr": "Fair demi-tour en direction de Destination 1",
         "nl": "Keer om richting Destination 1",
         "ru": "Развернитесь в направлении Destination 1",

--- a/test/fixtures/v5/merge/uturn_name.json
+++ b/test/fixtures/v5/merge/uturn_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "180°-Wendung auf Way Name",
         "en": "Make a U-turn onto Way Name",
+        "es": "Haz un cambio de sentido en Way Name",
         "fr": "Fair demi-tour sur Way Name",
         "nl": "Keer om naar Way Name",
         "ru": "Развернитесь на Way Name",

--- a/test/fixtures/v5/modes/driving_turn_left.json
+++ b/test/fixtures/v5/modes/driving_turn_left.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Links abbiegen auf Way Name",
         "en": "Turn left onto Way Name",
+        "es": "Gire a la izquierda en Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "nl": "Ga linksaf naar Way Name",
         "ru": "Поверните налево на Way Name",

--- a/test/fixtures/v5/modes/ferry_fork_left_default.json
+++ b/test/fixtures/v5/modes/ferry_fork_left_default.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Fähre nehmen",
         "en": "Take the ferry",
+        "es": "Coge el ferry",
         "fr": "Prendre le ferry",
         "nl": "Neem het veer",
         "ru": "Погрузитесь на паром",

--- a/test/fixtures/v5/modes/ferry_fork_left_destination.json
+++ b/test/fixtures/v5/modes/ferry_fork_left_destination.json
@@ -11,6 +11,7 @@
     "instructions": {
         "de": "Fähre nehmen Richtung Destination 1",
         "en": "Take the ferry towards Destination 1",
+        "es": "Coge el ferry a Destination 1",
         "fr": "Prendre le ferry en direction de Destination 1",
         "nl": "Neem het veer naar Destination 1",
         "ru": "Погрузитесь на паром в направлении Destination 1",

--- a/test/fixtures/v5/modes/ferry_fork_left_name.json
+++ b/test/fixtures/v5/modes/ferry_fork_left_name.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Fähre nehmen Way Name",
         "en": "Take the ferry Way Name",
+        "es": "Coge el ferry Way Name",
         "fr": "Prendre le ferry Way Name",
         "nl": "Neem het veer Way Name",
         "ru": "Погрузитесь на паром Way Name",

--- a/test/fixtures/v5/modes/ferry_turn_left_default.json
+++ b/test/fixtures/v5/modes/ferry_turn_left_default.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Fähre nehmen",
         "en": "Take the ferry",
+        "es": "Coge el ferry",
         "fr": "Prendre le ferry",
         "nl": "Neem het veer",
         "ru": "Погрузитесь на паром",

--- a/test/fixtures/v5/modes/ferry_turn_left_destination.json
+++ b/test/fixtures/v5/modes/ferry_turn_left_destination.json
@@ -11,6 +11,7 @@
     "instructions": {
         "de": "Fähre nehmen Richtung Destination 1",
         "en": "Take the ferry towards Destination 1",
+        "es": "Coge el ferry a Destination 1",
         "fr": "Prendre le ferry en direction de Destination 1",
         "nl": "Neem het veer naar Destination 1",
         "ru": "Погрузитесь на паром в направлении Destination 1",

--- a/test/fixtures/v5/modes/ferry_turn_left_name.json
+++ b/test/fixtures/v5/modes/ferry_turn_left_name.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Fähre nehmen Way Name",
         "en": "Take the ferry Way Name",
+        "es": "Coge el ferry Way Name",
         "fr": "Prendre le ferry Way Name",
         "nl": "Neem het veer Way Name",
         "ru": "Погрузитесь на паром Way Name",

--- a/test/fixtures/v5/new_name/left_default.json
+++ b/test/fixtures/v5/new_name/left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Links weiterfahren",
         "en": "Continue left",
+        "es": "Continua izquierda",
         "fr": "Continuer à gauche",
         "nl": "Ga links",
         "ru": "Поверните налево",

--- a/test/fixtures/v5/new_name/left_destination.json
+++ b/test/fixtures/v5/new_name/left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Links weiterfahren Richtung Destination 1",
         "en": "Continue left towards Destination 1",
+        "es": "Continua izquierda hacia Destination 1",
         "fr": "Continuer à gauche en direction de Destination 1",
         "nl": "Ga links richting Destination 1",
         "ru": "Поверните налево и продолжайте движение в направлении Destination 1",

--- a/test/fixtures/v5/new_name/left_name.json
+++ b/test/fixtures/v5/new_name/left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Links weiterfahren auf Way Name",
         "en": "Continue left onto Way Name",
+        "es": "Continua izquierda en Way Name",
         "fr": "Continuer à gauche sur Way Name",
         "nl": "Ga links naar Way Name",
         "ru": "Поверните налево на Way Name",

--- a/test/fixtures/v5/new_name/right_default.json
+++ b/test/fixtures/v5/new_name/right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rechts weiterfahren",
         "en": "Continue right",
+        "es": "Continua derecha",
         "fr": "Continuer à droite",
         "nl": "Ga rechts",
         "ru": "Поверните направо",

--- a/test/fixtures/v5/new_name/right_destination.json
+++ b/test/fixtures/v5/new_name/right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rechts weiterfahren Richtung Destination 1",
         "en": "Continue right towards Destination 1",
+        "es": "Continua derecha hacia Destination 1",
         "fr": "Continuer à droite en direction de Destination 1",
         "nl": "Ga rechts richting Destination 1",
         "ru": "Поверните направо и продолжайте движение в направлении Destination 1",

--- a/test/fixtures/v5/new_name/right_name.json
+++ b/test/fixtures/v5/new_name/right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rechts weiterfahren auf Way Name",
         "en": "Continue right onto Way Name",
+        "es": "Continua derecha en Way Name",
         "fr": "Continuer à droite sur Way Name",
         "nl": "Ga rechts naar Way Name",
         "ru": "Поверните направо на Way Name",

--- a/test/fixtures/v5/new_name/sharp_left_default.json
+++ b/test/fixtures/v5/new_name/sharp_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf links",
         "en": "Take a sharp left",
+        "es": "Gire a la izquierda",
         "fr": "Prendre à gauche",
         "nl": "Linksaf",
         "ru": "Резко поверните налево",

--- a/test/fixtures/v5/new_name/sharp_left_destination.json
+++ b/test/fixtures/v5/new_name/sharp_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Scharf links Richtung Destination 1",
         "en": "Take a sharp left towards Destination 1",
+        "es": "Gire a la izquierda hacia Destination 1",
         "fr": "Prendre à gauche en direction de Destination 1",
         "nl": "Linksaf richting Destination 1",
         "ru": "Резко поверните налево и продолжите движение в направлении Destination 1",

--- a/test/fixtures/v5/new_name/sharp_left_name.json
+++ b/test/fixtures/v5/new_name/sharp_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf links auf Way Name",
         "en": "Take a sharp left onto Way Name",
+        "es": "Gire a la izquierda en Way Name",
         "fr": "Prendre à gauche sur Way Name",
         "nl": "Linksaf naar Way Name",
         "ru": "Резко поверните налево на Way Name",

--- a/test/fixtures/v5/new_name/sharp_right_default.json
+++ b/test/fixtures/v5/new_name/sharp_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf rechts",
         "en": "Take a sharp right",
+        "es": "Gire a la derecha",
         "fr": "Prendre à droite",
         "nl": "Rechtsaf",
         "ru": "Резко поверните направо",

--- a/test/fixtures/v5/new_name/sharp_right_destination.json
+++ b/test/fixtures/v5/new_name/sharp_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Scharf rechts Richtung Destination 1",
         "en": "Take a sharp right towards Destination 1",
+        "es": "Gire a la derecha hacia Destination 1",
         "fr": "Prendre à droite en direction de Destination 1",
         "nl": "Rechtsaf richting Destination 1",
         "ru": "Резко поверните направо и продолжите движение в направлении Destination 1",

--- a/test/fixtures/v5/new_name/sharp_right_name.json
+++ b/test/fixtures/v5/new_name/sharp_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf rechts auf Way Name",
         "en": "Take a sharp right onto Way Name",
+        "es": "Gire a la derecha en Way Name",
         "fr": "Prendre à droite sur Way Name",
         "nl": "Rechtsaf naar Way Name",
         "ru": "Резко поверните направо на Way Name",

--- a/test/fixtures/v5/new_name/slight_left_default.json
+++ b/test/fixtures/v5/new_name/slight_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht links weiter",
         "en": "Continue slightly left",
+        "es": "Continua ligeramente a la izquierda",
         "fr": "Continuer légèrement à gauche",
         "nl": "Links aanhouden",
         "ru": "Плавно поверните налево",

--- a/test/fixtures/v5/new_name/slight_left_destination.json
+++ b/test/fixtures/v5/new_name/slight_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Leicht links weiter Richtung Destination 1",
         "en": "Continue slightly left towards Destination 1",
+        "es": "Continua ligeramente a la izquierda hacia Destination 1",
         "fr": "Continuer légèrement à gauche en direction de Destination 1",
         "nl": "Links aanhouden richting Destination 1",
         "ru": "Плавно поверните налево в направлении Destination 1",

--- a/test/fixtures/v5/new_name/slight_left_name.json
+++ b/test/fixtures/v5/new_name/slight_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht links weiter auf Way Name",
         "en": "Continue slightly left onto Way Name",
+        "es": "Continua ligeramente a la izquierda en Way Name",
         "fr": "Continuer légèrement à gauche sur Way Name",
         "nl": "Links aanhouden naar Way Name",
         "ru": "Плавно поверните налево на Way Name",

--- a/test/fixtures/v5/new_name/slight_right_default.json
+++ b/test/fixtures/v5/new_name/slight_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht rechts weiter",
         "en": "Continue slightly right",
+        "es": "Continua ligeramente a la derecha",
         "fr": "Continuer légèrement à droite",
         "nl": "Rechts aanhouden",
         "ru": "Плавно поверните направо",

--- a/test/fixtures/v5/new_name/slight_right_destination.json
+++ b/test/fixtures/v5/new_name/slight_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Leicht rechts weiter Richtung Destination 1",
         "en": "Continue slightly right towards Destination 1",
+        "es": "Continua ligeramente a la derecha hacia Destination 1",
         "fr": "Continuer légèrement à droite en direction de Destination 1",
         "nl": "Rechts aanhouden richting Destination 1",
         "ru": "Плавно поверните направо в направлении Destination 1",

--- a/test/fixtures/v5/new_name/slight_right_name.json
+++ b/test/fixtures/v5/new_name/slight_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht rechts weiter auf Way Name",
         "en": "Continue slightly right onto Way Name",
+        "es": "Continua ligeramente a la derecha en Way Name",
         "fr": "Continuer légèrement à droite sur Way Name",
         "nl": "Rechts aanhouden naar Way Name",
         "ru": "Плавно поверните направо на Way Name",

--- a/test/fixtures/v5/new_name/straight_default.json
+++ b/test/fixtures/v5/new_name/straight_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren",
         "en": "Continue straight",
+        "es": "Continua recto",
         "fr": "Continuer tout droit",
         "nl": "Ga rechtdoor",
         "ru": "Поверните прямо",

--- a/test/fixtures/v5/new_name/straight_destination.json
+++ b/test/fixtures/v5/new_name/straight_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren Richtung Destination 1",
         "en": "Continue straight towards Destination 1",
+        "es": "Continua recto hacia Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "nl": "Ga rechtdoor richting Destination 1",
         "ru": "Поверните прямо и продолжайте движение в направлении Destination 1",

--- a/test/fixtures/v5/new_name/straight_name.json
+++ b/test/fixtures/v5/new_name/straight_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren auf Way Name",
         "en": "Continue straight onto Way Name",
+        "es": "Continua recto en Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "nl": "Ga rechtdoor naar Way Name",
         "ru": "Поверните прямо на Way Name",

--- a/test/fixtures/v5/new_name/uturn_default.json
+++ b/test/fixtures/v5/new_name/uturn_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "180°-Wendung",
         "en": "Make a U-turn",
+        "es": "Haz un cambio de sentido",
         "fr": "Fair demi-tour",
         "nl": "Keer om",
         "ru": "Развернитесь",

--- a/test/fixtures/v5/new_name/uturn_destination.json
+++ b/test/fixtures/v5/new_name/uturn_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "180°-Wendung Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
+        "es": "Haz un cambio de sentido hacia Destination 1",
         "fr": "Fair demi-tour en direction de Destination 1",
         "nl": "Keer om richting Destination 1",
         "ru": "Развернитесь и продолжите движение в направлении Destination 1",

--- a/test/fixtures/v5/new_name/uturn_name.json
+++ b/test/fixtures/v5/new_name/uturn_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "180°-Wendung auf Way Name",
         "en": "Make a U-turn onto Way Name",
+        "es": "Haz un cambio de sentido en Way Name",
         "fr": "Fair demi-tour sur Way Name",
         "nl": "Keer om naar Way Name",
         "ru": "Развернитесь на Way Name",

--- a/test/fixtures/v5/notification/left_default.json
+++ b/test/fixtures/v5/notification/left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Links weiterfahren",
         "en": "Continue left",
+        "es": "Continua izquierda",
         "fr": "Continuer à gauche",
         "nl": "Ga links",
         "ru": "Двигайтесь налево",

--- a/test/fixtures/v5/notification/left_destination.json
+++ b/test/fixtures/v5/notification/left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Links weiterfahren Richtung Destination 1",
         "en": "Continue left towards Destination 1",
+        "es": "Continua izquierda hacia Destination 1",
         "fr": "Continuer à gauche en direction de Destination 1",
         "nl": "Ga links richting Destination 1",
         "ru": "Двигайтесь налево в направлении Destination 1",

--- a/test/fixtures/v5/notification/left_name.json
+++ b/test/fixtures/v5/notification/left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Links weiterfahren auf Way Name",
         "en": "Continue left onto Way Name",
+        "es": "Continua izquierda en Way Name",
         "fr": "Continuer à gauche sur Way Name",
         "nl": "Ga links naar Way Name",
         "ru": "Двигайтесь налево по Way Name",

--- a/test/fixtures/v5/notification/right_default.json
+++ b/test/fixtures/v5/notification/right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rechts weiterfahren",
         "en": "Continue right",
+        "es": "Continua derecha",
         "fr": "Continuer à droite",
         "nl": "Ga rechts",
         "ru": "Двигайтесь направо",

--- a/test/fixtures/v5/notification/right_destination.json
+++ b/test/fixtures/v5/notification/right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rechts weiterfahren Richtung Destination 1",
         "en": "Continue right towards Destination 1",
+        "es": "Continua derecha hacia Destination 1",
         "fr": "Continuer à droite en direction de Destination 1",
         "nl": "Ga rechts richting Destination 1",
         "ru": "Двигайтесь направо в направлении Destination 1",

--- a/test/fixtures/v5/notification/right_name.json
+++ b/test/fixtures/v5/notification/right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rechts weiterfahren auf Way Name",
         "en": "Continue right onto Way Name",
+        "es": "Continua derecha en Way Name",
         "fr": "Continuer à droite sur Way Name",
         "nl": "Ga rechts naar Way Name",
         "ru": "Двигайтесь направо по Way Name",

--- a/test/fixtures/v5/notification/sharp_left_default.json
+++ b/test/fixtures/v5/notification/sharp_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf links weiterfahren",
         "en": "Continue sharp left",
+        "es": "Continua cerrada a la izquierda",
         "fr": "Continuer franchement à gauche",
         "nl": "Ga linksaf",
         "ru": "Двигайтесь налево",

--- a/test/fixtures/v5/notification/sharp_left_destination.json
+++ b/test/fixtures/v5/notification/sharp_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Scharf links weiterfahren Richtung Destination 1",
         "en": "Continue sharp left towards Destination 1",
+        "es": "Continua cerrada a la izquierda hacia Destination 1",
         "fr": "Continuer franchement à gauche en direction de Destination 1",
         "nl": "Ga linksaf richting Destination 1",
         "ru": "Двигайтесь налево в направлении Destination 1",

--- a/test/fixtures/v5/notification/sharp_left_name.json
+++ b/test/fixtures/v5/notification/sharp_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf links weiterfahren auf Way Name",
         "en": "Continue sharp left onto Way Name",
+        "es": "Continua cerrada a la izquierda en Way Name",
         "fr": "Continuer franchement à gauche sur Way Name",
         "nl": "Ga linksaf naar Way Name",
         "ru": "Двигайтесь налево по Way Name",

--- a/test/fixtures/v5/notification/sharp_right_default.json
+++ b/test/fixtures/v5/notification/sharp_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf rechts weiterfahren",
         "en": "Continue sharp right",
+        "es": "Continua cerrada a la derecha",
         "fr": "Continuer franchement à droite",
         "nl": "Ga rechtsaf",
         "ru": "Двигайтесь направо",

--- a/test/fixtures/v5/notification/sharp_right_destination.json
+++ b/test/fixtures/v5/notification/sharp_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Scharf rechts weiterfahren Richtung Destination 1",
         "en": "Continue sharp right towards Destination 1",
+        "es": "Continua cerrada a la derecha hacia Destination 1",
         "fr": "Continuer franchement à droite en direction de Destination 1",
         "nl": "Ga rechtsaf richting Destination 1",
         "ru": "Двигайтесь направо в направлении Destination 1",

--- a/test/fixtures/v5/notification/sharp_right_name.json
+++ b/test/fixtures/v5/notification/sharp_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf rechts weiterfahren auf Way Name",
         "en": "Continue sharp right onto Way Name",
+        "es": "Continua cerrada a la derecha en Way Name",
         "fr": "Continuer franchement à droite sur Way Name",
         "nl": "Ga rechtsaf naar Way Name",
         "ru": "Двигайтесь направо по Way Name",

--- a/test/fixtures/v5/notification/slight_left_default.json
+++ b/test/fixtures/v5/notification/slight_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht links weiterfahren",
         "en": "Continue slight left",
+        "es": "Continua ligeramente a la izquierda",
         "fr": "Continuer légèrement à gauche",
         "nl": "Ga links",
         "ru": "Двигайтесь левее",

--- a/test/fixtures/v5/notification/slight_left_destination.json
+++ b/test/fixtures/v5/notification/slight_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Leicht links weiterfahren Richtung Destination 1",
         "en": "Continue slight left towards Destination 1",
+        "es": "Continua ligeramente a la izquierda hacia Destination 1",
         "fr": "Continuer légèrement à gauche en direction de Destination 1",
         "nl": "Ga links richting Destination 1",
         "ru": "Двигайтесь левее в направлении Destination 1",

--- a/test/fixtures/v5/notification/slight_left_name.json
+++ b/test/fixtures/v5/notification/slight_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht links weiterfahren auf Way Name",
         "en": "Continue slight left onto Way Name",
+        "es": "Continua ligeramente a la izquierda en Way Name",
         "fr": "Continuer légèrement à gauche sur Way Name",
         "nl": "Ga links naar Way Name",
         "ru": "Двигайтесь левее по Way Name",

--- a/test/fixtures/v5/notification/slight_right_default.json
+++ b/test/fixtures/v5/notification/slight_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht rechts weiterfahren",
         "en": "Continue slight right",
+        "es": "Continua ligeramente a la derecha",
         "fr": "Continuer légèrement à droite",
         "nl": "Ga rechts",
         "ru": "Двигайтесь правее",

--- a/test/fixtures/v5/notification/slight_right_destination.json
+++ b/test/fixtures/v5/notification/slight_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Leicht rechts weiterfahren Richtung Destination 1",
         "en": "Continue slight right towards Destination 1",
+        "es": "Continua ligeramente a la derecha hacia Destination 1",
         "fr": "Continuer légèrement à droite en direction de Destination 1",
         "nl": "Ga rechts richting Destination 1",
         "ru": "Двигайтесь правее в направлении Destination 1",

--- a/test/fixtures/v5/notification/slight_right_name.json
+++ b/test/fixtures/v5/notification/slight_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht rechts weiterfahren auf Way Name",
         "en": "Continue slight right onto Way Name",
+        "es": "Continua ligeramente a la derecha en Way Name",
         "fr": "Continuer légèrement à droite sur Way Name",
         "nl": "Ga rechts naar Way Name",
         "ru": "Двигайтесь правее по Way Name",

--- a/test/fixtures/v5/notification/straight_default.json
+++ b/test/fixtures/v5/notification/straight_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren",
         "en": "Continue straight",
+        "es": "Continua recto",
         "fr": "Continuer tout droit",
         "nl": "Ga rechtdoor",
         "ru": "Двигайтесь прямо",

--- a/test/fixtures/v5/notification/straight_destination.json
+++ b/test/fixtures/v5/notification/straight_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren Richtung Destination 1",
         "en": "Continue straight towards Destination 1",
+        "es": "Continua recto hacia Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "nl": "Ga rechtdoor richting Destination 1",
         "ru": "Двигайтесь прямо в направлении Destination 1",

--- a/test/fixtures/v5/notification/straight_name.json
+++ b/test/fixtures/v5/notification/straight_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren auf Way Name",
         "en": "Continue straight onto Way Name",
+        "es": "Continua recto en Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "nl": "Ga rechtdoor naar Way Name",
         "ru": "Двигайтесь прямо по Way Name",

--- a/test/fixtures/v5/notification/uturn_default.json
+++ b/test/fixtures/v5/notification/uturn_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "180°-Wendung",
         "en": "Make a U-turn",
+        "es": "Haz un cambio de sentido",
         "fr": "Fair demi-tour",
         "nl": "Keer om",
         "ru": "Развернитесь",

--- a/test/fixtures/v5/notification/uturn_destination.json
+++ b/test/fixtures/v5/notification/uturn_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "180°-Wendung Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
+        "es": "Haz un cambio de sentido hacia Destination 1",
         "fr": "Fair demi-tour en direction de Destination 1",
         "nl": "Keer om richting Destination 1",
         "ru": "Развернитесь и продолжите движение в направлении Destination 1",

--- a/test/fixtures/v5/notification/uturn_name.json
+++ b/test/fixtures/v5/notification/uturn_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "180°-Wendung auf Way Name",
         "en": "Make a U-turn onto Way Name",
+        "es": "Haz un cambio de sentido en Way Name",
         "fr": "Fair demi-tour sur Way Name",
         "nl": "Keer om naar Way Name",
         "ru": "Развернитесь на Way Name",

--- a/test/fixtures/v5/off_ramp/left_default.json
+++ b/test/fixtures/v5/off_ramp/left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen",
         "en": "Take the ramp on the left",
+        "es": "Ve cuesta abajo en la izquierda",
         "fr": "Prendre la sortie à gauche",
         "nl": "Neem de afrit links",
         "ru": "Сверните на левый съезд",

--- a/test/fixtures/v5/off_ramp/left_destination.json
+++ b/test/fixtures/v5/off_ramp/left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen Richtung Destination 1",
         "en": "Take the ramp on the left towards Destination 1",
+        "es": "Ve cuesta abajo en la izquierda hacia Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "nl": "Neem de afrit links richting Destination 1",
         "ru": "Сверните на правый съезд в направлении Destination 1",

--- a/test/fixtures/v5/off_ramp/left_name.json
+++ b/test/fixtures/v5/off_ramp/left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen auf Way Name",
         "en": "Take the ramp on the left onto Way Name",
+        "es": "Ve cuesta abajo en la izquierda en Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "nl": "Neem de afrit links naar Way Name",
         "ru": "Сверните на левый съезд на Way Name",

--- a/test/fixtures/v5/off_ramp/right_default.json
+++ b/test/fixtures/v5/off_ramp/right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen",
         "en": "Take the ramp on the right",
+        "es": "Ve cuesta abajo en la derecha",
         "fr": "Prendre la sortie à droite",
         "nl": "Neem de afrit rechts",
         "ru": "Сверните на правый съезд",

--- a/test/fixtures/v5/off_ramp/right_destination.json
+++ b/test/fixtures/v5/off_ramp/right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen Richtung Destination 1",
         "en": "Take the ramp on the right towards Destination 1",
+        "es": "Ve cuesta abajo en la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "nl": "Neem de afrit rechts richting Destination 1",
         "ru": "Сверните на правый съезд в направлении Destination 1",

--- a/test/fixtures/v5/off_ramp/right_name.json
+++ b/test/fixtures/v5/off_ramp/right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen auf Way Name",
         "en": "Take the ramp on the right onto Way Name",
+        "es": "Ve cuesta abajo en la derecha en Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "nl": "Neem de afrit rechts naar Way Name",
         "ru": "Сверните на правый съезд на Way Name",

--- a/test/fixtures/v5/off_ramp/sharp_left_default.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen",
         "en": "Take the ramp on the left",
+        "es": "Ve cuesta abajo en la izquierda",
         "fr": "Prendre la sortie à gauche",
         "nl": "Neem de afrit links",
         "ru": "Поверните на левый съезд",

--- a/test/fixtures/v5/off_ramp/sharp_left_destination.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen Richtung Destination 1",
         "en": "Take the ramp on the left towards Destination 1",
+        "es": "Ve cuesta abajo en la izquierda hacia Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "nl": "Neem de afrit links richting Destination 1",
         "ru": "Поверните на левый съезд в направлении Destination 1",

--- a/test/fixtures/v5/off_ramp/sharp_left_name.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen auf Way Name",
         "en": "Take the ramp on the left onto Way Name",
+        "es": "Ve cuesta abajo en la izquierda en Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "nl": "Neem de afrit links naar Way Name",
         "ru": "Поверните на левый съезд на Way Name",

--- a/test/fixtures/v5/off_ramp/sharp_right_default.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen",
         "en": "Take the ramp on the right",
+        "es": "Ve cuesta abajo en la derecha",
         "fr": "Prendre la sortie à droite",
         "nl": "Neem de afrit rechts",
         "ru": "Поверните на правый съезд",

--- a/test/fixtures/v5/off_ramp/sharp_right_destination.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen Richtung Destination 1",
         "en": "Take the ramp on the right towards Destination 1",
+        "es": "Ve cuesta abajo en la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "nl": "Neem de afrit rechts richting Destination 1",
         "ru": "Поверните на правый съезд в направлении Destination 1",

--- a/test/fixtures/v5/off_ramp/sharp_right_name.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen auf Way Name",
         "en": "Take the ramp on the right onto Way Name",
+        "es": "Ve cuesta abajo en la derecha en Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "nl": "Neem de afrit rechts naar Way Name",
         "ru": "Поверните на правый съезд на Way Name",

--- a/test/fixtures/v5/off_ramp/slight_left_default.json
+++ b/test/fixtures/v5/off_ramp/slight_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen",
         "en": "Take the ramp on the left",
+        "es": "Ve cuesta abajo en la izquierda",
         "fr": "Prendre la sortie à gauche",
         "nl": "Neem de afrit links",
         "ru": "Плавно сверните на левый съезд",

--- a/test/fixtures/v5/off_ramp/slight_left_destination.json
+++ b/test/fixtures/v5/off_ramp/slight_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen Richtung Destination 1",
         "en": "Take the ramp on the left towards Destination 1",
+        "es": "Ve cuesta abajo en la izquierda hacia Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "nl": "Neem de afrit links richting Destination 1",
         "ru": "Плавно сверните на левый съезд в направлении Destination 1",

--- a/test/fixtures/v5/off_ramp/slight_left_name.json
+++ b/test/fixtures/v5/off_ramp/slight_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen auf Way Name",
         "en": "Take the ramp on the left onto Way Name",
+        "es": "Ve cuesta abajo en la izquierda en Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "nl": "Neem de afrit links naar Way Name",
         "ru": "Плавно сверните на левый съезд на Way Name",

--- a/test/fixtures/v5/off_ramp/slight_right_default.json
+++ b/test/fixtures/v5/off_ramp/slight_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen",
         "en": "Take the ramp on the right",
+        "es": "Ve cuesta abajo en la derecha",
         "fr": "Prendre la sortie à droite",
         "nl": "Neem de afrit rechts",
         "ru": "Плавно сверните на правый съезд",

--- a/test/fixtures/v5/off_ramp/slight_right_destination.json
+++ b/test/fixtures/v5/off_ramp/slight_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen Richtung Destination 1",
         "en": "Take the ramp on the right towards Destination 1",
+        "es": "Ve cuesta abajo en la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "nl": "Neem de afrit rechts richting Destination 1",
         "ru": "Плавно сверните на правый съезд в направлении Destination 1",

--- a/test/fixtures/v5/off_ramp/slight_right_name.json
+++ b/test/fixtures/v5/off_ramp/slight_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen auf Way Name",
         "en": "Take the ramp on the right onto Way Name",
+        "es": "Ve cuesta abajo en la derecha en Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "nl": "Neem de afrit rechts naar Way Name",
         "ru": "Плавно сверните на правый съезд на Way Name",

--- a/test/fixtures/v5/off_ramp/straight_default.json
+++ b/test/fixtures/v5/off_ramp/straight_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe nehmen",
         "en": "Take the ramp",
+        "es": "Ve cuesta abajo",
         "fr": "Prendre la sortie",
         "nl": "Neem de afrit",
         "ru": "Сверните на съезд",

--- a/test/fixtures/v5/off_ramp/straight_destination.json
+++ b/test/fixtures/v5/off_ramp/straight_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rampe nehmen Richtung Destination 1",
         "en": "Take the ramp towards Destination 1",
+        "es": "Ve cuesta abajo hacia Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "nl": "Neem de afrit richting Destination 1",
         "ru": "Сверните на съезд в направлении Destination 1",

--- a/test/fixtures/v5/off_ramp/straight_name.json
+++ b/test/fixtures/v5/off_ramp/straight_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe nehmen auf Way Name",
         "en": "Take the ramp onto Way Name",
+        "es": "Ve cuesta abajo en Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "nl": "Neem de afrit naar Way Name",
         "ru": "Сверните на съезд на Way Name",

--- a/test/fixtures/v5/off_ramp/uturn_default.json
+++ b/test/fixtures/v5/off_ramp/uturn_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe nehmen",
         "en": "Take the ramp",
+        "es": "Ve cuesta abajo",
         "fr": "Prendre la sortie",
         "nl": "Neem de afrit",
         "ru": "Сверните на съезд",

--- a/test/fixtures/v5/off_ramp/uturn_destination.json
+++ b/test/fixtures/v5/off_ramp/uturn_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rampe nehmen Richtung Destination 1",
         "en": "Take the ramp towards Destination 1",
+        "es": "Ve cuesta abajo hacia Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "nl": "Neem de afrit richting Destination 1",
         "ru": "Сверните на съезд в направлении Destination 1",

--- a/test/fixtures/v5/off_ramp/uturn_name.json
+++ b/test/fixtures/v5/off_ramp/uturn_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe nehmen auf Way Name",
         "en": "Take the ramp onto Way Name",
+        "es": "Ve cuesta abajo en Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "nl": "Neem de afrit naar Way Name",
         "ru": "Сверните на съезд на Way Name",

--- a/test/fixtures/v5/on_ramp/left_default.json
+++ b/test/fixtures/v5/on_ramp/left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen",
         "en": "Take the ramp on the left",
+        "es": "Ve cuesta abajo en la izquierda",
         "fr": "Prendre la sortie à gauche",
         "nl": "Neem de oprit links",
         "ru": "Сверните на левый въезд на автомагистраль",

--- a/test/fixtures/v5/on_ramp/left_destination.json
+++ b/test/fixtures/v5/on_ramp/left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen Richtung Destination 1",
         "en": "Take the ramp on the left towards Destination 1",
+        "es": "Ve cuesta abajo en la izquierda hacia Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "nl": "Neem de oprit links richting Destination 1",
         "ru": "Сверните на левый въезд на автомагистраль в направлении Destination 1",

--- a/test/fixtures/v5/on_ramp/left_name.json
+++ b/test/fixtures/v5/on_ramp/left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen auf Way Name",
         "en": "Take the ramp on the left onto Way Name",
+        "es": "Ve cuesta abajo en la izquierda en Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "nl": "Neem de oprit links naar Way Name",
         "ru": "Сверните на левый въезд на Way Name",

--- a/test/fixtures/v5/on_ramp/right_default.json
+++ b/test/fixtures/v5/on_ramp/right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen",
         "en": "Take the ramp on the right",
+        "es": "Ve cuesta abajo en la derecha",
         "fr": "Prendre la sortie à droite",
         "nl": "Neem de oprit rechts",
         "ru": "Сверните на правый въезд на автомагистраль",

--- a/test/fixtures/v5/on_ramp/right_destination.json
+++ b/test/fixtures/v5/on_ramp/right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen Richtung Destination 1",
         "en": "Take the ramp on the right towards Destination 1",
+        "es": "Ve cuesta abajo en la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "nl": "Neem de oprit rechts richting Destination 1",
         "ru": "Сверните на правый въезд на автомагистраль в направлении Destination 1",

--- a/test/fixtures/v5/on_ramp/right_name.json
+++ b/test/fixtures/v5/on_ramp/right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen auf Way Name",
         "en": "Take the ramp on the right onto Way Name",
+        "es": "Ve cuesta abajo en la derecha en Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "nl": "Neem de oprit rechts naar Way Name",
         "ru": "Сверните на правый въезд на Way Name",

--- a/test/fixtures/v5/on_ramp/sharp_left_default.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen",
         "en": "Take the ramp on the left",
+        "es": "Ve cuesta abajo en la izquierda",
         "fr": "Prendre la sortie à gauche",
         "nl": "Neem de oprit links",
         "ru": "Поверните на левый въезд на автомагистраль",

--- a/test/fixtures/v5/on_ramp/sharp_left_destination.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen Richtung Destination 1",
         "en": "Take the ramp on the left towards Destination 1",
+        "es": "Ve cuesta abajo en la izquierda hacia Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "nl": "Neem de oprit links richting Destination 1",
         "ru": "Поверните на левый въезд на автомагистраль в направлении Destination 1",

--- a/test/fixtures/v5/on_ramp/sharp_left_name.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen auf Way Name",
         "en": "Take the ramp on the left onto Way Name",
+        "es": "Ve cuesta abajo en la izquierda en Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "nl": "Neem de oprit links naar Way Name",
         "ru": "Поверните на левый въезд на Way Name",

--- a/test/fixtures/v5/on_ramp/sharp_right_default.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen",
         "en": "Take the ramp on the right",
+        "es": "Ve cuesta abajo en la derecha",
         "fr": "Prendre la sortie à droite",
         "nl": "Neem de oprit rechts",
         "ru": "Поверните на правый въезд на автомагистраль",

--- a/test/fixtures/v5/on_ramp/sharp_right_destination.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen Richtung Destination 1",
         "en": "Take the ramp on the right towards Destination 1",
+        "es": "Ve cuesta abajo en la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "nl": "Neem de oprit rechts richting Destination 1",
         "ru": "Поверните на правый въезд на автомагистраль в направлении Destination 1",

--- a/test/fixtures/v5/on_ramp/sharp_right_name.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen auf Way Name",
         "en": "Take the ramp on the right onto Way Name",
+        "es": "Ve cuesta abajo en la derecha en Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "nl": "Neem de oprit rechts naar Way Name",
         "ru": "Поверните на правый въезд на Way Name",

--- a/test/fixtures/v5/on_ramp/slight_left_default.json
+++ b/test/fixtures/v5/on_ramp/slight_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen",
         "en": "Take the ramp on the left",
+        "es": "Ve cuesta abajo en la izquierda",
         "fr": "Prendre la sortie à gauche",
         "nl": "Neem de oprit links",
         "ru": "Перестройтесь левее на въезд на автомагистраль",

--- a/test/fixtures/v5/on_ramp/slight_left_destination.json
+++ b/test/fixtures/v5/on_ramp/slight_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen Richtung Destination 1",
         "en": "Take the ramp on the left towards Destination 1",
+        "es": "Ve cuesta abajo en la izquierda hacia Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "nl": "Neem de oprit links richting Destination 1",
         "ru": "Перестройтесь левее на автомагистраль в направлении Destination 1",

--- a/test/fixtures/v5/on_ramp/slight_left_name.json
+++ b/test/fixtures/v5/on_ramp/slight_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der linken Seite nehmen auf Way Name",
         "en": "Take the ramp on the left onto Way Name",
+        "es": "Ve cuesta abajo en la izquierda en Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "nl": "Neem de oprit links naar Way Name",
         "ru": "Перестройтесь левее на Way Name",

--- a/test/fixtures/v5/on_ramp/slight_right_default.json
+++ b/test/fixtures/v5/on_ramp/slight_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen",
         "en": "Take the ramp on the right",
+        "es": "Ve cuesta abajo en la derecha",
         "fr": "Prendre la sortie à droite",
         "nl": "Neem de oprit rechts",
         "ru": "Перестройтесь правее на въезд на автомагистраль",

--- a/test/fixtures/v5/on_ramp/slight_right_destination.json
+++ b/test/fixtures/v5/on_ramp/slight_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen Richtung Destination 1",
         "en": "Take the ramp on the right towards Destination 1",
+        "es": "Ve cuesta abajo en la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "nl": "Neem de oprit rechts richting Destination 1",
         "ru": "Перестройтесь правее на автомагистраль в направлении Destination 1",

--- a/test/fixtures/v5/on_ramp/slight_right_name.json
+++ b/test/fixtures/v5/on_ramp/slight_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen auf Way Name",
         "en": "Take the ramp on the right onto Way Name",
+        "es": "Ve cuesta abajo en la derecha en Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "nl": "Neem de oprit rechts naar Way Name",
         "ru": "Перестройтесь правее на Way Name",

--- a/test/fixtures/v5/on_ramp/straight_default.json
+++ b/test/fixtures/v5/on_ramp/straight_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe nehmen",
         "en": "Take the ramp",
+        "es": "Ve cuesta abajo",
         "fr": "Prendre la sortie",
         "nl": "Neem de oprit",
         "ru": "Сверните на автомагистраль",

--- a/test/fixtures/v5/on_ramp/straight_destination.json
+++ b/test/fixtures/v5/on_ramp/straight_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rampe nehmen Richtung Destination 1",
         "en": "Take the ramp towards Destination 1",
+        "es": "Ve cuesta abajo hacia Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "nl": "Neem de oprit richting Destination 1",
         "ru": "Сверните на въезд на автомагистраль в направлении Destination 1",

--- a/test/fixtures/v5/on_ramp/straight_name.json
+++ b/test/fixtures/v5/on_ramp/straight_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe nehmen auf Way Name",
         "en": "Take the ramp onto Way Name",
+        "es": "Ve cuesta abajo en Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "nl": "Neem de oprit naar Way Name",
         "ru": "Сверните на въезд на Way Name",

--- a/test/fixtures/v5/on_ramp/uturn_default.json
+++ b/test/fixtures/v5/on_ramp/uturn_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe nehmen",
         "en": "Take the ramp",
+        "es": "Ve cuesta abajo",
         "fr": "Prendre la sortie",
         "nl": "Neem de oprit",
         "ru": "Сверните на автомагистраль",

--- a/test/fixtures/v5/on_ramp/uturn_destination.json
+++ b/test/fixtures/v5/on_ramp/uturn_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rampe nehmen Richtung Destination 1",
         "en": "Take the ramp towards Destination 1",
+        "es": "Ve cuesta abajo hacia Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "nl": "Neem de oprit richting Destination 1",
         "ru": "Сверните на въезд на автомагистраль в направлении Destination 1",

--- a/test/fixtures/v5/on_ramp/uturn_name.json
+++ b/test/fixtures/v5/on_ramp/uturn_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rampe nehmen auf Way Name",
         "en": "Take the ramp onto Way Name",
+        "es": "Ve cuesta abajo en Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "nl": "Neem de oprit naar Way Name",
         "ru": "Сверните на въезд на Way Name",

--- a/test/fixtures/v5/other/invalid_type.json
+++ b/test/fixtures/v5/other/invalid_type.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Links abbiegen auf Way Name",
         "en": "Turn left onto Way Name",
+        "es": "Gire a la izquierda en Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "nl": "Ga linksaf naar Way Name",
         "ru": "Поверните налево на Way Name",

--- a/test/fixtures/v5/other/way_name_ref.json
+++ b/test/fixtures/v5/other/way_name_ref.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Links abbiegen auf Ref1",
         "en": "Turn left onto Ref1",
+        "es": "Gire a la izquierda en Ref1",
         "fr": "Tourner à gauche sur Ref1",
         "nl": "Ga linksaf naar Ref1",
         "ru": "Поверните налево на Ref1",

--- a/test/fixtures/v5/other/way_name_ref_destinations.json
+++ b/test/fixtures/v5/other/way_name_ref_destinations.json
@@ -11,6 +11,7 @@
     "instructions": {
         "de": "Links abbiegen Richtung Destination 1",
         "en": "Turn left towards Destination 1",
+        "es": "Gire a la izquierda hacia Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "nl": "Ga linksaf richting Destination 1",
         "ru": "Поверните налево в направлении Destination 1",

--- a/test/fixtures/v5/other/way_name_ref_mapbox_hack_1.json
+++ b/test/fixtures/v5/other/way_name_ref_mapbox_hack_1.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Links abbiegen auf Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
         "en": "Turn left onto Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
+        "es": "Gire a la izquierda en Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
         "fr": "Tourner à gauche sur Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
         "nl": "Ga linksaf naar Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
         "ru": "Поверните налево на Way Name (Ref1 (Another+Way \\ (Ref1.1)))",

--- a/test/fixtures/v5/other/way_name_ref_mapbox_hack_2.json
+++ b/test/fixtures/v5/other/way_name_ref_mapbox_hack_2.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Links abbiegen auf Way Name (Ref0)",
         "en": "Turn left onto Way Name (Ref0)",
+        "es": "Gire a la izquierda en Way Name (Ref0)",
         "fr": "Tourner à gauche sur Way Name (Ref0)",
         "nl": "Ga linksaf naar Way Name (Ref0)",
         "ru": "Поверните налево на Way Name (Ref0)",

--- a/test/fixtures/v5/other/way_name_ref_mapbox_hack_3.json
+++ b/test/fixtures/v5/other/way_name_ref_mapbox_hack_3.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Links abbiegen auf Ref0",
         "en": "Turn left onto Ref0",
+        "es": "Gire a la izquierda en Ref0",
         "fr": "Tourner à gauche sur Ref0",
         "nl": "Ga linksaf naar Ref0",
         "ru": "Поверните налево на Ref0",

--- a/test/fixtures/v5/other/way_name_ref_name.json
+++ b/test/fixtures/v5/other/way_name_ref_name.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Links abbiegen auf Way Name (Ref1)",
         "en": "Turn left onto Way Name (Ref1)",
+        "es": "Gire a la izquierda en Way Name (Ref1)",
         "fr": "Tourner à gauche sur Way Name (Ref1)",
         "nl": "Ga linksaf naar Way Name (Ref1)",
         "ru": "Поверните налево на Way Name (Ref1)",

--- a/test/fixtures/v5/rotary/default_default.json
+++ b/test/fixtures/v5/rotary/default_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren",
         "en": "Enter the rotary",
+        "es": "Entra en la rotonda",
         "fr": "Entrer dans le rond-point",
         "nl": "Ga het knooppunt op",
         "ru": "Продолжите движение по круговой развязке",

--- a/test/fixtures/v5/rotary/default_destination.json
+++ b/test/fixtures/v5/rotary/default_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und Richtung Destination 1 verlassen",
         "en": "Enter the rotary and exit towards Destination 1",
+        "es": "Entra en la rotonda y sal hacia Destination 1",
         "fr": "Entrer dans le rond-point et sortir en direction de Destination 1",
         "nl": "Verlaat het knooppunt richting Destination 1",
         "ru": "На круговой развязке сверните в направлении Destination 1",

--- a/test/fixtures/v5/rotary/default_name.json
+++ b/test/fixtures/v5/rotary/default_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und auf Way Name verlassen",
         "en": "Enter the rotary and exit onto Way Name",
+        "es": "Entra en la rotonda y sal en Way Name",
         "fr": "Entrer dans le rond-point et sortir par Way Name",
         "nl": "Verlaat het knooppunt naar Way Name",
         "ru": "На круговой развязке сверните на Way Name",

--- a/test/fixtures/v5/rotary/exit_10.json
+++ b/test/fixtures/v5/rotary/exit_10.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und zehnte Ausfahrt nehmen",
         "en": "Enter the rotary and take the 10th exit",
+        "es": "Entra en la rotonda y toma la 10ª salida",
         "fr": "Entrer dans le rond-point et prendre la dixième sortie",
         "nl": "Ga het knooppunt op en neem afslag tiende",
         "ru": "На круговой развязке сверните на десятый съезд",

--- a/test/fixtures/v5/rotary/exit_11.json
+++ b/test/fixtures/v5/rotary/exit_11.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und Ausfahrt nehmen",
         "en": "Enter the rotary and take the exit",
+        "es": "Entra en la rotonda y toma la salida",
         "fr": "Entrer dans le rond-point et prendre la sortie",
         "nl": "Ga het knooppunt op en neem afslag ",
         "ru": "На круговой развязке сверните на съезд",

--- a/test/fixtures/v5/rotary/exit_1_default.json
+++ b/test/fixtures/v5/rotary/exit_1_default.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und erste Ausfahrt nehmen",
         "en": "Enter the rotary and take the 1st exit",
+        "es": "Entra en la rotonda y toma la 1ª salida",
         "fr": "Entrer dans le rond-point et prendre la première sortie",
         "nl": "Ga het knooppunt op en neem afslag eerste",
         "ru": "На круговой развязке сверните на первый съезд",

--- a/test/fixtures/v5/rotary/exit_1_destination.json
+++ b/test/fixtures/v5/rotary/exit_1_destination.json
@@ -11,6 +11,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und erste Ausfahrt nehmen Richtung Destination 1",
         "en": "Enter the rotary and take the 1st exit towards Destination 1",
+        "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "fr": "Entrer dans le rond-point et prendre la première sortie en direction de Destination 1",
         "nl": "Ga het knooppunt op en neem afslag eerste richting Destination 1",
         "ru": "На круговой развязке сверните на первый съезд в направлении Destination 1",

--- a/test/fixtures/v5/rotary/exit_1_name.json
+++ b/test/fixtures/v5/rotary/exit_1_name.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und erste Ausfahrt nehmen auf Way Name",
         "en": "Enter the rotary and take the 1st exit onto Way Name",
+        "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
         "fr": "Entrer dans le rond-point et prendre la première sortie sur Way Name",
         "nl": "Ga het knooppunt op en neem afslag eerste naar Way Name",
         "ru": "На круговой развязке сверните на первый съезд на Way Name",

--- a/test/fixtures/v5/rotary/exit_2.json
+++ b/test/fixtures/v5/rotary/exit_2.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und zweite Ausfahrt nehmen",
         "en": "Enter the rotary and take the 2nd exit",
+        "es": "Entra en la rotonda y toma la 2ª salida",
         "fr": "Entrer dans le rond-point et prendre la seconde sortie",
         "nl": "Ga het knooppunt op en neem afslag tweede",
         "ru": "На круговой развязке сверните на второй съезд",

--- a/test/fixtures/v5/rotary/exit_3.json
+++ b/test/fixtures/v5/rotary/exit_3.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und dritte Ausfahrt nehmen",
         "en": "Enter the rotary and take the 3rd exit",
+        "es": "Entra en la rotonda y toma la 3ª salida",
         "fr": "Entrer dans le rond-point et prendre la troisième sortie",
         "nl": "Ga het knooppunt op en neem afslag derde",
         "ru": "На круговой развязке сверните на третий съезд",

--- a/test/fixtures/v5/rotary/exit_4.json
+++ b/test/fixtures/v5/rotary/exit_4.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und vierte Ausfahrt nehmen",
         "en": "Enter the rotary and take the 4th exit",
+        "es": "Entra en la rotonda y toma la 4ª salida",
         "fr": "Entrer dans le rond-point et prendre la quatrième sortie",
         "nl": "Ga het knooppunt op en neem afslag vierde",
         "ru": "На круговой развязке сверните на четвёртый съезд",

--- a/test/fixtures/v5/rotary/exit_5.json
+++ b/test/fixtures/v5/rotary/exit_5.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und fünfte Ausfahrt nehmen",
         "en": "Enter the rotary and take the 5th exit",
+        "es": "Entra en la rotonda y toma la 5ª salida",
         "fr": "Entrer dans le rond-point et prendre la cinquième sortie",
         "nl": "Ga het knooppunt op en neem afslag vijfde",
         "ru": "На круговой развязке сверните на пятый съезд",

--- a/test/fixtures/v5/rotary/exit_6.json
+++ b/test/fixtures/v5/rotary/exit_6.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und sechste Ausfahrt nehmen",
         "en": "Enter the rotary and take the 6th exit",
+        "es": "Entra en la rotonda y toma la 6ª salida",
         "fr": "Entrer dans le rond-point et prendre la sixième sortie",
         "nl": "Ga het knooppunt op en neem afslag zesde",
         "ru": "На круговой развязке сверните на шестой съезд",

--- a/test/fixtures/v5/rotary/exit_7.json
+++ b/test/fixtures/v5/rotary/exit_7.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und siebente Ausfahrt nehmen",
         "en": "Enter the rotary and take the 7th exit",
+        "es": "Entra en la rotonda y toma la 7ª salida",
         "fr": "Entrer dans le rond-point et prendre la setpième sortie",
         "nl": "Ga het knooppunt op en neem afslag zevende",
         "ru": "На круговой развязке сверните на седьмой съезд",

--- a/test/fixtures/v5/rotary/exit_8.json
+++ b/test/fixtures/v5/rotary/exit_8.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und achte Ausfahrt nehmen",
         "en": "Enter the rotary and take the 8th exit",
+        "es": "Entra en la rotonda y toma la 8ª salida",
         "fr": "Entrer dans le rond-point et prendre la huitième sortie",
         "nl": "Ga het knooppunt op en neem afslag achtste",
         "ru": "На круговой развязке сверните на восьмой съезд",

--- a/test/fixtures/v5/rotary/exit_9.json
+++ b/test/fixtures/v5/rotary/exit_9.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und neunte Ausfahrt nehmen",
         "en": "Enter the rotary and take the 9th exit",
+        "es": "Entra en la rotonda y toma la 9ª salida",
         "fr": "Entrer dans le rond-point et prendre la neuvième sortie",
         "nl": "Ga het knooppunt op en neem afslag negende",
         "ru": "На круговой развязке сверните на девятый съезд",

--- a/test/fixtures/v5/rotary/name_default.json
+++ b/test/fixtures/v5/rotary/name_default.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In Rotary Name fahren",
         "en": "Enter Rotary Name",
+        "es": "Entra en Rotary Name",
         "fr": "Entrer dans le rond-point Rotary Name",
         "nl": "Ga het knooppunt Rotary Name op",
         "ru": "Продолжите движение по Rotary Name с круговым движением",

--- a/test/fixtures/v5/rotary/name_destination.json
+++ b/test/fixtures/v5/rotary/name_destination.json
@@ -11,6 +11,7 @@
     "instructions": {
         "de": "In Rotary Name fahren und Richtung Destination 1 verlassen",
         "en": "Enter Rotary Name and exit towards Destination 1",
+        "es": "Entra en Rotary Name y sal hacia Destination 1",
         "fr": "Entrer dans le rond-point Rotary Name et sortir en direction de Destination 1",
         "nl": "Verlaat het knooppunt Rotary Name richting Destination 1",
         "ru": "На Rotary Name с круговым движением сверните в направлении Destination 1",

--- a/test/fixtures/v5/rotary/name_exit_default.json
+++ b/test/fixtures/v5/rotary/name_exit_default.json
@@ -11,6 +11,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und zweite Ausfahrt nehmen",
         "en": "Enter Rotary Name and take the 2nd exit",
+        "es": "Entra en Rotary Name y coge la 2ª salida",
         "fr": "Entrer dans le rond-point Rotary Name et prendre la seconde sortie",
         "nl": "Ga het knooppunt Rotary Name op en neem afslag tweede",
         "ru": "На Rotary Name с круговым движением сверните на второй съезд",

--- a/test/fixtures/v5/rotary/name_exit_destination.json
+++ b/test/fixtures/v5/rotary/name_exit_destination.json
@@ -12,6 +12,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und zweite Ausfahrt nehmen Richtung Destination 1",
         "en": "Enter Rotary Name and take the 2nd exit towards Destination 1",
+        "es": "Entra en Rotary Name y coge la 2ª salida hacia Destination 1",
         "fr": "Entrer dans le rond-point Rotary Name et prendre la seconde sortie en direction de Destination 1",
         "nl": "Ga het knooppunt Rotary Name op en neem afslag tweede richting Destination 1",
         "ru": "На Rotary Name с круговым движением сверните на второй съезд в направлении Destination 1",

--- a/test/fixtures/v5/rotary/name_exit_name.json
+++ b/test/fixtures/v5/rotary/name_exit_name.json
@@ -11,6 +11,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und zweite Ausfahrt nehmen auf Way Name",
         "en": "Enter Rotary Name and take the 2nd exit onto Way Name",
+        "es": "Entra en Rotary Name y coge la 2ª salida en Way Name",
         "fr": "Entrer dans le rond-point Rotary Name et prendre la seconde sortie sur Way Name",
         "nl": "Ga het knooppunt Rotary Name op en neem afslag tweede naar Way Name",
         "ru": "На Rotary Name с круговым движением сверните на второй съезд на Way Name",

--- a/test/fixtures/v5/rotary/name_name.json
+++ b/test/fixtures/v5/rotary/name_name.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In Rotary Name fahren und auf Way Name verlassen",
         "en": "Enter Rotary Name and exit onto Way Name",
+        "es": "Entra en Rotary Name y sal en Way Name",
         "fr": "Entrer dans le rond-point Rotary Name et sortir par Way Name",
         "nl": "Verlaat het knooppunt Rotary Name naar Way Name",
         "ru": "На Rotary Name с круговым движением сверните на Way Name",

--- a/test/fixtures/v5/roundabout/default_default.json
+++ b/test/fixtures/v5/roundabout/default_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren",
         "en": "Enter the roundabout",
+        "es": "Entra en la rotonda",
         "fr": "Entrer dans le rond-point",
         "nl": "Ga de rotonde op",
         "ru": "Продолжите движение по круговой развязке",

--- a/test/fixtures/v5/roundabout/default_destination.json
+++ b/test/fixtures/v5/roundabout/default_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und Richtung Destination 1 verlassen",
         "en": "Enter the roundabout and exit towards Destination 1",
+        "es": "Entra en la rotonda y sal hacia Destination 1",
         "fr": "Entrer dans le rond-point et sortir en direction de Destination 1",
         "nl": "Verlaat de rotonde richting Destination 1",
         "ru": "На круговой развязке сверните в направлении Destination 1",

--- a/test/fixtures/v5/roundabout/default_name.json
+++ b/test/fixtures/v5/roundabout/default_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und auf Way Name verlassen",
         "en": "Enter the roundabout and exit onto Way Name",
+        "es": "Entra en la rotonda y sal en Way Name",
         "fr": "Entrer dans le rond-point et sortir par Way Name",
         "nl": "Verlaat de rotonde naar Way Name",
         "ru": "На круговой развязке сверните на Way Name",

--- a/test/fixtures/v5/roundabout/exit_default.json
+++ b/test/fixtures/v5/roundabout/exit_default.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und erste Ausfahrt nehmen",
         "en": "Enter the roundabout and take the 1st exit",
+        "es": "Entra en la rotonda y toma la 1ª salida",
         "fr": "Entrer dans le rond-point et prendre la première sortie",
         "nl": "Ga de rotonde op en neem afslag eerste",
         "ru": "На круговой развязке сверните на первый съезд",

--- a/test/fixtures/v5/roundabout/exit_destination.json
+++ b/test/fixtures/v5/roundabout/exit_destination.json
@@ -11,6 +11,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und erste Ausfahrt nehmen Richtung Destination 1",
         "en": "Enter the roundabout and take the 1st exit towards Destination 1",
+        "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "fr": "Entrer dans le rond-point et prendre la première sortie en direction de Destination 1",
         "nl": "Ga de rotonde op en neem afslag eerste richting Destination 1",
         "ru": "На круговой развязке сверните на первый съезд в направлении Destination 1",

--- a/test/fixtures/v5/roundabout/exit_name.json
+++ b/test/fixtures/v5/roundabout/exit_name.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "In den Kreisverkehr fahren und erste Ausfahrt nehmen auf Way Name",
         "en": "Enter the roundabout and take the 1st exit onto Way Name",
+        "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
         "fr": "Entrer dans le rond-point et prendre la première sortie sur Way Name",
         "nl": "Ga de rotonde op en neem afslag eerste naar Way Name",
         "ru": "На круговой развязке сверните на первый съезд на Way Name",

--- a/test/fixtures/v5/roundabout_turn/left_default.json
+++ b/test/fixtures/v5/roundabout_turn/left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Am Kreisverkehr links",
         "en": "At the roundabout turn left",
+        "es": "En la rotonda gira a la izquierda",
         "fr": "Au rond-point, tourner à gauche",
         "nl": "Ga links op de rotonde",
         "ru": "На круговой развязке сверните налево",

--- a/test/fixtures/v5/roundabout_turn/left_destination.json
+++ b/test/fixtures/v5/roundabout_turn/left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Am Kreisverkehr links Richtung Destination 1",
         "en": "At the roundabout turn left towards Destination 1",
+        "es": "En la rotonda gira a la izquierda hacia Destination 1",
         "fr": "Au rond-point, tourner à gauche en direction de Destination 1",
         "nl": "Ga links op de rotonde richting Destination 1",
         "ru": "На круговой развязке сверните налево в направлении Destination 1",

--- a/test/fixtures/v5/roundabout_turn/left_name.json
+++ b/test/fixtures/v5/roundabout_turn/left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Am Kreisverkehr links auf Way Name",
         "en": "At the roundabout turn left onto Way Name",
+        "es": "En la rotonda gira a la izquierda en Way Name",
         "fr": "Au rond-point, tourner à gauche sur Way Name",
         "nl": "Ga links op de rotonde naar Way Name",
         "ru": "На круговой развязке сверните налево на Way Name",

--- a/test/fixtures/v5/roundabout_turn/right_default.json
+++ b/test/fixtures/v5/roundabout_turn/right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Am Kreisverkehr rechts",
         "en": "At the roundabout turn right",
+        "es": "En la rotonda gira a la derecha",
         "fr": "Au rond-point, tourner à droite",
         "nl": "Ga rechts op de rotonde",
         "ru": "На круговой развязке сверните направо",

--- a/test/fixtures/v5/roundabout_turn/right_destination.json
+++ b/test/fixtures/v5/roundabout_turn/right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Am Kreisverkehr rechts Richtung Destination 1",
         "en": "At the roundabout turn right towards Destination 1",
+        "es": "En la rotonda gira a la derecha hacia Destination 1",
         "fr": "Au rond-point, tourner à droite en direction de Destination 1",
         "nl": "Ga rechts op de rotonde richting Destination 1",
         "ru": "На круговой развязке сверните направо в направлении Destination 1",

--- a/test/fixtures/v5/roundabout_turn/right_name.json
+++ b/test/fixtures/v5/roundabout_turn/right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Am Kreisverkehr rechts auf Way Name",
         "en": "At the roundabout turn right onto Way Name",
+        "es": "En la rotonda gira a la derecha en Way Name",
         "fr": "Au rond-point, tourner à droite sur Way Name",
         "nl": "Ga rechts op de rotonde naar Way Name",
         "ru": "На круговой развязке сверните направо на Way Name",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_default.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Am Kreisverkehr scharf links",
         "en": "At the roundabout make a sharp left",
+        "es": "En la rotonda siga cerrada a la izquierda",
         "fr": "Au rond-point, tourner franchement à gauche",
         "nl": "Ga linksaf op de rotonde",
         "ru": "На круговой развязке двигайтесь налево",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Am Kreisverkehr scharf links Richtung Destination 1",
         "en": "At the roundabout make a sharp left towards Destination 1",
+        "es": "En la rotonda siga cerrada a la izquierda hacia Destination 1",
         "fr": "Au rond-point, tourner franchement à gauche en direction de Destination 1",
         "nl": "Ga linksaf op de rotonde richting Destination 1",
         "ru": "На круговой развязке двигайтесь налево в направлении Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_name.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Am Kreisverkehr scharf links auf Way Name",
         "en": "At the roundabout make a sharp left onto Way Name",
+        "es": "En la rotonda siga cerrada a la izquierda en Way Name",
         "fr": "Au rond-point, tourner franchement à gauche sur Way Name",
         "nl": "Ga linksaf op de rotonde naar Way Name",
         "ru": "На круговой развязке двигайтесь налево на Way Name",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_default.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Am Kreisverkehr scharf rechts",
         "en": "At the roundabout make a sharp right",
+        "es": "En la rotonda siga cerrada a la derecha",
         "fr": "Au rond-point, tourner franchement à droite",
         "nl": "Ga rechtsaf op de rotonde",
         "ru": "На круговой развязке двигайтесь направо",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Am Kreisverkehr scharf rechts Richtung Destination 1",
         "en": "At the roundabout make a sharp right towards Destination 1",
+        "es": "En la rotonda siga cerrada a la derecha hacia Destination 1",
         "fr": "Au rond-point, tourner franchement à droite en direction de Destination 1",
         "nl": "Ga rechtsaf op de rotonde richting Destination 1",
         "ru": "На круговой развязке двигайтесь направо в направлении Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_name.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Am Kreisverkehr scharf rechts auf Way Name",
         "en": "At the roundabout make a sharp right onto Way Name",
+        "es": "En la rotonda siga cerrada a la derecha en Way Name",
         "fr": "Au rond-point, tourner franchement à droite sur Way Name",
         "nl": "Ga rechtsaf op de rotonde naar Way Name",
         "ru": "На круговой развязке двигайтесь направо на Way Name",

--- a/test/fixtures/v5/roundabout_turn/slight_left_default.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Am Kreisverkehr leicht links",
         "en": "At the roundabout make a slight left",
+        "es": "En la rotonda siga ligeramente a la izquierda",
         "fr": "Au rond-point, tourner légèrement à gauche",
         "nl": "Ga links op de rotonde",
         "ru": "На круговой развязке двигайтесь левее",

--- a/test/fixtures/v5/roundabout_turn/slight_left_destination.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Am Kreisverkehr leicht links Richtung Destination 1",
         "en": "At the roundabout make a slight left towards Destination 1",
+        "es": "En la rotonda siga ligeramente a la izquierda hacia Destination 1",
         "fr": "Au rond-point, tourner légèrement à gauche en direction de Destination 1",
         "nl": "Ga links op de rotonde richting Destination 1",
         "ru": "На круговой развязке двигайтесь левее в направлении Destination 1",

--- a/test/fixtures/v5/roundabout_turn/slight_left_name.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Am Kreisverkehr leicht links auf Way Name",
         "en": "At the roundabout make a slight left onto Way Name",
+        "es": "En la rotonda siga ligeramente a la izquierda en Way Name",
         "fr": "Au rond-point, tourner légèrement à gauche sur Way Name",
         "nl": "Ga links op de rotonde naar Way Name",
         "ru": "На круговой развязке двигайтесь левее на Way Name",

--- a/test/fixtures/v5/roundabout_turn/slight_right_default.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Am Kreisverkehr leicht rechts",
         "en": "At the roundabout make a slight right",
+        "es": "En la rotonda siga ligeramente a la derecha",
         "fr": "Au rond-point, tourner légèrement à droite",
         "nl": "Ga rechts op de rotonde",
         "ru": "На круговой развязке двигайтесь правее",

--- a/test/fixtures/v5/roundabout_turn/slight_right_destination.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Am Kreisverkehr leicht rechts Richtung Destination 1",
         "en": "At the roundabout make a slight right towards Destination 1",
+        "es": "En la rotonda siga ligeramente a la derecha hacia Destination 1",
         "fr": "Au rond-point, tourner légèrement à droite en direction de Destination 1",
         "nl": "Ga rechts op de rotonde richting Destination 1",
         "ru": "На круговой развязке двигайтесь правее в направлении Destination 1",

--- a/test/fixtures/v5/roundabout_turn/slight_right_name.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Am Kreisverkehr leicht rechts auf Way Name",
         "en": "At the roundabout make a slight right onto Way Name",
+        "es": "En la rotonda siga ligeramente a la derecha en Way Name",
         "fr": "Au rond-point, tourner légèrement à droite sur Way Name",
         "nl": "Ga rechts op de rotonde naar Way Name",
         "ru": "На круговой развязке двигайтесь правее на Way Name",

--- a/test/fixtures/v5/roundabout_turn/straight_default.json
+++ b/test/fixtures/v5/roundabout_turn/straight_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Am Kreisverkehr geradeaus weiterfahren",
         "en": "At the roundabout continue straight",
+        "es": "En la rotonda continua recto",
         "fr": "Au rond-point, continuer tout droit",
         "nl": "Rechtdoor op de rotonde",
         "ru": "На круговой развязке двигайтесь прямо",

--- a/test/fixtures/v5/roundabout_turn/straight_destination.json
+++ b/test/fixtures/v5/roundabout_turn/straight_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Am Kreisverkehr geradeaus weiterfahren Richtung Destination 1",
         "en": "At the roundabout continue straight towards Destination 1",
+        "es": "En la rotonda continua recto hacia Destination 1",
         "fr": "Au rond-point, continuer tout droit en direction de Destination 1",
         "nl": "Rechtdoor op de rotonde richting Destination 1",
         "ru": "На круговой развязке двигайтесь в направлении Destination 1",

--- a/test/fixtures/v5/roundabout_turn/straight_name.json
+++ b/test/fixtures/v5/roundabout_turn/straight_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Am Kreisverkehr geradeaus weiterfahren auf Way Name",
         "en": "At the roundabout continue straight onto Way Name",
+        "es": "En la rotonda continua recto en Way Name",
         "fr": "Au rond-point, continuer tout droit sur Way Name",
         "nl": "Rechtdoor op de rotonde naar Way Name",
         "ru": "На круговой развязке двигайтесь по Way Name",

--- a/test/fixtures/v5/roundabout_turn/uturn_default.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Am Kreisverkehr 180°-Wendung",
         "en": "At the roundabout make a U-turn",
+        "es": "En la rotonda siga cambio de sentido",
         "fr": "Au rond-point, tourner demi-tour",
         "nl": "Ga omkeren op de rotonde",
         "ru": "На круговой развязке двигайтесь на разворот",

--- a/test/fixtures/v5/roundabout_turn/uturn_destination.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Am Kreisverkehr 180°-Wendung Richtung Destination 1",
         "en": "At the roundabout make a U-turn towards Destination 1",
+        "es": "En la rotonda siga cambio de sentido hacia Destination 1",
         "fr": "Au rond-point, tourner demi-tour en direction de Destination 1",
         "nl": "Ga omkeren op de rotonde richting Destination 1",
         "ru": "На круговой развязке двигайтесь на разворот в направлении Destination 1",

--- a/test/fixtures/v5/roundabout_turn/uturn_name.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Am Kreisverkehr 180°-Wendung auf Way Name",
         "en": "At the roundabout make a U-turn onto Way Name",
+        "es": "En la rotonda siga cambio de sentido en Way Name",
         "fr": "Au rond-point, tourner demi-tour sur Way Name",
         "nl": "Ga omkeren op de rotonde naar Way Name",
         "ru": "На круговой развязке двигайтесь на разворот на Way Name",

--- a/test/fixtures/v5/turn/left_default.json
+++ b/test/fixtures/v5/turn/left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Links abbiegen",
         "en": "Turn left",
+        "es": "Gire a la izquierda",
         "fr": "Tourner à gauche",
         "nl": "Ga linksaf",
         "ru": "Поверните налево",

--- a/test/fixtures/v5/turn/left_destination.json
+++ b/test/fixtures/v5/turn/left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Links abbiegen Richtung Destination 1",
         "en": "Turn left towards Destination 1",
+        "es": "Gire a la izquierda hacia Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "nl": "Ga linksaf richting Destination 1",
         "ru": "Поверните налево в направлении Destination 1",

--- a/test/fixtures/v5/turn/left_name.json
+++ b/test/fixtures/v5/turn/left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Links abbiegen auf Way Name",
         "en": "Turn left onto Way Name",
+        "es": "Gire a la izquierda en Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "nl": "Ga linksaf naar Way Name",
         "ru": "Поверните налево на Way Name",

--- a/test/fixtures/v5/turn/right_default.json
+++ b/test/fixtures/v5/turn/right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rechts abbiegen",
         "en": "Turn right",
+        "es": "Gire a la derecha",
         "fr": "Tourner à droite",
         "nl": "Ga rechtsaf",
         "ru": "Поверните направо",

--- a/test/fixtures/v5/turn/right_destination.json
+++ b/test/fixtures/v5/turn/right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Rechts abbiegen Richtung Destination 1",
         "en": "Turn right towards Destination 1",
+        "es": "Gire a la derecha hacia Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "nl": "Ga rechtsaf richting Destination 1",
         "ru": "Поверните направо в направлении Destination 1",

--- a/test/fixtures/v5/turn/right_name.json
+++ b/test/fixtures/v5/turn/right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Rechts abbiegen auf Way Name",
         "en": "Turn right onto Way Name",
+        "es": "Gire a la derecha en Way Name",
         "fr": "Tourner à droite sur Way Name",
         "nl": "Ga rechtsaf naar Way Name",
         "ru": "Поверните направо на Way Name",

--- a/test/fixtures/v5/turn/sharp_left_default.json
+++ b/test/fixtures/v5/turn/sharp_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf links abbiegen",
         "en": "Make a sharp left",
+        "es": "Siga cerrada a la izquierda",
         "fr": "Tourner franchement à gauche",
         "nl": "Ga linksaf",
         "ru": "Двигайтесь налево",

--- a/test/fixtures/v5/turn/sharp_left_destination.json
+++ b/test/fixtures/v5/turn/sharp_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Scharf links abbiegen Richtung Destination 1",
         "en": "Make a sharp left towards Destination 1",
+        "es": "Siga cerrada a la izquierda hacia Destination 1",
         "fr": "Tourner franchement à gauche en direction de Destination 1",
         "nl": "Ga linksaf richting Destination 1",
         "ru": "Двигайтесь налево в направлении Destination 1",

--- a/test/fixtures/v5/turn/sharp_left_name.json
+++ b/test/fixtures/v5/turn/sharp_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf links abbiegen auf Way Name",
         "en": "Make a sharp left onto Way Name",
+        "es": "Siga cerrada a la izquierda en Way Name",
         "fr": "Tourner franchement à gauche sur Way Name",
         "nl": "Ga linksaf naar Way Name",
         "ru": "Двигайтесь налево на Way Name",

--- a/test/fixtures/v5/turn/sharp_right_default.json
+++ b/test/fixtures/v5/turn/sharp_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf rechts abbiegen",
         "en": "Make a sharp right",
+        "es": "Siga cerrada a la derecha",
         "fr": "Tourner franchement à droite",
         "nl": "Ga rechtsaf",
         "ru": "Двигайтесь направо",

--- a/test/fixtures/v5/turn/sharp_right_destination.json
+++ b/test/fixtures/v5/turn/sharp_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Scharf rechts abbiegen Richtung Destination 1",
         "en": "Make a sharp right towards Destination 1",
+        "es": "Siga cerrada a la derecha hacia Destination 1",
         "fr": "Tourner franchement à droite en direction de Destination 1",
         "nl": "Ga rechtsaf richting Destination 1",
         "ru": "Двигайтесь направо в направлении Destination 1",

--- a/test/fixtures/v5/turn/sharp_right_name.json
+++ b/test/fixtures/v5/turn/sharp_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Scharf rechts abbiegen auf Way Name",
         "en": "Make a sharp right onto Way Name",
+        "es": "Siga cerrada a la derecha en Way Name",
         "fr": "Tourner franchement à droite sur Way Name",
         "nl": "Ga rechtsaf naar Way Name",
         "ru": "Двигайтесь направо на Way Name",

--- a/test/fixtures/v5/turn/slight_left_default.json
+++ b/test/fixtures/v5/turn/slight_left_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht links abbiegen",
         "en": "Make a slight left",
+        "es": "Siga ligeramente a la izquierda",
         "fr": "Tourner légèrement à gauche",
         "nl": "Ga links",
         "ru": "Двигайтесь левее",

--- a/test/fixtures/v5/turn/slight_left_destination.json
+++ b/test/fixtures/v5/turn/slight_left_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Leicht links abbiegen Richtung Destination 1",
         "en": "Make a slight left towards Destination 1",
+        "es": "Siga ligeramente a la izquierda hacia Destination 1",
         "fr": "Tourner légèrement à gauche en direction de Destination 1",
         "nl": "Ga links richting Destination 1",
         "ru": "Двигайтесь левее в направлении Destination 1",

--- a/test/fixtures/v5/turn/slight_left_name.json
+++ b/test/fixtures/v5/turn/slight_left_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht links abbiegen auf Way Name",
         "en": "Make a slight left onto Way Name",
+        "es": "Siga ligeramente a la izquierda en Way Name",
         "fr": "Tourner légèrement à gauche sur Way Name",
         "nl": "Ga links naar Way Name",
         "ru": "Двигайтесь левее на Way Name",

--- a/test/fixtures/v5/turn/slight_right_default.json
+++ b/test/fixtures/v5/turn/slight_right_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht rechts abbiegen",
         "en": "Make a slight right",
+        "es": "Siga ligeramente a la derecha",
         "fr": "Tourner légèrement à droite",
         "nl": "Ga rechts",
         "ru": "Двигайтесь правее",

--- a/test/fixtures/v5/turn/slight_right_destination.json
+++ b/test/fixtures/v5/turn/slight_right_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Leicht rechts abbiegen Richtung Destination 1",
         "en": "Make a slight right towards Destination 1",
+        "es": "Siga ligeramente a la derecha hacia Destination 1",
         "fr": "Tourner légèrement à droite en direction de Destination 1",
         "nl": "Ga rechts richting Destination 1",
         "ru": "Двигайтесь правее в направлении Destination 1",

--- a/test/fixtures/v5/turn/slight_right_name.json
+++ b/test/fixtures/v5/turn/slight_right_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Leicht rechts abbiegen auf Way Name",
         "en": "Make a slight right onto Way Name",
+        "es": "Siga ligeramente a la derecha en Way Name",
         "fr": "Tourner légèrement à droite sur Way Name",
         "nl": "Ga rechts naar Way Name",
         "ru": "Двигайтесь правее на Way Name",

--- a/test/fixtures/v5/turn/straight_default.json
+++ b/test/fixtures/v5/turn/straight_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren",
         "en": "Go straight",
+        "es": "Ve recto",
         "fr": "Aller tout droit",
         "nl": "Ga rechtdoor",
         "ru": "Двигайтесь прямо",

--- a/test/fixtures/v5/turn/straight_destination.json
+++ b/test/fixtures/v5/turn/straight_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren Richtung Destination 1",
         "en": "Go straight towards Destination 1",
+        "es": "Ve recto hacia Destination 1",
         "fr": "Aller tout droit en direction de Destination 1",
         "nl": "Ga rechtdoor richting Destination 1",
         "ru": "Двигайтесь в направлении Destination 1",

--- a/test/fixtures/v5/turn/straight_name.json
+++ b/test/fixtures/v5/turn/straight_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren auf Way Name",
         "en": "Go straight onto Way Name",
+        "es": "Ve recto en Way Name",
         "fr": "Aller tout droit sur Way Name",
         "nl": "Ga rechtdoor naar Way Name",
         "ru": "Двигайтесь по Way Name",

--- a/test/fixtures/v5/turn/uturn_default.json
+++ b/test/fixtures/v5/turn/uturn_default.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "180°-Wendung abbiegen",
         "en": "Make a U-turn",
+        "es": "Siga cambio de sentido",
         "fr": "Tourner demi-tour",
         "nl": "Ga omkeren",
         "ru": "Двигайтесь на разворот",

--- a/test/fixtures/v5/turn/uturn_destination.json
+++ b/test/fixtures/v5/turn/uturn_destination.json
@@ -10,6 +10,7 @@
     "instructions": {
         "de": "180°-Wendung abbiegen Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
+        "es": "Siga cambio de sentido hacia Destination 1",
         "fr": "Tourner demi-tour en direction de Destination 1",
         "nl": "Ga omkeren richting Destination 1",
         "ru": "Двигайтесь на разворот в направлении Destination 1",

--- a/test/fixtures/v5/turn/uturn_name.json
+++ b/test/fixtures/v5/turn/uturn_name.json
@@ -9,6 +9,7 @@
     "instructions": {
         "de": "180°-Wendung abbiegen auf Way Name",
         "en": "Make a U-turn onto Way Name",
+        "es": "Siga cambio de sentido en Way Name",
         "fr": "Tourner demi-tour sur Way Name",
         "nl": "Ga omkeren naar Way Name",
         "ru": "Двигайтесь на разворот на Way Name",

--- a/test/fixtures/v5/use_lane/o.json
+++ b/test/fixtures/v5/use_lane/o.json
@@ -35,6 +35,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren",
         "en": "Continue straight",
+        "es": "Continua recto",
         "fr": "Continuer tout droit",
         "nl": "Rechtdoor",
         "ru": "Продолжайте движение прямо",

--- a/test/fixtures/v5/use_lane/ooo.json
+++ b/test/fixtures/v5/use_lane/ooo.json
@@ -47,6 +47,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren",
         "en": "Continue straight",
+        "es": "Continua recto",
         "fr": "Continuer tout droit",
         "nl": "Rechtdoor",
         "ru": "Продолжайте движение прямо",

--- a/test/fixtures/v5/use_lane/oooxxo.json
+++ b/test/fixtures/v5/use_lane/oooxxo.json
@@ -65,6 +65,7 @@
     "instructions": {
         "de": "Rechts oder links halten",
         "en": "Keep left or right",
+        "es": "Mantengase a la izquierda o derecha",
         "fr": "Rester à gauche ou à droite",
         "nl": "Links of rechts blijven",
         "ru": "Держитесь слева или справа",

--- a/test/fixtures/v5/use_lane/oox.json
+++ b/test/fixtures/v5/use_lane/oox.json
@@ -47,6 +47,7 @@
     "instructions": {
         "de": "Links halten",
         "en": "Keep left",
+        "es": "Mantengase a la izquierda",
         "fr": "Serrer à gauche",
         "nl": "Links aanhouden",
         "ru": "Держитесь левее",

--- a/test/fixtures/v5/use_lane/ooxx.json
+++ b/test/fixtures/v5/use_lane/ooxx.json
@@ -53,6 +53,7 @@
     "instructions": {
         "de": "Links halten",
         "en": "Keep left",
+        "es": "Mantengase a la izquierda",
         "fr": "Serrer à gauche",
         "nl": "Links aanhouden",
         "ru": "Держитесь левее",

--- a/test/fixtures/v5/use_lane/oxo.json
+++ b/test/fixtures/v5/use_lane/oxo.json
@@ -47,6 +47,7 @@
     "instructions": {
         "de": "Rechts oder links halten",
         "en": "Keep left or right",
+        "es": "Mantengase a la izquierda o derecha",
         "fr": "Rester à gauche ou à droite",
         "nl": "Links of rechts blijven",
         "ru": "Держитесь слева или справа",

--- a/test/fixtures/v5/use_lane/xoo.json
+++ b/test/fixtures/v5/use_lane/xoo.json
@@ -47,6 +47,7 @@
     "instructions": {
         "de": "Rechts halten",
         "en": "Keep right",
+        "es": "Mantengase a la derecha",
         "fr": "Serrer à droite",
         "nl": "Rechts aanhouden",
         "ru": "Держитесь правее",

--- a/test/fixtures/v5/use_lane/xox.json
+++ b/test/fixtures/v5/use_lane/xox.json
@@ -47,6 +47,7 @@
     "instructions": {
         "de": "Mittlere Spur nutzen",
         "en": "Keep in the middle",
+        "es": "Mantengase en el medio",
         "fr": "Rester au milieu",
         "nl": "In het midden blijven",
         "ru": "Держитесь посередине",

--- a/test/fixtures/v5/use_lane/xxoo.json
+++ b/test/fixtures/v5/use_lane/xxoo.json
@@ -53,6 +53,7 @@
     "instructions": {
         "de": "Rechts halten",
         "en": "Keep right",
+        "es": "Mantengase a la derecha",
         "fr": "Serrer à droite",
         "nl": "Rechts aanhouden",
         "ru": "Держитесь правее",

--- a/test/fixtures/v5/use_lane/xxooxx.json
+++ b/test/fixtures/v5/use_lane/xxooxx.json
@@ -65,6 +65,7 @@
     "instructions": {
         "de": "Mittlere Spur nutzen",
         "en": "Keep in the middle",
+        "es": "Mantengase en el medio",
         "fr": "Rester au milieu",
         "nl": "In het midden blijven",
         "ru": "Держитесь посередине",

--- a/test/fixtures/v5/use_lane/xxoxo.json
+++ b/test/fixtures/v5/use_lane/xxoxo.json
@@ -59,6 +59,7 @@
     "instructions": {
         "de": "Geradeaus weiterfahren",
         "en": "Continue straight",
+        "es": "Continua recto",
         "fr": "Continuer tout droit",
         "nl": "Rechtdoor",
         "ru": "Продолжайте движение прямо",


### PR DESCRIPTION
Added Spanish translation from Transifex.

@josek5494, thank you for your contributions! Please review the test fixtures in this PR for any edge cases that may need to be overridden. Incidentally, it looks like we got very lucky in that we only ended up needing feminine ordinals (for _destina_ and _salida_).

/cc @MallorcaRedes