### PR TITLE
Don't publish transifex.auth into NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 ./test/
+transifex.auth


### PR DESCRIPTION
I suppose that transifex.auth file with Transifex authitication was published into NPM repository by mistake. This commit excludes this file from publishing.