### PR TITLE
Update Dutch ordinals from Transifex

### DIFF
--- a/languages/translations/nl.json
+++ b/languages/translations/nl.json
@@ -5,16 +5,16 @@
     "v5": {
         "constants": {
             "ordinalize": {
-                "1": "eerste",
-                "2": "tweede",
-                "3": "derde",
-                "4": "vierde",
-                "5": "vijfde",
-                "6": "zesde",
-                "7": "zevende",
-                "8": "achtste",
-                "9": "negende",
-                "10": "tiende"
+                "1": "1e",
+                "2": "2e",
+                "3": "3e",
+                "4": "4e",
+                "5": "5e",
+                "6": "6e",
+                "7": "7e",
+                "8": "8e",
+                "9": "9e",
+                "10": "10e"
             },
             "direction": {
                 "north": "noord",

--- a/test/fixtures/v5/rotary/exit_10.json
+++ b/test/fixtures/v5/rotary/exit_10.json
@@ -12,7 +12,7 @@
         "en": "Enter the rotary and take the 10th exit",
         "es": "Entra en la rotonda y toma la 10ª salida",
         "fr": "Entrer dans le rond-point et prendre la dixième sortie",
-        "nl": "Ga het knooppunt op en neem afslag tiende",
+        "nl": "Ga het knooppunt op en neem afslag 10e",
         "ru": "На круговой развязке сверните на десятый съезд",
         "sv": "Kör in i rondellen och ta avfart 10:e",
         "vi": "Đi vào bùng binh và ra tại đường thứ 10",

--- a/test/fixtures/v5/rotary/exit_1_default.json
+++ b/test/fixtures/v5/rotary/exit_1_default.json
@@ -12,7 +12,7 @@
         "en": "Enter the rotary and take the 1st exit",
         "es": "Entra en la rotonda y toma la 1ª salida",
         "fr": "Entrer dans le rond-point et prendre la première sortie",
-        "nl": "Ga het knooppunt op en neem afslag eerste",
+        "nl": "Ga het knooppunt op en neem afslag 1e",
         "ru": "На круговой развязке сверните на первый съезд",
         "sv": "Kör in i rondellen och ta avfart 1:a",
         "vi": "Đi vào bùng binh và ra tại đường đầu tiên",

--- a/test/fixtures/v5/rotary/exit_1_destination.json
+++ b/test/fixtures/v5/rotary/exit_1_destination.json
@@ -13,7 +13,7 @@
         "en": "Enter the rotary and take the 1st exit towards Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "fr": "Entrer dans le rond-point et prendre la première sortie en direction de Destination 1",
-        "nl": "Ga het knooppunt op en neem afslag eerste richting Destination 1",
+        "nl": "Ga het knooppunt op en neem afslag 1e richting Destination 1",
         "ru": "На круговой развязке сверните на первый съезд в направлении Destination 1",
         "sv": "Kör in i rondellen och ta avfart 1:a mot Destination 1",
         "vi": "Đi vào bùng binh và ra tại đường đầu tiên đến Destination 1",

--- a/test/fixtures/v5/rotary/exit_1_name.json
+++ b/test/fixtures/v5/rotary/exit_1_name.json
@@ -12,7 +12,7 @@
         "en": "Enter the rotary and take the 1st exit onto Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
         "fr": "Entrer dans le rond-point et prendre la première sortie sur Way Name",
-        "nl": "Ga het knooppunt op en neem afslag eerste naar Way Name",
+        "nl": "Ga het knooppunt op en neem afslag 1e naar Way Name",
         "ru": "На круговой развязке сверните на первый съезд на Way Name",
         "sv": "Kör in i rondellen och ta avfart 1:a mot Way Name",
         "vi": "Đi vào bùng binh và ra tại đường đầu tiên tức Way Name",

--- a/test/fixtures/v5/rotary/exit_2.json
+++ b/test/fixtures/v5/rotary/exit_2.json
@@ -12,7 +12,7 @@
         "en": "Enter the rotary and take the 2nd exit",
         "es": "Entra en la rotonda y toma la 2ª salida",
         "fr": "Entrer dans le rond-point et prendre la seconde sortie",
-        "nl": "Ga het knooppunt op en neem afslag tweede",
+        "nl": "Ga het knooppunt op en neem afslag 2e",
         "ru": "На круговой развязке сверните на второй съезд",
         "sv": "Kör in i rondellen och ta avfart 2:a",
         "vi": "Đi vào bùng binh và ra tại đường thứ 2",

--- a/test/fixtures/v5/rotary/exit_3.json
+++ b/test/fixtures/v5/rotary/exit_3.json
@@ -12,7 +12,7 @@
         "en": "Enter the rotary and take the 3rd exit",
         "es": "Entra en la rotonda y toma la 3ª salida",
         "fr": "Entrer dans le rond-point et prendre la troisième sortie",
-        "nl": "Ga het knooppunt op en neem afslag derde",
+        "nl": "Ga het knooppunt op en neem afslag 3e",
         "ru": "На круговой развязке сверните на третий съезд",
         "sv": "Kör in i rondellen och ta avfart 3:e",
         "vi": "Đi vào bùng binh và ra tại đường thứ 3",

--- a/test/fixtures/v5/rotary/exit_4.json
+++ b/test/fixtures/v5/rotary/exit_4.json
@@ -12,7 +12,7 @@
         "en": "Enter the rotary and take the 4th exit",
         "es": "Entra en la rotonda y toma la 4ª salida",
         "fr": "Entrer dans le rond-point et prendre la quatrième sortie",
-        "nl": "Ga het knooppunt op en neem afslag vierde",
+        "nl": "Ga het knooppunt op en neem afslag 4e",
         "ru": "На круговой развязке сверните на четвёртый съезд",
         "sv": "Kör in i rondellen och ta avfart 4:e",
         "vi": "Đi vào bùng binh và ra tại đường thứ 4",

--- a/test/fixtures/v5/rotary/exit_5.json
+++ b/test/fixtures/v5/rotary/exit_5.json
@@ -12,7 +12,7 @@
         "en": "Enter the rotary and take the 5th exit",
         "es": "Entra en la rotonda y toma la 5ª salida",
         "fr": "Entrer dans le rond-point et prendre la cinquième sortie",
-        "nl": "Ga het knooppunt op en neem afslag vijfde",
+        "nl": "Ga het knooppunt op en neem afslag 5e",
         "ru": "На круговой развязке сверните на пятый съезд",
         "sv": "Kör in i rondellen och ta avfart 5:e",
         "vi": "Đi vào bùng binh và ra tại đường thứ 5",

--- a/test/fixtures/v5/rotary/exit_6.json
+++ b/test/fixtures/v5/rotary/exit_6.json
@@ -12,7 +12,7 @@
         "en": "Enter the rotary and take the 6th exit",
         "es": "Entra en la rotonda y toma la 6ª salida",
         "fr": "Entrer dans le rond-point et prendre la sixième sortie",
-        "nl": "Ga het knooppunt op en neem afslag zesde",
+        "nl": "Ga het knooppunt op en neem afslag 6e",
         "ru": "На круговой развязке сверните на шестой съезд",
         "sv": "Kör in i rondellen och ta avfart 6:e",
         "vi": "Đi vào bùng binh và ra tại đường thú 6",

--- a/test/fixtures/v5/rotary/exit_7.json
+++ b/test/fixtures/v5/rotary/exit_7.json
@@ -12,7 +12,7 @@
         "en": "Enter the rotary and take the 7th exit",
         "es": "Entra en la rotonda y toma la 7ª salida",
         "fr": "Entrer dans le rond-point et prendre la setpième sortie",
-        "nl": "Ga het knooppunt op en neem afslag zevende",
+        "nl": "Ga het knooppunt op en neem afslag 7e",
         "ru": "На круговой развязке сверните на седьмой съезд",
         "sv": "Kör in i rondellen och ta avfart 7:e",
         "vi": "Đi vào bùng binh và ra tại đường thứ 7",

--- a/test/fixtures/v5/rotary/exit_8.json
+++ b/test/fixtures/v5/rotary/exit_8.json
@@ -12,7 +12,7 @@
         "en": "Enter the rotary and take the 8th exit",
         "es": "Entra en la rotonda y toma la 8ª salida",
         "fr": "Entrer dans le rond-point et prendre la huitième sortie",
-        "nl": "Ga het knooppunt op en neem afslag achtste",
+        "nl": "Ga het knooppunt op en neem afslag 8e",
         "ru": "На круговой развязке сверните на восьмой съезд",
         "sv": "Kör in i rondellen och ta avfart 8:e",
         "vi": "Đi vào bùng binh và ra tại đường thứ 8",

--- a/test/fixtures/v5/rotary/exit_9.json
+++ b/test/fixtures/v5/rotary/exit_9.json
@@ -12,7 +12,7 @@
         "en": "Enter the rotary and take the 9th exit",
         "es": "Entra en la rotonda y toma la 9ª salida",
         "fr": "Entrer dans le rond-point et prendre la neuvième sortie",
-        "nl": "Ga het knooppunt op en neem afslag negende",
+        "nl": "Ga het knooppunt op en neem afslag 9e",
         "ru": "На круговой развязке сверните на девятый съезд",
         "sv": "Kör in i rondellen och ta avfart 9:e",
         "vi": "Đi vào bùng binh và ra tại đường thứ 9",

--- a/test/fixtures/v5/rotary/name_exit_default.json
+++ b/test/fixtures/v5/rotary/name_exit_default.json
@@ -13,7 +13,7 @@
         "en": "Enter Rotary Name and take the 2nd exit",
         "es": "Entra en Rotary Name y coge la 2ª salida",
         "fr": "Entrer dans le rond-point Rotary Name et prendre la seconde sortie",
-        "nl": "Ga het knooppunt Rotary Name op en neem afslag tweede",
+        "nl": "Ga het knooppunt Rotary Name op en neem afslag 2e",
         "ru": "На Rotary Name с круговым движением сверните на второй съезд",
         "sv": "Kör in i Rotary Name och ta avfart 2:a",
         "vi": "Đi vào Rotary Name và ra tại đường thứ 2",

--- a/test/fixtures/v5/rotary/name_exit_destination.json
+++ b/test/fixtures/v5/rotary/name_exit_destination.json
@@ -14,7 +14,7 @@
         "en": "Enter Rotary Name and take the 2nd exit towards Destination 1",
         "es": "Entra en Rotary Name y coge la 2ª salida hacia Destination 1",
         "fr": "Entrer dans le rond-point Rotary Name et prendre la seconde sortie en direction de Destination 1",
-        "nl": "Ga het knooppunt Rotary Name op en neem afslag tweede richting Destination 1",
+        "nl": "Ga het knooppunt Rotary Name op en neem afslag 2e richting Destination 1",
         "ru": "На Rotary Name с круговым движением сверните на второй съезд в направлении Destination 1",
         "sv": "Kör in i Rotary Name och ta avfart 2:a mot Destination 1",
         "vi": "Đi vào Rotary Name và ra tại đường thứ 2 đến Destination 1",

--- a/test/fixtures/v5/rotary/name_exit_name.json
+++ b/test/fixtures/v5/rotary/name_exit_name.json
@@ -13,7 +13,7 @@
         "en": "Enter Rotary Name and take the 2nd exit onto Way Name",
         "es": "Entra en Rotary Name y coge la 2ª salida en Way Name",
         "fr": "Entrer dans le rond-point Rotary Name et prendre la seconde sortie sur Way Name",
-        "nl": "Ga het knooppunt Rotary Name op en neem afslag tweede naar Way Name",
+        "nl": "Ga het knooppunt Rotary Name op en neem afslag 2e naar Way Name",
         "ru": "На Rotary Name с круговым движением сверните на второй съезд на Way Name",
         "sv": "Kör in i Rotary Name och ta avfart 2:a mot Way Name",
         "vi": "Đi vào Rotary Name và ra tại đường thứ 2 tức Way Name",

--- a/test/fixtures/v5/roundabout/exit_default.json
+++ b/test/fixtures/v5/roundabout/exit_default.json
@@ -12,7 +12,7 @@
         "en": "Enter the roundabout and take the 1st exit",
         "es": "Entra en la rotonda y toma la 1ª salida",
         "fr": "Entrer dans le rond-point et prendre la première sortie",
-        "nl": "Ga de rotonde op en neem afslag eerste",
+        "nl": "Ga de rotonde op en neem afslag 1e",
         "ru": "На круговой развязке сверните на первый съезд",
         "sv": "Kör in i rondellen och ta avfart 1:a",
         "vi": "Đi vào vòng xuyến và ra tại đường đầu tiên",

--- a/test/fixtures/v5/roundabout/exit_destination.json
+++ b/test/fixtures/v5/roundabout/exit_destination.json
@@ -13,7 +13,7 @@
         "en": "Enter the roundabout and take the 1st exit towards Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "fr": "Entrer dans le rond-point et prendre la première sortie en direction de Destination 1",
-        "nl": "Ga de rotonde op en neem afslag eerste richting Destination 1",
+        "nl": "Ga de rotonde op en neem afslag 1e richting Destination 1",
         "ru": "На круговой развязке сверните на первый съезд в направлении Destination 1",
         "sv": "Kör in i rondellen och ta avfart 1:a mot Destination 1",
         "vi": "Đi vào vòng xuyến và ra tại đường đầu tiên đến Destination 1",

--- a/test/fixtures/v5/roundabout/exit_name.json
+++ b/test/fixtures/v5/roundabout/exit_name.json
@@ -12,7 +12,7 @@
         "en": "Enter the roundabout and take the 1st exit onto Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
         "fr": "Entrer dans le rond-point et prendre la première sortie sur Way Name",
-        "nl": "Ga de rotonde op en neem afslag eerste naar Way Name",
+        "nl": "Ga de rotonde op en neem afslag 1e naar Way Name",
         "ru": "На круговой развязке сверните на первый съезд на Way Name",
         "sv": "Kör in i rondellen och ta avfart 1:a mot Way Name",
         "vi": "Đi vào vòng xuyến và ra tại đường đầu tiên tức Way Name",


### PR DESCRIPTION
Pulled the Dutch localization from Transifex to use numerals instead of spelling out the ordinals.