### PR TITLE
Multiple language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file. For change 
 
 - put future changes here
 
+- Breaking API change: move language selection from module loading to `compile(language, step)`
+
 # 0.2.1 2017-04-05
 
 - Add Spanish translation (thanks @josek5494)

--- a/Readme.md
+++ b/Readme.md
@@ -17,17 +17,18 @@ OSRM Text Instructions has been translated into [several languages](https://gith
 
 ### JavaScript Usage
 
-```
+```js
 var version = 'v5';
-var language = 'en';
-var options = {};
-var osrmTextInstructions = require('osrm-text-instructions')(version, language, options);
+var options = {
+    languages: [ 'en', 'fr' ]
+};
+var osrmTextInstructions = require('osrm-text-instructions')(version, options);
 
-// make your request against the API
+// make your request against the API, save result to response variable
 
 response.legs.forEach(function(leg) {
   leg.steps.forEach(function(step) {
-    instruction = osrmTextInstructions.compile(step)
+    instruction = osrmTextInstructions.compile(step, 'en')
   });
 });
 ```
@@ -35,8 +36,8 @@ response.legs.forEach(function(leg) {
 parameter | required? | values | description
 ---|----|----|---
 `version` | required | `v5` | Major OSRM version
-`language` | required | `en` `de` `zh-Hans` `fr` `nl` `ru` | Language identifier
 `options.hooks.tokenizedInstruction` | optional | `function(instruction)` | A function to change the raw instruction string before tokens are replaced. Useful to inject custom markup for tokens
+`options.languages` | optional | `en` `de` `zh-Hans` `fr` `nl` `ru` | Array of language identifiers that should be supported. Default is loading all language files, which can be huge on websites
 
 ### Development
 #### Architecture

--- a/Readme.md
+++ b/Readme.md
@@ -19,13 +19,11 @@ OSRM Text Instructions has been translated into [several languages](https://gith
 
 ```js
 var version = 'v5';
-var options = {
-    languages: [ 'en', 'fr' ]
-};
-var osrmTextInstructions = require('osrm-text-instructions')(version, options);
+var osrmTextInstructions = require('osrm-text-instructions')(version);
 
 // make your request against the API, save result to response variable
 
+var language = 'en';
 response.legs.forEach(function(leg) {
   leg.steps.forEach(function(step) {
     instruction = osrmTextInstructions.compile(language, step)
@@ -71,7 +69,7 @@ To add an own translations:
 - Go to [Transifex](https://www.transifex.com/project-osrm/osrm-text-instructions/) and create the new translation there
 - When the translation on Transifex is ready, pull in the translation file:
   - Create an empty translation file `echo "{}" > languages/translations/{language_code}.json`
-  - Add the language code to `./languages.js`
+  - Add the new translation file and language code to `./languages.js`
   - If needed: make overrides in `languages/overrides/{language_code}.json`
   - `npm run transifex`
 - Generate fixture strings for the tests via `UPDATE=1 npm test` (see changes in `git diff`)

--- a/Readme.md
+++ b/Readme.md
@@ -27,8 +27,8 @@ var osrmTextInstructions = require('osrm-text-instructions')(version, options);
 // make your request against the API, save result to response variable
 
 response.legs.forEach(function(leg) {
-  leg.steps.forEach(function(step) {
-    instruction = osrmTextInstructions.compile(step, 'en')
+  leg.steps.forEach(function(language, step) {
+    instruction = osrmTextInstructions.compile(language, step)
   });
 });
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -27,7 +27,7 @@ var osrmTextInstructions = require('osrm-text-instructions')(version, options);
 // make your request against the API, save result to response variable
 
 response.legs.forEach(function(leg) {
-  leg.steps.forEach(function(language, step) {
+  leg.steps.forEach(function(step) {
     instruction = osrmTextInstructions.compile(language, step)
   });
 });

--- a/Readme.md
+++ b/Readme.md
@@ -70,9 +70,9 @@ To add an own translations:
 
 - Go to [Transifex](https://www.transifex.com/project-osrm/osrm-text-instructions/) and create the new translation there
 - When the translation on Transifex is ready, pull in the translation file:
-  - Create an empty translation file `echo "{}" > languages/translations/{language_tag}.json`
-  - Add the new translation file and language tag to `./languages.js`
-  - If needed: make overrides in `languages/overrides/{language_tag}.json`
+  - Create an empty translation file `echo "{}" > languages/translations/{language_code}.json`
+  - Add the new translation file and language code to `./languages.js`
+  - If needed: make overrides in `languages/overrides/{language_code}.json`
   - `npm run transifex`
 - Generate fixture strings for the tests via `UPDATE=1 npm test` (see changes in `git diff`)
 - Make a PR

--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ parameter | required? | values | description
 ---|----|----|---
 `version` | required | `v5` | Major OSRM version
 `options.hooks.tokenizedInstruction` | optional | `function(instruction)` | A function to change the raw instruction string before tokens are replaced. Useful to inject custom markup for tokens
-`options.languages` | optional | `en` `de` `zh-Hans` `fr` `nl` `ru` | Array of language identifiers that should be supported. Default is loading all language files, which can be huge on websites
+`options.languages` | optional | `en` `de` `zh-Hans` `fr` `nl` `ru` [`etc`](https://github.com/Project-OSRM/osrm-text-instructions/tree/master/languages/translations/) | Array of language identifiers that should be supported. Default is loading all language files, which can be huge on websites
 
 ### Development
 #### Architecture
@@ -62,7 +62,7 @@ Fixtures are programatically created and updated via `test/fixtures_test`. To up
 
 #### Translations
 
-The main language of this project is English `en`. We support other languages via translations, as seen in `languages/translations`.
+The main language of this project is English `en`. We support other languages via translations, as seen in [`languages/translations`](https://github.com/Project-OSRM/osrm-text-instructions/tree/master/languages/translations/).
 
 You can help translating on the web via [Transifex](https://www.transifex.com/project-osrm/osrm-text-instructions/)
 
@@ -71,7 +71,7 @@ To add an own translations:
 - Go to [Transifex](https://www.transifex.com/project-osrm/osrm-text-instructions/) and create the new translation there
 - When the translation on Transifex is ready, pull in the translation file:
   - Create an empty translation file `echo "{}" > languages/translations/{language_code}.json`
-  - Add the new translation file and language code to `./languages.js`
+  - Add the language code to `./languages.js`
   - If needed: make overrides in `languages/overrides/{language_code}.json`
   - `npm run transifex`
 - Generate fixture strings for the tests via `UPDATE=1 npm test` (see changes in `git diff`)

--- a/Readme.md
+++ b/Readme.md
@@ -35,7 +35,7 @@ parameter | required? | values | description
 ---|----|----|---
 `version` | required | `v5` | Major OSRM version
 `options.hooks.tokenizedInstruction` | optional | `function(instruction)` | A function to change the raw instruction string before tokens are replaced. Useful to inject custom markup for tokens
-`options.languages` | optional | `en` `de` `zh-Hans` `fr` `nl` `ru` [`etc`](https://github.com/Project-OSRM/osrm-text-instructions/tree/master/languages/translations/) | Array of language identifiers that should be supported. Default is loading all language files, which can be huge on websites
+`language` | required | `en` `de` `zh-Hans` `fr` `nl` `ru` [and more](https://github.com/Project-OSRM/osrm-text-instructions/tree/master/languages/translations/) | Compiling instructions for the selected language code.
 
 ### Development
 #### Architecture

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = function(version, _options) {
     var options = {};
     options.hooks = {};
     options.hooks.tokenizedInstruction = ((_options || {}).hooks || {}).tokenizedInstruction;
-    options.languages = (_options || {}).languages || languages.supportedTags;
+    options.languages = (_options || {}).languages || languages.supportedCodes;
 
         // TODO Validate language
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var languages = require('./languages');
 var instructions = languages.instructions;
 
 module.exports = function(version, _options) {
-    // load instructions
     var options = {};
     options.hooks = {};
     options.hooks.tokenizedInstruction = ((_options || {}).hooks || {}).tokenizedInstruction;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,13 @@
-module.exports = function(version, language, options) {
+module.exports = function(version, _options) {
     // load instructions
-    var instructions = require('./languages').get(language);
+    var options = {};
+    options.hook = {};
+    options.hook.tokeninzedInstruction = ((_options || {}).hook || {}).tokeninzedInstruction;
+    options.languages = _options.languages || ['en', 'fr'];
+
+        // TODO Validate language
+
+    var instructions = require('./languages').get(options.languages);
     if (Object !== instructions.constructor) throw 'instructions must be object';
     if (!instructions[version]) { throw 'invalid version ' + version; }
 
@@ -147,9 +154,8 @@ module.exports = function(version, language, options) {
                 instruction = instructionObject.default;
             }
 
-            var tokenizedInstructionHook = ((options || {}).hooks || {}).tokenizedInstruction;
-            if (tokenizedInstructionHook) {
-                instruction = tokenizedInstructionHook(instruction);
+            if (options.tokenizedInstruction) {
+                instruction = options.tokenizedInstruction(instruction);
             }
 
             // Replace tokens

--- a/index.js
+++ b/index.js
@@ -1,18 +1,14 @@
 var languages = require('./languages');
+var instructions = languages.instructions;
 
 module.exports = function(version, _options) {
     // load instructions
     var options = {};
     options.hooks = {};
     options.hooks.tokenizedInstruction = ((_options || {}).hooks || {}).tokenizedInstruction;
-    options.languages = (_options || {}).languages || languages.supportedCodes;
 
-        // TODO Validate language
-
-    var instructions = require('./languages').get(options.languages);
-    if (Object !== instructions.constructor) throw 'instructions must be object';
     Object.keys(instructions).forEach(function(code) {
-        if (!instructions[code][version]) { throw 'invalid version ' + version; }
+        if (!instructions[code][version]) { throw 'invalid version ' + version + ': ' + code + ' not supported'; }
     });
 
     return {
@@ -75,7 +71,7 @@ module.exports = function(version, _options) {
         },
         compile: function(language, step) {
             if (!language) throw new Error('No language code provided');
-            if (options.languages.indexOf(language) === -1) throw new Error('language code ' + language + ' not loaded');
+            if (languages.supportedCodes.indexOf(language) === -1) throw new Error('language code ' + language + ' not loaded');
             if (!step.maneuver) throw new Error('No step maneuver provided');
 
             var type = step.maneuver.type;

--- a/languages.js
+++ b/languages.js
@@ -1,5 +1,5 @@
-// Create a list of supported tags
-var supportedTags = [
+// Create a list of supported codes
+var supportedCodes = [
     'de',
     'en',
     'es',
@@ -13,18 +13,18 @@ var supportedTags = [
 ];
 
 module.exports = {
-    get: function(tags) {
-        // Loads translation files for only supported and user requested tags
+    get: function(codes) {
+        // Loads translation files for only supported and user requested codes
         var languages = {};
-        tags.forEach(function(tag) {
-            if (supportedTags.indexOf(tag) === -1) {
-                throw 'Unsupported language tag: ' + tag;
+        codes.forEach(function(code) {
+            if (supportedCodes.indexOf(code) === -1) {
+                throw 'Unsupported language code: ' + code;
             } else {
-                languages[tag] = require('./languages/translations/' + tag + '.json');
+                languages[code] = require('./languages/translations/' + code + '.json');
             }
         });
 
         return languages;
     },
-    supportedTags: supportedTags
+    supportedCodes: supportedCodes
 };

--- a/languages.js
+++ b/languages.js
@@ -1,30 +1,32 @@
+// Load all language files excplicitely to allow integration
+// with bundling tools like webpack and browserify
+var instructionsDe = require('./languages/translations/de.json');
+var instructionsEn = require('./languages/translations/en.json');
+var instructionsEs = require('./languages/translations/es.json');
+var instructionsFr = require('./languages/translations/fr.json');
+var instructionsId = require('./languages/translations/id.json');
+var instructionsNl = require('./languages/translations/nl.json');
+var instructionsRu = require('./languages/translations/ru.json');
+var instructionsSv = require('./languages/translations/sv.json');
+var instructionsVi = require('./languages/translations/vi.json');
+var instructionsZhHans = require('./languages/translations/zh-Hans.json');
+
+
 // Create a list of supported codes
-var supportedCodes = [
-    'de',
-    'en',
-    'es',
-    'fr',
-    'id',
-    'nl',
-    'ru',
-    'sv',
-    'vi',
-    'zh-Hans'
-];
+var instructions = {
+    'de': instructionsDe,
+    'en': instructionsEn,
+    'es': instructionsEs,
+    'fr': instructionsFr,
+    'id': instructionsId,
+    'nl': instructionsNl,
+    'ru': instructionsRu,
+    'sv': instructionsSv,
+    'vi': instructionsVi,
+    'zh-Hans': instructionsZhHans
+};
 
 module.exports = {
-    get: function(codes) {
-        // Loads translation files for only supported and user requested codes
-        var languages = {};
-        codes.forEach(function(code) {
-            if (supportedCodes.indexOf(code) === -1) {
-                throw 'Unsupported language code: ' + code;
-            } else {
-                languages[code] = require('./languages/translations/' + code + '.json');
-            }
-        });
-
-        return languages;
-    },
-    supportedCodes: supportedCodes
+    supportedCodes: Object.keys(instructions),
+    instructions: instructions
 };

--- a/languages.js
+++ b/languages.js
@@ -1,49 +1,30 @@
-// Load all language files excplicitely to allow integration
-// with bundling tools like webpack and browserify
-var instructionsDe = require('./languages/translations/de.json');
-var instructionsEn = require('./languages/translations/en.json');
-var instructionsEs = require('./languages/translations/es.json');
-var instructionsFr = require('./languages/translations/fr.json');
-var instructionsId = require('./languages/translations/id.json');
-var instructionsNl = require('./languages/translations/nl.json');
-var instructionsRu = require('./languages/translations/ru.json');
-var instructionsSv = require('./languages/translations/sv.json');
-var instructionsVi = require('./languages/translations/vi.json');
-var instructionsZhHans = require('./languages/translations/zh-Hans.json');
-
-// Match tag to required language files
-var tags = {
-    'de': instructionsDe,
-    'en': instructionsEn,
-    'es': instructionsEs,
-    'fr': instructionsFr,
-    'id': instructionsId,
-    'nl': instructionsNl,
-    'ru': instructionsRu,
-    'sv': instructionsSv,
-    'vi': instructionsVi,
-    'zh-Hans': instructionsZhHans
-};
-
-// A tag can redirect to another tag via the language tag as string value
-var redirects = {
-    'zh': 'zh-Hans'
-};
+// Create a list of supported tags
+var supportedTags = [
+    'de',
+    'en',
+    'es',
+    'fr',
+    'id',
+    'nl',
+    'ru',
+    'sv',
+    'vi',
+    'zh-Hans'
+];
 
 module.exports = {
-    tags: tags,
-    redirects: redirects,
-    get: function(tag) {
-        if (this.redirects[tag]) {
-            // redirect to other tag
-            this.get(this.redirects[tag]);
-        }
+    get: function(tags) {
+        // Loads translation files for only supported and user requested tags
+        var languages = {};
+        tags.forEach(function(tag) {
+            if (supportedTags.indexOf(tag) === -1) {
+                throw 'Unsupported language tag: ' + tag;
+            } else {
+                languages[tag] = require('./languages/translations/' + tag + '.json');
+            }
+        });
 
-        var language = this.tags[tag];
-        if (!language) {
-            throw 'invalid language ' + tag;
-        }
-
-        return language;
-    }
+        return languages;
+    },
+    supportedTags: supportedTags
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "request": "2.79.0"
   },
   "scripts": {
-    "lint": "eslint *.js test/*.js",
+    "lint": "eslint *.js test/*.js scripts/*.js",
     "pretest": "npm run lint",
     "test": "tape test/*_test.js",
     "transifex": "node scripts/transifex.js"

--- a/scripts/transifex.js
+++ b/scripts/transifex.js
@@ -21,23 +21,24 @@ if (!auth.user || !auth.pass) throw 'invalid transifex.auth';
 var urls = {};
 urls.api = 'https://www.transifex.com/api/2';
 urls.project = 'project/osrm-text-instructions';
-urls.translation = `${urls.api}/${urls.project}/resource/enjson/translation`
+urls.translation = `${urls.api}/${urls.project}/resource/enjson/translation`;
 
-Object.keys(languages.tags).forEach((tag) => {
-    if (tag === 'en') { return }; // no need to download english
+Object.keys(languages.codes).forEach((code) => {
+    // no need to download english
+    if (code === 'en') { return };
 
     // Download from Transifex
-    request.get(`${urls.translation}/${tag}`, { auth: auth }, (err, resp, body) => {
+    request.get(`${urls.translation}/${code}`, {auth: auth}, (err, resp, body) => {
         if (err) throw err;
         var content = JSON.parse(JSON.parse(body).content);
 
         // Apply language-specific overrides
-        var override = `${__dirname}/../languages/overrides/${tag}.js`
-        if(fs.existsSync(override)) {
+        var override = `${__dirname}/../languages/overrides/${code}.js`;
+        if (fs.existsSync(override)) {
             content = require(override)(content);
         }
 
         // Write language file
-        fs.writeFileSync(`${__dirname}/../languages/translations/${tag}.json`, JSON.stringify(content, null, 4));
+        fs.writeFileSync(`${__dirname}/../languages/translations/${code}.json`, JSON.stringify(content, null, 4));
     });
 });

--- a/scripts/transifex.js
+++ b/scripts/transifex.js
@@ -25,7 +25,7 @@ urls.translation = `${urls.api}/${urls.project}/resource/enjson/translation`;
 
 Object.keys(languages.codes).forEach((code) => {
     // no need to download english
-    if (code === 'en') { return };
+    if (code === 'en') return;
 
     // Download from Transifex
     request.get(`${urls.translation}/${code}`, {auth: auth}, (err, resp, body) => {

--- a/test/fixtures_test.js
+++ b/test/fixtures_test.js
@@ -9,10 +9,7 @@ var constants = require('./constants');
 var instructions = require('../index.js');
 
 // Load instructions files for each language
-var languages = {};
-Object.keys(require('../languages').tags).forEach((l) => {
-    languages[l] = instructions('v5', l);
-});
+var languages = instructions('v5');
 
 tape.test('verify existance/update fixtures', function(assert) {
     function clone(obj) {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -5,7 +5,7 @@ var tape = require('tape');
 var instructions = require('../index');
 
 tape.test('v5 directionFromDegree', function(assert) {
-    var v5Instructions = instructions('v5', {languages: ['en']});
+    var v5Instructions = instructions('v5');
 
     assert.equal(
         v5Instructions.directionFromDegree('en', undefined), // eslint-disable-line no-undefined
@@ -106,7 +106,7 @@ tape.test('v5 compile', function(t) {
     });
 
     t.test('throws an error if a non supported language code is provided', function(assert) {
-        var v5Instructions = instructions('v5', {languages: ['en']});
+        var v5Instructions = instructions('v5');
 
         assert.throws(function() {
             v5Instructions.compile('foo');
@@ -122,8 +122,7 @@ tape.test('v5 compile', function(t) {
                 tokenizedInstruction: function(instruction) {
                     return instruction.replace('{way_name}', '<blink>{way_name}</blink>');
                 }
-            },
-            languages: ['en']
+            }
         });
 
         assert.equal(v5Instructions.compile('en', {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -3,7 +3,6 @@ var fs = require('fs');
 var tape = require('tape');
 
 var instructions = require('../index');
-var languageInstructions = require('../languages');
 
 tape.test('v5 directionFromDegree', function(assert) {
     var v5Instructions = instructions('v5', {languages: ['en']});

--- a/test/languages_test.js
+++ b/test/languages_test.js
@@ -50,8 +50,11 @@ tape.test('verify language files structure', function(assert) {
 tape.test('verify that instructions are only returned for user requested languages', function(assert) {
     var translations = languages.get(['en', 'fr']);
 
-    assert.deepEqual(Object.keys(translations).sort(), ['fr', 'en'].sort(),
-    'only returns en and fr');
+    assert.deepEqual(
+        Object.keys(translations).sort(),
+        ['fr', 'en'].sort(),
+        'only returns en and fr'
+    );
 
     assert.end();
 });

--- a/test/languages_test.js
+++ b/test/languages_test.js
@@ -2,12 +2,12 @@ var tape = require('tape');
 
 var languages = require('../languages');
 
-tape.test('throws on invalid tags', function(assert) {
+tape.test('throws on invalid codes', function(assert) {
     assert.throws(function() {
         languages.get(['en', 'foo']);
     },
-    /Unsupported language tag: foo/,
-    'throws error when gets foo language tag'
+    /Unsupported language code: foo/,
+    'throws error when gets foo language code'
     );
 
     assert.end();
@@ -16,7 +16,7 @@ tape.test('throws on invalid tags', function(assert) {
 tape.test('verify language files structure', function(assert) {
     // check that language files have about the same structure as
     // the reference english language file
-    var translations = languages.get(languages.supportedTags);
+    var translations = languages.get(languages.supportedCodes);
     var english = translations.en;
 
     Object.keys(translations).forEach((l) => {

--- a/test/languages_test.js
+++ b/test/languages_test.js
@@ -1,24 +1,13 @@
 var tape = require('tape');
 
-var instructions = require('../index.js');
 var languages = require('../languages');
-const tags = Object.keys(languages.tags);
 
-tape.test('verify language files load', function(assert) {
-    var step = {
-        maneuver: {
-            'type': 'turn',
-            'modifier': 'left'
-        }
-    };
-
-    tags.forEach((t) => {
-        assert.ok(instructions('v5', t).compile(step), 'has ' + t);
-    });
-
-    assert.throws(
-        () => { instructions('v5', 'this-will-never-exist'); },
-        'throws on non-existing language'
+tape.test('throws on invalid tags', function(assert) {
+    assert.throws(function() {
+        languages.get(['en', 'foo']);
+    },
+    /Unsupported language tag: foo/,
+    'throws error when gets foo language tag'
     );
 
     assert.end();
@@ -27,15 +16,16 @@ tape.test('verify language files load', function(assert) {
 tape.test('verify language files structure', function(assert) {
     // check that language files have about the same structure as
     // the reference english language file
-    var english = languages.get('en');
+    var translations = languages.get(languages.supportedTags);
+    var english = translations.en;
 
-    tags.forEach((l) => {
+    Object.keys(translations).forEach((l) => {
         if (l === 'en') return; // do not need to compare to self
-        var translation = languages.get(l);
+        var translation = translations[l];
 
         assert.deepEqual(
             Object.keys(translation.v5),
-            Object.keys(english.v5),
+            Object.keys(translations.en.v5),
             l + ' has correct type keys'
         );
 
@@ -53,6 +43,15 @@ tape.test('verify language files structure', function(assert) {
             l + ' has correct rotary variance keys'
         );
     });
+
+    assert.end();
+});
+
+tape.test('verify that instructions are only returned for user requested languages', function(assert) {
+    var translations = languages.get(['en', 'fr']);
+
+    assert.deepEqual(Object.keys(translations).sort(), ['fr', 'en'].sort(),
+    'only returns en and fr');
 
     assert.end();
 });

--- a/test/languages_test.js
+++ b/test/languages_test.js
@@ -2,21 +2,10 @@ var tape = require('tape');
 
 var languages = require('../languages');
 
-tape.test('throws on invalid codes', function(assert) {
-    assert.throws(function() {
-        languages.get(['en', 'foo']);
-    },
-    /Unsupported language code: foo/,
-    'throws error when gets foo language code'
-    );
-
-    assert.end();
-});
-
 tape.test('verify language files structure', function(assert) {
     // check that language files have about the same structure as
     // the reference english language file
-    var translations = languages.get(languages.supportedCodes);
+    var translations = languages.instructions;
     var english = translations.en;
 
     Object.keys(translations).forEach((l) => {
@@ -43,18 +32,6 @@ tape.test('verify language files structure', function(assert) {
             l + ' has correct rotary variance keys'
         );
     });
-
-    assert.end();
-});
-
-tape.test('verify that instructions are only returned for user requested languages', function(assert) {
-    var translations = languages.get(['en', 'fr']);
-
-    assert.deepEqual(
-        Object.keys(translations).sort(),
-        ['fr', 'en'].sort(),
-        'only returns en and fr'
-    );
 
     assert.end();
 });


### PR DESCRIPTION
This PR introduces support for multiple language support. ~~Right now all language files are always loaded. With this PR, the developer can decide which language files to require. During test instruction compilation, the language used can be chosen. This allows us to scale this project to large numbers of languages, without bloating data downloaded in browsers for all users.~~

The module API as well as internal APIs have breaking changes, since we had to change several function signatures.

TODOs

- [x] Integrate PR within Mapbox (to see what breaks)
- [x] Integrate PR with [osrm-frontend](https://github.com/Project-OSRM/osrm-frontend/) (to see what breaks)
- [x] Code review
- [x] Update the changelog
- [x] Make sure that relevant docs are updated
- [ ] Merge
- [ ] Release as new version 0.3
- [ ] Update osrm-frontend to use 0.3

CC @freenerd 

edit: We will continue to load every language for now because browserify doesn't support dynamic requires. ([cf @freenerd's comment](ttps://github.com/Project-OSRM/osrm-text-instructions/pull/107#issuecomment-302864645))
