### PR TITLE
Add support for exits.

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,8 +150,12 @@ module.exports = function(version, _options) {
             // Decide which instruction string to use
             // Destination takes precedence over name
             var instruction;
-            if (step.destinations && instructionObject.destination) {
+            if (step.destinations && step.exits && instructionObject.exit_destination) {
+                instruction = instructionObject.exit_destination;
+            } else if (step.destinations && instructionObject.destination) {
                 instruction = instructionObject.destination;
+            } else if (step.exits && instructionObject.exit) {
+                instruction = instructionObject.exit;
             } else if (wayName && instructionObject.name) {
                 instruction = instructionObject.name;
             } else {
@@ -169,6 +173,7 @@ module.exports = function(version, _options) {
             instruction = instruction
                 .replace('{way_name}', wayName)
                 .replace('{destination}', (step.destinations || '').split(',')[0])
+                .replace('{exit}', (step.exits || '').split(',')[0])
                 .replace('{exit_number}', this.ordinalize(language, step.maneuver.exit || 1))
                 .replace('{rotary_name}', step.rotary_name)
                 .replace('{lane_instruction}', laneInstruction)

--- a/languages/translations/en.json
+++ b/languages/translations/en.json
@@ -254,7 +254,7 @@
                 "name": "Take the ramp on the right onto {way_name}",
                 "destination": "Take the ramp on the right towards {destination}",
                 "exit": "Take exit {exit}",
-                "exit_destination": "Take exit {exit} towards {destination}"
+                "exit_destination": "Take exit {exit} on the right towards {destination}"
             },
             "sharp left": {
                 "default": "Take the ramp on the left",
@@ -268,7 +268,7 @@
                 "name": "Take the ramp on the right onto {way_name}",
                 "destination": "Take the ramp on the right towards {destination}",
                 "exit": "Take exit {exit}",
-                "exit_destination": "Take exit {exit} towards {destination}"
+                "exit_destination": "Take exit {exit} on the right towards {destination}"
             },
             "slight left": {
                 "default": "Take the ramp on the left",
@@ -282,7 +282,7 @@
                 "name": "Take the ramp on the right onto {way_name}",
                 "destination": "Take the ramp on the right towards {destination}",
                 "exit": "Take exit {exit}",
-                "exit_destination": "Take exit {exit} towards {destination}"
+                "exit_destination": "Take exit {exit} on the right towards {destination}"
             }
         },
         "on ramp": {

--- a/languages/translations/en.json
+++ b/languages/translations/en.json
@@ -238,37 +238,51 @@
             "default": {
                 "default": "Take the ramp",
                 "name": "Take the ramp onto {way_name}",
-                "destination": "Take the ramp towards {destination}"
+                "destination": "Take the ramp towards {destination}",
+                "exit": "Take exit {exit}",
+                "exit_destination": "Take exit {exit} towards {destination}"
             },
             "left": {
                 "default": "Take the ramp on the left",
                 "name": "Take the ramp on the left onto {way_name}",
-                "destination": "Take the ramp on the left towards {destination}"
+                "destination": "Take the ramp on the left towards {destination}",
+                "exit": "Take exit {exit} on the left",
+                "exit_destination": "Take exit {exit} on the left towards {destination}"
             },
             "right": {
                 "default": "Take the ramp on the right",
                 "name": "Take the ramp on the right onto {way_name}",
-                "destination": "Take the ramp on the right towards {destination}"
+                "destination": "Take the ramp on the right towards {destination}",
+                "exit": "Take exit {exit}",
+                "exit_destination": "Take exit {exit} towards {destination}"
             },
             "sharp left": {
                 "default": "Take the ramp on the left",
                 "name": "Take the ramp on the left onto {way_name}",
-                "destination": "Take the ramp on the left towards {destination}"
+                "destination": "Take the ramp on the left towards {destination}",
+                "exit": "Take exit {exit} on the left",
+                "exit_destination": "Take exit {exit} on the left towards {destination}"
             },
             "sharp right": {
                 "default": "Take the ramp on the right",
                 "name": "Take the ramp on the right onto {way_name}",
-                "destination": "Take the ramp on the right towards {destination}"
+                "destination": "Take the ramp on the right towards {destination}",
+                "exit": "Take exit {exit}",
+                "exit_destination": "Take exit {exit} towards {destination}"
             },
             "slight left": {
                 "default": "Take the ramp on the left",
                 "name": "Take the ramp on the left onto {way_name}",
-                "destination": "Take the ramp on the left towards {destination}"
+                "destination": "Take the ramp on the left towards {destination}",
+                "exit": "Take exit {exit} on the left",
+                "exit_destination": "Take exit {exit} on the left towards {destination}"
             },
             "slight right": {
                 "default": "Take the ramp on the right",
                 "name": "Take the ramp on the right onto {way_name}",
-                "destination": "Take the ramp on the right towards {destination}"
+                "destination": "Take the ramp on the right towards {destination}",
+                "exit": "Take exit {exit}",
+                "exit_destination": "Take exit {exit} towards {destination}"
             }
         },
         "on ramp": {

--- a/test/fixtures/v5/continue/left_exit.json
+++ b/test/fixtures/v5/continue/left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Links weiterfahren auf Way Name",
+        "en": "Continue left onto Way Name",
+        "es": "Continua izquierda en Way Name",
+        "fr": "Continuer à gauche sur Way Name",
+        "id": "Terus kiri ke Way Name",
+        "nl": "Ga links naar Way Name",
+        "ru": "Двигайтесь налево по Way Name",
+        "sv": "Fortsätt vänster in på Way Name",
+        "vi": "Chạy tiếp bên trái trên Way Name",
+        "zh-Hans": "继续向左，上Way Name"
+    }
+}

--- a/test/fixtures/v5/continue/left_exit_destination.json
+++ b/test/fixtures/v5/continue/left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Links weiterfahren Richtung Destination 1",
+        "en": "Continue left towards Destination 1",
+        "es": "Continua izquierda hacia Destination 1",
+        "fr": "Continuer à gauche en direction de Destination 1",
+        "id": "Teruskan kiri menuju Destination 1",
+        "nl": "Ga links richting Destination 1",
+        "ru": "Двигайтесь налево в направлении Destination 1",
+        "sv": "Fortsätt vänster mot Destination 1",
+        "vi": "Chạy tiếp bên trái đến Destination 1",
+        "zh-Hans": "继续向左行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/continue/right_exit.json
+++ b/test/fixtures/v5/continue/right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rechts weiterfahren auf Way Name",
+        "en": "Continue right onto Way Name",
+        "es": "Continua derecha en Way Name",
+        "fr": "Continuer à droite sur Way Name",
+        "id": "Terus kanan ke Way Name",
+        "nl": "Ga rechts naar Way Name",
+        "ru": "Двигайтесь направо по Way Name",
+        "sv": "Fortsätt höger in på Way Name",
+        "vi": "Chạy tiếp bên phải trên Way Name",
+        "zh-Hans": "继续向右，上Way Name"
+    }
+}

--- a/test/fixtures/v5/continue/right_exit_destination.json
+++ b/test/fixtures/v5/continue/right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rechts weiterfahren Richtung Destination 1",
+        "en": "Continue right towards Destination 1",
+        "es": "Continua derecha hacia Destination 1",
+        "fr": "Continuer à droite en direction de Destination 1",
+        "id": "Teruskan kanan menuju Destination 1",
+        "nl": "Ga rechts richting Destination 1",
+        "ru": "Двигайтесь направо в направлении Destination 1",
+        "sv": "Fortsätt höger mot Destination 1",
+        "vi": "Chạy tiếp bên phải đến Destination 1",
+        "zh-Hans": "继续向右行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/continue/sharp_left_exit.json
+++ b/test/fixtures/v5/continue/sharp_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf links weiterfahren auf Way Name",
+        "en": "Continue sharp left onto Way Name",
+        "es": "Continua cerrada a la izquierda en Way Name",
+        "fr": "Continuer franchement à gauche sur Way Name",
+        "id": "Terus tajam kiri ke Way Name",
+        "nl": "Ga linksaf naar Way Name",
+        "ru": "Двигайтесь налево по Way Name",
+        "sv": "Fortsätt skarp vänster in på Way Name",
+        "vi": "Chạy tiếp bên trái gắt trên Way Name",
+        "zh-Hans": "继续向左，上Way Name"
+    }
+}

--- a/test/fixtures/v5/continue/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/continue/sharp_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf links weiterfahren Richtung Destination 1",
+        "en": "Continue sharp left towards Destination 1",
+        "es": "Continua cerrada a la izquierda hacia Destination 1",
+        "fr": "Continuer franchement à gauche en direction de Destination 1",
+        "id": "Teruskan tajam kiri menuju Destination 1",
+        "nl": "Ga linksaf richting Destination 1",
+        "ru": "Двигайтесь налево в направлении Destination 1",
+        "sv": "Fortsätt skarp vänster mot Destination 1",
+        "vi": "Chạy tiếp bên trái gắt đến Destination 1",
+        "zh-Hans": "继续向左行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/continue/sharp_right_exit.json
+++ b/test/fixtures/v5/continue/sharp_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts weiterfahren auf Way Name",
+        "en": "Continue sharp right onto Way Name",
+        "es": "Continua cerrada a la derecha en Way Name",
+        "fr": "Continuer franchement à droite sur Way Name",
+        "id": "Terus tajam kanan ke Way Name",
+        "nl": "Ga rechtsaf naar Way Name",
+        "ru": "Двигайтесь направо по Way Name",
+        "sv": "Fortsätt skarp höger in på Way Name",
+        "vi": "Chạy tiếp bên phải gắt trên Way Name",
+        "zh-Hans": "继续向右，上Way Name"
+    }
+}

--- a/test/fixtures/v5/continue/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/continue/sharp_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts weiterfahren Richtung Destination 1",
+        "en": "Continue sharp right towards Destination 1",
+        "es": "Continua cerrada a la derecha hacia Destination 1",
+        "fr": "Continuer franchement à droite en direction de Destination 1",
+        "id": "Teruskan tajam kanan menuju Destination 1",
+        "nl": "Ga rechtsaf richting Destination 1",
+        "ru": "Двигайтесь направо в направлении Destination 1",
+        "sv": "Fortsätt skarp höger mot Destination 1",
+        "vi": "Chạy tiếp bên phải gắt đến Destination 1",
+        "zh-Hans": "继续向右行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/continue/slight_left_exit.json
+++ b/test/fixtures/v5/continue/slight_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht links weiter auf Way Name",
+        "en": "Continue slightly left onto Way Name",
+        "es": "Continua ligeramente a la izquierda en Way Name",
+        "fr": "Continuer légèrement à gauche sur Way Name",
+        "id": "Tetap agak di kiri ke Way Name",
+        "nl": "Links aanhouden naar Way Name",
+        "ru": "Плавно поверните налево на Way Name",
+        "sv": "Fortsätt med lätt vänstersväng in på Way Name",
+        "vi": "Nghiêng về bên trái vào Way Name",
+        "zh-Hans": "继续向左，上Way Name"
+    }
+}

--- a/test/fixtures/v5/continue/slight_left_exit_destination.json
+++ b/test/fixtures/v5/continue/slight_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht links weiter Richtung Destination 1",
+        "en": "Continue slightly left towards Destination 1",
+        "es": "Continua ligeramente a la izquierda hacia Destination 1",
+        "fr": "Continuer légèrement à gauche en direction de Destination 1",
+        "id": "Tetap agak di kiri menuju Destination 1",
+        "nl": "Links aanhouden richting Destination 1",
+        "ru": "Плавно поверните налево в направлении Destination 1",
+        "sv": "Fortsätt med lätt vänstersväng mot Destination 1",
+        "vi": "Nghiêng về bên trái đến Destination 1",
+        "zh-Hans": "继续向左行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/continue/slight_right_exit.json
+++ b/test/fixtures/v5/continue/slight_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht rechts weiter auf Way Name",
+        "en": "Continue slightly right onto Way Name",
+        "es": "Continua ligeramente a la derecha en Way Name",
+        "fr": "Continuer légèrement à droite sur Way Name",
+        "id": "Tetap agak di kanan ke Way Name",
+        "nl": "Rechts aanhouden naar Way Name",
+        "ru": "Плавно поверните направо на Way Name",
+        "sv": "Fortsätt med lätt högersväng in på Way Name",
+        "vi": "Nghiêng về bên phải vào Way Name",
+        "zh-Hans": "继续向右，上Way Name"
+    }
+}

--- a/test/fixtures/v5/continue/slight_right_exit_destination.json
+++ b/test/fixtures/v5/continue/slight_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht rechts weiter Richtung Destination 1",
+        "en": "Continue slightly right towards Destination 1",
+        "es": "Continua ligeramente a la derecha hacia Destination 1",
+        "fr": "Continuer légèrement à droite en direction de Destination 1",
+        "id": "Tetap agak di kanan menuju Destination 1",
+        "nl": "Rechts aanhouden richting Destination 1",
+        "ru": "Плавно поверните направо в направлении Destination 1",
+        "sv": "Fortsätt med lätt högersväng mot Destination 1",
+        "vi": "Nghiêng về bên phải đến Destination 1",
+        "zh-Hans": "继续向右行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/continue/straight_exit.json
+++ b/test/fixtures/v5/continue/straight_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren auf Way Name",
+        "en": "Continue onto Way Name",
+        "es": "Continua en Way Name",
+        "fr": "Continuer tout droit sur Way Name",
+        "id": "Terus ke Way Name",
+        "nl": "Ga rechtdoor naar Way Name",
+        "ru": "Продолжите движение по Way Name",
+        "sv": "Fortsätt in på Way Name",
+        "vi": "Chạy tiếp trên Way Name",
+        "zh-Hans": "继续直行，上Way Name"
+    }
+}

--- a/test/fixtures/v5/continue/straight_exit_destination.json
+++ b/test/fixtures/v5/continue/straight_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren Richtung Destination 1",
+        "en": "Continue towards Destination 1",
+        "es": "Continua hacia Destination 1",
+        "fr": "Continuer tout droit en direction de Destination 1",
+        "id": "Terus menuju Destination 1",
+        "nl": "Ga rechtdoor richting Destination 1",
+        "ru": "Продолжите движение в направлении Destination 1",
+        "sv": "Fortsätt mot Destination 1",
+        "vi": "Chạy tiếp đến Destination 1",
+        "zh-Hans": "继续直行行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/continue/uturn_exit.json
+++ b/test/fixtures/v5/continue/uturn_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung auf Way Name",
+        "en": "Make a U-turn onto Way Name",
+        "es": "Haz un cambio de sentido en Way Name",
+        "fr": "Faire demi-tour sur Way Name",
+        "id": "Putar balik ke arah Way Name",
+        "nl": "Keer om naar Way Name",
+        "ru": "Развернитесь на Way Name",
+        "sv": "Gör en U-sväng in på Way Name",
+        "vi": "Quẹo ngược lại Way Name",
+        "zh-Hans": "调头上Way Name"
+    }
+}

--- a/test/fixtures/v5/continue/uturn_exit_destination.json
+++ b/test/fixtures/v5/continue/uturn_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung Richtung Destination 1",
+        "en": "Make a U-turn towards Destination 1",
+        "es": "Haz un cambio de sentido hacia Destination 1",
+        "fr": "Faire demi-tour en direction de Destination 1",
+        "id": "Putar balik menuju Destination 1",
+        "nl": "Keer om richting Destination 1",
+        "ru": "Развернитесь в направлении Destination 1",
+        "sv": "Gör en U-sväng mot Destination 1",
+        "vi": "Quẹo ngược đến Destination 1",
+        "zh-Hans": "调头后前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/depart/modifier_exit.json
+++ b/test/fixtures/v5/depart/modifier_exit.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "bearing_after": 0,
+            "type": "depart",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Fahren Sie Richtung Norden auf Way Name",
+        "en": "Head north on Way Name",
+        "es": "Ve a norte en Way Name",
+        "fr": "Rouler vers le nord sur Way Name",
+        "id": "Arah utara di Way Name",
+        "nl": "Neem Way Name in noordelijke richting",
+        "ru": "Двигайтесь в северном направлении по Way Name",
+        "sv": "Kör åt norr på Way Name",
+        "vi": "Đi về hướng bắc trên Way Name",
+        "zh-Hans": "出发向北，上Way Name"
+    }
+}

--- a/test/fixtures/v5/depart/modifier_exit_destination.json
+++ b/test/fixtures/v5/depart/modifier_exit_destination.json
@@ -1,0 +1,24 @@
+{
+    "step": {
+        "maneuver": {
+            "bearing_after": 0,
+            "type": "depart",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Fahren Sie Richtung Norden auf Way Name",
+        "en": "Head north on Way Name",
+        "es": "Ve a norte en Way Name",
+        "fr": "Rouler vers le nord sur Way Name",
+        "id": "Arah utara di Way Name",
+        "nl": "Neem Way Name in noordelijke richting",
+        "ru": "Двигайтесь в северном направлении по Way Name",
+        "sv": "Kör åt norr på Way Name",
+        "vi": "Đi về hướng bắc trên Way Name",
+        "zh-Hans": "出发向北，上Way Name"
+    }
+}

--- a/test/fixtures/v5/end_of_road/left_exit.json
+++ b/test/fixtures/v5/end_of_road/left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Links abbiegen auf Way Name",
+        "en": "Turn left onto Way Name",
+        "es": "Gire a izquierda en Way Name",
+        "fr": "Tourner à gauche sur Way Name",
+        "id": "Belok kiri ke Way Name",
+        "nl": "Ga links naar Way Name",
+        "ru": "Поверните налево на Way Name",
+        "sv": "Sväng vänster in på Way Name",
+        "vi": "Quẹo trái vào Way Name",
+        "zh-Hans": "向左行驶，上Way Name"
+    }
+}

--- a/test/fixtures/v5/end_of_road/left_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Links abbiegen Richtung Destination 1",
+        "en": "Turn left towards Destination 1",
+        "es": "Gire a izquierda hacia Destination 1",
+        "fr": "Tourner à gauche en direction de Destination 1",
+        "id": "Belok kiri menuju Destination 1",
+        "nl": "Ga links richting Destination 1",
+        "ru": "Поверните налево в направлении Destination 1",
+        "sv": "Sväng vänster mot Destination 1",
+        "vi": "Quẹo trái đến Destination 1",
+        "zh-Hans": "向左行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/end_of_road/right_exit.json
+++ b/test/fixtures/v5/end_of_road/right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rechts abbiegen auf Way Name",
+        "en": "Turn right onto Way Name",
+        "es": "Gire a derecha en Way Name",
+        "fr": "Tourner à droite sur Way Name",
+        "id": "Belok kanan ke Way Name",
+        "nl": "Ga rechts naar Way Name",
+        "ru": "Поверните направо на Way Name",
+        "sv": "Sväng höger in på Way Name",
+        "vi": "Quẹo phải vào Way Name",
+        "zh-Hans": "向右行驶，上Way Name"
+    }
+}

--- a/test/fixtures/v5/end_of_road/right_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rechts abbiegen Richtung Destination 1",
+        "en": "Turn right towards Destination 1",
+        "es": "Gire a derecha hacia Destination 1",
+        "fr": "Tourner à droite en direction de Destination 1",
+        "id": "Belok kanan menuju Destination 1",
+        "nl": "Ga rechts richting Destination 1",
+        "ru": "Поверните направо в направлении Destination 1",
+        "sv": "Sväng höger mot Destination 1",
+        "vi": "Quẹo phải đến Destination 1",
+        "zh-Hans": "向右行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/end_of_road/sharp_left_exit.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf links abbiegen auf Way Name",
+        "en": "Turn sharp left onto Way Name",
+        "es": "Gire a cerrada a la izquierda en Way Name",
+        "fr": "Tourner franchement à gauche sur Way Name",
+        "id": "Belok tajam kiri ke Way Name",
+        "nl": "Ga linksaf naar Way Name",
+        "ru": "Поверните налево на Way Name",
+        "sv": "Sväng skarp vänster in på Way Name",
+        "vi": "Quẹo trái gắt vào Way Name",
+        "zh-Hans": "向左行驶，上Way Name"
+    }
+}

--- a/test/fixtures/v5/end_of_road/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf links abbiegen Richtung Destination 1",
+        "en": "Turn sharp left towards Destination 1",
+        "es": "Gire a cerrada a la izquierda hacia Destination 1",
+        "fr": "Tourner franchement à gauche en direction de Destination 1",
+        "id": "Belok tajam kiri menuju Destination 1",
+        "nl": "Ga linksaf richting Destination 1",
+        "ru": "Поверните налево в направлении Destination 1",
+        "sv": "Sväng skarp vänster mot Destination 1",
+        "vi": "Quẹo trái gắt đến Destination 1",
+        "zh-Hans": "向左行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/end_of_road/sharp_right_exit.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts abbiegen auf Way Name",
+        "en": "Turn sharp right onto Way Name",
+        "es": "Gire a cerrada a la derecha en Way Name",
+        "fr": "Tourner franchement à droite sur Way Name",
+        "id": "Belok tajam kanan ke Way Name",
+        "nl": "Ga rechtsaf naar Way Name",
+        "ru": "Поверните направо на Way Name",
+        "sv": "Sväng skarp höger in på Way Name",
+        "vi": "Quẹo phải gắt vào Way Name",
+        "zh-Hans": "向右行驶，上Way Name"
+    }
+}

--- a/test/fixtures/v5/end_of_road/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts abbiegen Richtung Destination 1",
+        "en": "Turn sharp right towards Destination 1",
+        "es": "Gire a cerrada a la derecha hacia Destination 1",
+        "fr": "Tourner franchement à droite en direction de Destination 1",
+        "id": "Belok tajam kanan menuju Destination 1",
+        "nl": "Ga rechtsaf richting Destination 1",
+        "ru": "Поверните направо в направлении Destination 1",
+        "sv": "Sväng skarp höger mot Destination 1",
+        "vi": "Quẹo phải gắt đến Destination 1",
+        "zh-Hans": "向右行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/end_of_road/slight_left_exit.json
+++ b/test/fixtures/v5/end_of_road/slight_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht links abbiegen auf Way Name",
+        "en": "Turn slight left onto Way Name",
+        "es": "Gire a ligeramente a la izquierda en Way Name",
+        "fr": "Tourner légèrement à gauche sur Way Name",
+        "id": "Belok agak ke kiri ke Way Name",
+        "nl": "Ga links naar Way Name",
+        "ru": "Поверните левее на Way Name",
+        "sv": "Sväng lätt vänster in på Way Name",
+        "vi": "Quẹo trái nghiêng vào Way Name",
+        "zh-Hans": "向左行驶，上Way Name"
+    }
+}

--- a/test/fixtures/v5/end_of_road/slight_left_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/slight_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht links abbiegen Richtung Destination 1",
+        "en": "Turn slight left towards Destination 1",
+        "es": "Gire a ligeramente a la izquierda hacia Destination 1",
+        "fr": "Tourner légèrement à gauche en direction de Destination 1",
+        "id": "Belok agak ke kiri menuju Destination 1",
+        "nl": "Ga links richting Destination 1",
+        "ru": "Поверните левее в направлении Destination 1",
+        "sv": "Sväng lätt vänster mot Destination 1",
+        "vi": "Quẹo trái nghiêng đến Destination 1",
+        "zh-Hans": "向左行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/end_of_road/slight_right_exit.json
+++ b/test/fixtures/v5/end_of_road/slight_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht rechts abbiegen auf Way Name",
+        "en": "Turn slight right onto Way Name",
+        "es": "Gire a ligeramente a la derecha en Way Name",
+        "fr": "Tourner légèrement à droite sur Way Name",
+        "id": "Belok agak ke kanan ke Way Name",
+        "nl": "Ga rechts naar Way Name",
+        "ru": "Поверните правее на Way Name",
+        "sv": "Sväng lätt höger in på Way Name",
+        "vi": "Quẹo phải nghiêng vào Way Name",
+        "zh-Hans": "向右行驶，上Way Name"
+    }
+}

--- a/test/fixtures/v5/end_of_road/slight_right_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/slight_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht rechts abbiegen Richtung Destination 1",
+        "en": "Turn slight right towards Destination 1",
+        "es": "Gire a ligeramente a la derecha hacia Destination 1",
+        "fr": "Tourner légèrement à droite en direction de Destination 1",
+        "id": "Belok agak ke kanan menuju Destination 1",
+        "nl": "Ga rechts richting Destination 1",
+        "ru": "Поверните правее в направлении Destination 1",
+        "sv": "Sväng lätt höger mot Destination 1",
+        "vi": "Quẹo phải nghiêng đến Destination 1",
+        "zh-Hans": "向右行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/end_of_road/straight_exit.json
+++ b/test/fixtures/v5/end_of_road/straight_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren auf Way Name",
+        "en": "Continue straight onto Way Name",
+        "es": "Continua recto en Way Name",
+        "fr": "Continuer tout droit sur Way Name",
+        "id": "Tetap lurus ke Way Name ",
+        "nl": "Ga naar Way Name",
+        "ru": "Двигайтесь прямо по Way Name",
+        "sv": "Fortsätt rakt fram in på Way Name",
+        "vi": "Chạy tiếp trên Way Name",
+        "zh-Hans": "继续直行，上Way Name"
+    }
+}

--- a/test/fixtures/v5/end_of_road/straight_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/straight_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren Richtung Destination 1",
+        "en": "Continue straight towards Destination 1",
+        "es": "Continua recto hacia Destination 1",
+        "fr": "Continuer tout droit en direction de Destination 1",
+        "id": "Tetap lurus menuju Destination 1",
+        "nl": "Ga richting Destination 1",
+        "ru": "Двигайтесь прямо в направлении Destination 1",
+        "sv": "Fortsätt rakt fram mot Destination 1",
+        "vi": "Chạy tiếp đến Destination 1",
+        "zh-Hans": "继续直行，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/end_of_road/uturn_exit.json
+++ b/test/fixtures/v5/end_of_road/uturn_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung auf Way Name am Ende der Straße",
+        "en": "Make a U-turn onto Way Name at the end of the road",
+        "es": "Haz un cambio de sentido en Way Name al final de la via",
+        "fr": "Faire demi-tour à la fin de la route Way Name",
+        "id": "Putar balik di Way Name di akhir jalan",
+        "nl": "Keer om naar Way Name",
+        "ru": "Развернитесь в конце Way Name",
+        "sv": "Gör en U-sväng in på Way Name i slutet av vägen",
+        "vi": "Quẹo ngược vào Way Name tại cuối đường",
+        "zh-Hans": "在道路尽头调头上Way Name"
+    }
+}

--- a/test/fixtures/v5/end_of_road/uturn_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/uturn_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung Richtung Destination 1 am Ende der Straße",
+        "en": "Make a U-turn towards Destination 1 at the end of the road",
+        "es": "Haz un cambio de sentido hacia Destination 1 al final de la via",
+        "fr": "Faire demi-tour à la fin de la route en direction de Destination 1",
+        "id": "Putar balik menuju Destination 1 di akhir jalan",
+        "nl": "Keer om richting Destination 1",
+        "ru": "В конце дороги развернитесь в направлении Destination 1",
+        "sv": "Gör en U-sväng mot Destination 1 i slutet av vägen",
+        "vi": "Quẹo ngược đến Destination 1 tại cuối đường",
+        "zh-Hans": "在道路尽头调头，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/fork/left_exit.json
+++ b/test/fixtures/v5/fork/left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Links halten an der Gabelung auf Way Name",
+        "en": "Keep left at the fork onto Way Name",
+        "es": "Mantengase izquierda en el cruce en Way Name",
+        "fr": "Rester à gauche à l'embranchement sur Way Name",
+        "id": "Tetap kiri di pertigaan ke Way Name",
+        "nl": "Ga links op de splitsing naar Way Name",
+        "ru": "На развилке двигайтесь налево на Way Name",
+        "sv": "Håll till vänster in på Way Name",
+        "vi": "Đi bên trái ở ngã ba vào Way Name",
+        "zh-Hans": "在岔道保持向左，上Way Name"
+    }
+}

--- a/test/fixtures/v5/fork/left_exit_destination.json
+++ b/test/fixtures/v5/fork/left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Links halten an der Gabelung Richtung Destination 1",
+        "en": "Keep left at the fork towards Destination 1",
+        "es": "Mantengase izquierda en el cruce hacia Destination 1",
+        "fr": "Rester à gauche à l'embranchement en direction de Destination 1",
+        "id": "Tetap kiri di pertigaan menuju Destination 1",
+        "nl": "Ga links op de splitsing richting Destination 1",
+        "ru": "На развилке двигайтесь налево в направлении Destination 1",
+        "sv": "Håll till vänster mot Destination 1",
+        "vi": "Đi bên trái ở ngã ba đến Destination 1",
+        "zh-Hans": "在岔道保持向左，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/fork/right_exit.json
+++ b/test/fixtures/v5/fork/right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rechts halten an der Gabelung auf Way Name",
+        "en": "Keep right at the fork onto Way Name",
+        "es": "Mantengase derecha en el cruce en Way Name",
+        "fr": "Rester à droite à l'embranchement sur Way Name",
+        "id": "Tetap kanan di pertigaan ke Way Name",
+        "nl": "Ga rechts op de splitsing naar Way Name",
+        "ru": "На развилке двигайтесь направо на Way Name",
+        "sv": "Håll till höger in på Way Name",
+        "vi": "Đi bên phải ở ngã ba vào Way Name",
+        "zh-Hans": "在岔道保持向右，上Way Name"
+    }
+}

--- a/test/fixtures/v5/fork/right_exit_destination.json
+++ b/test/fixtures/v5/fork/right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rechts halten an der Gabelung Richtung Destination 1",
+        "en": "Keep right at the fork towards Destination 1",
+        "es": "Mantengase derecha en el cruce hacia Destination 1",
+        "fr": "Rester à droite à l'embranchement en direction de Destination 1",
+        "id": "Tetap kanan di pertigaan menuju Destination 1",
+        "nl": "Ga rechts op de splitsing richting Destination 1",
+        "ru": "На развилке двигайтесь направо в направлении Destination 1",
+        "sv": "Håll till höger mot Destination 1",
+        "vi": "Đi bên phải ở ngã ba đến Destination 1",
+        "zh-Hans": "在岔道保持向右，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/fork/sharp_left_exit.json
+++ b/test/fixtures/v5/fork/sharp_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf links abbiegen an der Gabelung auf Way Name",
+        "en": "Take a sharp left at the fork onto Way Name",
+        "es": "Gire a la izquierda en el cruce en Way Name",
+        "fr": "Prendre à gauche à l'embranchement sur Way Name",
+        "id": "Belok kiri pada pertigaan ke arah Way Name",
+        "nl": "Linksaf op de splitsing naar Way Name",
+        "ru": "На развилке резко поверните налево на Way Name",
+        "sv": "Gör en skarp vänstersväng in på Way Name",
+        "vi": "Quẹo gắt bên trái ở ngã ba vào Way Name",
+        "zh-Hans": "在岔道保持向左，上Way Name"
+    }
+}

--- a/test/fixtures/v5/fork/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/fork/sharp_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf links abbiegen an der Gabelung Richtung Destination 1",
+        "en": "Take a sharp left at the fork towards Destination 1",
+        "es": "Gire a la izquierda en el cruce hacia Destination 1",
+        "fr": "Prendre à gauche à l'embranchement en direction de Destination 1",
+        "id": "Belok kiri pada pertigaan menuju Destination 1",
+        "nl": "Linksaf op de splitsing richting Destination 1",
+        "ru": "На развилке резко поверните налево и продолжите движение в направлении Destination 1",
+        "sv": "Gör en skarp vänstersväng mot Destination 1",
+        "vi": "Quẹo gắt bên trái ở ngã ba đến Destination 1",
+        "zh-Hans": "在岔道保持向左，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/fork/sharp_right_exit.json
+++ b/test/fixtures/v5/fork/sharp_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts abbiegen an der Gabelung auf Way Name",
+        "en": "Take a sharp right at the fork onto Way Name",
+        "es": "Gire a la derecha en el cruce en Way Name",
+        "fr": "Prendre à droite à l'embranchement sur Way Name",
+        "id": "Belok kanan pada pertigaan ke arah Way Name",
+        "nl": "Rechtsaf op de splitsing naar Way Name",
+        "ru": "На развилке резко поверните направо на Way Name",
+        "sv": "Gör en skarp högersväng in på Way Name",
+        "vi": "Quẹo gắt bên phải ở ngã ba vào Way Name",
+        "zh-Hans": "在岔道保持向右，上Way Name"
+    }
+}

--- a/test/fixtures/v5/fork/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/fork/sharp_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts abbiegen an der Gabelung Richtung Destination 1",
+        "en": "Take a sharp right at the fork towards Destination 1",
+        "es": "Gire a la derecha en el cruce hacia Destination 1",
+        "fr": "Prendre à droite à l'embranchement en direction de Destination 1",
+        "id": "Belok kanan pada pertigaan menuju Destination 1",
+        "nl": "Rechtsaf op de splitsing richting Destination 1",
+        "ru": "На развилке резко поверните направо и продолжите движение в направлении Destination 1",
+        "sv": "Gör en skarp högersväng mot Destination 1",
+        "vi": "Quẹo gắt bên phải ở ngã ba đến Destination 1",
+        "zh-Hans": "在岔道保持向右，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/fork/slight_left_exit.json
+++ b/test/fixtures/v5/fork/slight_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Links halten an der Gabelung auf Way Name",
+        "en": "Keep left at the fork onto Way Name",
+        "es": "Mantengase a la izquierda en el cruce en Way Name",
+        "fr": "Rester à gauche à l'embranchement sur Way Name",
+        "id": "Tetap di kiri pada pertigaan ke arah Way Name",
+        "nl": "Links aanhouden op de splitsing naar Way Name",
+        "ru": "На развилке держитесь левее на Way Name",
+        "sv": "Håll till vänster in på Way Name",
+        "vi": "Nghiêng về bên trái ở ngã ba vào Way Name",
+        "zh-Hans": "在岔道保持向左，上Way Name"
+    }
+}

--- a/test/fixtures/v5/fork/slight_left_exit_destination.json
+++ b/test/fixtures/v5/fork/slight_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Links halten an der Gabelung Richtung Destination 1",
+        "en": "Keep left at the fork towards Destination 1",
+        "es": "Mantengase a la izquierda en el cruce hacia Destination 1",
+        "fr": "Rester à gauche à l'embranchement en direction de Destination 1",
+        "id": "Tetap di kiri pada pertigaan menuju Destination 1",
+        "nl": "Links aanhouden op de splitsing richting Destination 1",
+        "ru": "На развилке держитесь левее и продолжите движение в направлении Destination 1",
+        "sv": "Håll till vänster mot Destination 1",
+        "vi": "Nghiêng về bên trái ở ngã ba đến Destination 1",
+        "zh-Hans": "在岔道保持向左，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/fork/slight_right_exit.json
+++ b/test/fixtures/v5/fork/slight_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rechts halten an der Gabelung auf Way Name",
+        "en": "Keep right at the fork onto Way Name",
+        "es": "Mantengase a la derecha en el cruce en Way Name",
+        "fr": "Rester à droite à l'embranchement sur Way Name",
+        "id": "Tetap di kanan pada pertigaan ke arah Way Name",
+        "nl": "Rechts aanhouden op de splitsing naar Way Name",
+        "ru": "На развилке держитесь правее на Way Name",
+        "sv": "Håll till höger in på Way Name",
+        "vi": "Nghiêng về bên phải ở ngã ba vào Way Name",
+        "zh-Hans": "在岔道保持向右，上Way Name"
+    }
+}

--- a/test/fixtures/v5/fork/slight_right_exit_destination.json
+++ b/test/fixtures/v5/fork/slight_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rechts halten an der Gabelung Richtung Destination 1",
+        "en": "Keep right at the fork towards Destination 1",
+        "es": "Mantengase a la derecha en el cruce hacia Destination 1",
+        "fr": "Rester à droite à l'embranchement en direction de Destination 1",
+        "id": "Tetap di kanan pada pertigaan menuju Destination 1",
+        "nl": "Rechts aanhouden op de splitsing richting Destination 1",
+        "ru": "На развилке держитесь правее и продолжите движение в направлении Destination 1",
+        "sv": "Håll till höger mot Destination 1",
+        "vi": "Nghiêng về bên phải ở ngã ba đến Destination 1",
+        "zh-Hans": "在岔道保持向右，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/fork/straight_exit.json
+++ b/test/fixtures/v5/fork/straight_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Geradeaus halten an der Gabelung auf Way Name",
+        "en": "Keep straight at the fork onto Way Name",
+        "es": "Mantengase recto en el cruce en Way Name",
+        "fr": "Rester tout droit à l'embranchement sur Way Name",
+        "id": "Tetap lurus di pertigaan ke Way Name",
+        "nl": "Ga rechtdoor op de splitsing naar Way Name",
+        "ru": "На развилке двигайтесь прямо на Way Name",
+        "sv": "Håll till rakt fram in på Way Name",
+        "vi": "Đi bên thẳng ở ngã ba vào Way Name",
+        "zh-Hans": "在岔道保持直行，上Way Name"
+    }
+}

--- a/test/fixtures/v5/fork/straight_exit_destination.json
+++ b/test/fixtures/v5/fork/straight_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Geradeaus halten an der Gabelung Richtung Destination 1",
+        "en": "Keep straight at the fork towards Destination 1",
+        "es": "Mantengase recto en el cruce hacia Destination 1",
+        "fr": "Rester tout droit à l'embranchement en direction de Destination 1",
+        "id": "Tetap lurus di pertigaan menuju Destination 1",
+        "nl": "Ga rechtdoor op de splitsing richting Destination 1",
+        "ru": "На развилке двигайтесь прямо в направлении Destination 1",
+        "sv": "Håll till rakt fram mot Destination 1",
+        "vi": "Đi bên thẳng ở ngã ba đến Destination 1",
+        "zh-Hans": "在岔道保持直行，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/fork/uturn_exit.json
+++ b/test/fixtures/v5/fork/uturn_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung auf Way Name",
+        "en": "Make a U-turn onto Way Name",
+        "es": "Haz un cambio de sentido en Way Name",
+        "fr": "Faire demi-tour sur Way Name",
+        "id": "Putar balik ke arah Way Name",
+        "nl": "Keer om naar Way Name",
+        "ru": "На развилке развернитесь на Way Name",
+        "sv": "Gör en U-sväng in på Way Name",
+        "vi": "Quẹo ngược lại Way Name",
+        "zh-Hans": "调头，上Way Name"
+    }
+}

--- a/test/fixtures/v5/fork/uturn_exit_destination.json
+++ b/test/fixtures/v5/fork/uturn_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung Richtung Destination 1",
+        "en": "Make a U-turn towards Destination 1",
+        "es": "Haz un cambio de sentido hacia Destination 1",
+        "fr": "Faire demi-tour en direction de Destination 1",
+        "id": "Putar balik menuju Destination 1",
+        "nl": "Keer om richting Destination 1",
+        "ru": "На развилке развернитесь и продолжите движение в направлении Destination 1",
+        "sv": "Gör en U-sväng mot Destination 1",
+        "vi": "Quẹo ngược lại đến Destination 1",
+        "zh-Hans": "调头，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/merge/left_exit.json
+++ b/test/fixtures/v5/merge/left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Links auffahren auf Way Name",
+        "en": "Merge left onto Way Name",
+        "es": "Gire a izquierda en Way Name",
+        "fr": "Rejoindre à gauche sur Way Name",
+        "id": "Bergabung kiri ke arah Way Name",
+        "nl": "Bij de splitsing links naar Way Name",
+        "ru": "Перестройтесь налево на Way Name",
+        "sv": "Körfältsbyte åt vänster in på Way Name",
+        "vi": "Nhập sang trái vào Way Name",
+        "zh-Hans": "向左并道，上Way Name"
+    }
+}

--- a/test/fixtures/v5/merge/left_exit_destination.json
+++ b/test/fixtures/v5/merge/left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Links auffahren Richtung Destination 1",
+        "en": "Merge left towards Destination 1",
+        "es": "Gire a izquierda hacia Destination 1",
+        "fr": "Rejoindre à gauche en direction de Destination 1",
+        "id": "Bergabung kiri menuju Destination 1",
+        "nl": "Bij de splitsing links richting Destination 1",
+        "ru": "Перестройтесь налево в направлении Destination 1",
+        "sv": "Körfältsbyte åt vänster mot Destination 1",
+        "vi": "Nhập sang trái đến Destination 1",
+        "zh-Hans": "向左并道，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/merge/right_exit.json
+++ b/test/fixtures/v5/merge/right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rechts auffahren auf Way Name",
+        "en": "Merge right onto Way Name",
+        "es": "Gire a derecha en Way Name",
+        "fr": "Rejoindre à droite sur Way Name",
+        "id": "Bergabung kanan ke arah Way Name",
+        "nl": "Bij de splitsing rechts naar Way Name",
+        "ru": "Перестройтесь направо на Way Name",
+        "sv": "Körfältsbyte åt höger in på Way Name",
+        "vi": "Nhập sang phải vào Way Name",
+        "zh-Hans": "向右并道，上Way Name"
+    }
+}

--- a/test/fixtures/v5/merge/right_exit_destination.json
+++ b/test/fixtures/v5/merge/right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rechts auffahren Richtung Destination 1",
+        "en": "Merge right towards Destination 1",
+        "es": "Gire a derecha hacia Destination 1",
+        "fr": "Rejoindre à droite en direction de Destination 1",
+        "id": "Bergabung kanan menuju Destination 1",
+        "nl": "Bij de splitsing rechts richting Destination 1",
+        "ru": "Перестройтесь направо в направлении Destination 1",
+        "sv": "Körfältsbyte åt höger mot Destination 1",
+        "vi": "Nhập sang phải đến Destination 1",
+        "zh-Hans": "向右并道，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/merge/sharp_left_exit.json
+++ b/test/fixtures/v5/merge/sharp_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf links auffahren auf Way Name",
+        "en": "Merge left onto Way Name",
+        "es": "Gire a la izquierda en Way Name",
+        "fr": "Rejoindre Way Name par la gauche",
+        "id": "Bergabung di kiri ke arah Way Name",
+        "nl": "Bij de splitsing linksaf naar Way Name",
+        "ru": "Перестраивайтесь левее на Way Name",
+        "sv": "Körfältsbyte åt vänster in på Way Name",
+        "vi": "Nhập sang trái vào Way Name",
+        "zh-Hans": "向左并道，上Way Name"
+    }
+}

--- a/test/fixtures/v5/merge/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/merge/sharp_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf links auffahren Richtung Destination 1",
+        "en": "Merge left towards Destination 1",
+        "es": "Gire a la izquierda hacia Destination 1",
+        "fr": "Rejoindre par la gauche la route en direction de Destination 1",
+        "id": "Bergabung di kiri menuju Destination 1",
+        "nl": "Bij de splitsing linksaf richting Destination 1",
+        "ru": "Перестраивайтесь левее в направлении Destination 1",
+        "sv": "Körfältsbyte åt vänster mot Destination 1",
+        "vi": "Nhập sang trái đến Destination 1",
+        "zh-Hans": "向左并道，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/merge/sharp_right_exit.json
+++ b/test/fixtures/v5/merge/sharp_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts auffahren auf Way Name",
+        "en": "Merge right onto Way Name",
+        "es": "Gire a la derecha en Way Name",
+        "fr": "Rejoindre Way Name par la droite",
+        "id": "Bergabung di kanan ke arah Way Name",
+        "nl": "Bij de splitsing rechtsaf naar Way Name",
+        "ru": "Перестраивайтесь правее на Way Name",
+        "sv": "Körfältsbyte åt höger in på Way Name",
+        "vi": "Nhập sang phải vào Way Name",
+        "zh-Hans": "向右并道，上Way Name"
+    }
+}

--- a/test/fixtures/v5/merge/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/merge/sharp_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts auffahren Richtung Destination 1",
+        "en": "Merge right towards Destination 1",
+        "es": "Gire a la derecha hacia Destination 1",
+        "fr": "Rejoindre par la droite la route en direction de Destination 1",
+        "id": "Bergabung di kanan menuju Destination 1",
+        "nl": "Bij de splitsing rechtsaf richting Destination 1",
+        "ru": "Перестраивайтесь правее в направлении Destination 1",
+        "sv": "Körfältsbyte åt höger mot Destination 1",
+        "vi": "Nhập sang phải đến Destination 1",
+        "zh-Hans": "向右并道，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/merge/slight_left_exit.json
+++ b/test/fixtures/v5/merge/slight_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht links auffahren auf Way Name",
+        "en": "Merge left onto Way Name",
+        "es": "Gire a la izquierda en Way Name",
+        "fr": "Rejoindre Way Name légèrement par la gauche",
+        "id": "Bergabung di kiri ke arah Way Name",
+        "nl": "Bij de splitsing links aanhouden naar Way Name",
+        "ru": "Перестройтесь левее на Way Name",
+        "sv": "Körfältsbyte åt vänster in på Way Name",
+        "vi": "Nhập sang trái vào Way Name",
+        "zh-Hans": "向左并道，上Way Name"
+    }
+}

--- a/test/fixtures/v5/merge/slight_left_exit_destination.json
+++ b/test/fixtures/v5/merge/slight_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht links auffahren Richtung Destination 1",
+        "en": "Merge left towards Destination 1",
+        "es": "Gire a la izquierda hacia Destination 1",
+        "fr": "Rejoindre légèrement par la gauche la route en direction de Destination 1",
+        "id": "Bergabung di kiri menuju Destination 1",
+        "nl": "Bij de splitsing links aanhouden richting Destination 1",
+        "ru": "Перестройтесь левее в направлении Destination 1",
+        "sv": "Körfältsbyte åt vänster mot Destination 1",
+        "vi": "Nhập sang trái đến Destination 1",
+        "zh-Hans": "向左并道，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/merge/slight_right_exit.json
+++ b/test/fixtures/v5/merge/slight_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht rechts auffahren auf Way Name",
+        "en": "Merge right onto Way Name",
+        "es": "Gire a la derecha en Way Name",
+        "fr": "Rejoindre Way Name légèrement par la droite",
+        "id": "Bergabung di kanan ke arah Way Name",
+        "nl": "Bij de splitsing rechts aanhouden naar Way Name",
+        "ru": "Перестройтесь правее на Way Name",
+        "sv": "Körfältsbyte åt höger in på Way Name",
+        "vi": "Nhập sang phải vào Way Name",
+        "zh-Hans": "向右并道，上Way Name"
+    }
+}

--- a/test/fixtures/v5/merge/slight_right_exit_destination.json
+++ b/test/fixtures/v5/merge/slight_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht rechts auffahren Richtung Destination 1",
+        "en": "Merge right towards Destination 1",
+        "es": "Gire a la derecha hacia Destination 1",
+        "fr": "Rejoindre légèrement par la droite la route en direction de Destination 1",
+        "id": "Bergabung di kanan menuju Destination 1",
+        "nl": "Bij de splitsing rechts aanhouden richting Destination 1",
+        "ru": "Перестройтесь правее в направлении Destination 1",
+        "sv": "Körfältsbyte åt höger mot Destination 1",
+        "vi": "Nhập sang phải đến Destination 1",
+        "zh-Hans": "向右并道，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/merge/straight_exit.json
+++ b/test/fixtures/v5/merge/straight_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Geradeaus auffahren auf Way Name",
+        "en": "Merge straight onto Way Name",
+        "es": "Gire a recto en Way Name",
+        "fr": "Rejoindre tout droit sur Way Name",
+        "id": "Bergabung lurus ke arah Way Name",
+        "nl": "Bij de splitsing rechtdoor naar Way Name",
+        "ru": "Перестройтесь прямо на Way Name",
+        "sv": "Körfältsbyte åt rakt fram in på Way Name",
+        "vi": "Nhập sang thẳng vào Way Name",
+        "zh-Hans": "直行并道，上Way Name"
+    }
+}

--- a/test/fixtures/v5/merge/straight_exit_destination.json
+++ b/test/fixtures/v5/merge/straight_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Geradeaus auffahren Richtung Destination 1",
+        "en": "Merge straight towards Destination 1",
+        "es": "Gire a recto hacia Destination 1",
+        "fr": "Rejoindre tout droit en direction de Destination 1",
+        "id": "Bergabung lurus menuju Destination 1",
+        "nl": "Bij de splitsing rechtdoor richting Destination 1",
+        "ru": "Перестройтесь прямо в направлении Destination 1",
+        "sv": "Körfältsbyte åt rakt fram mot Destination 1",
+        "vi": "Nhập sang thẳng đến Destination 1",
+        "zh-Hans": "直行并道，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/merge/uturn_exit.json
+++ b/test/fixtures/v5/merge/uturn_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung auf Way Name",
+        "en": "Make a U-turn onto Way Name",
+        "es": "Haz un cambio de sentido en Way Name",
+        "fr": "Fair demi-tour sur Way Name",
+        "id": "Putar balik ke arah Way Name",
+        "nl": "Keer om naar Way Name",
+        "ru": "Развернитесь на Way Name",
+        "sv": "Gör en U-sväng in på Way Name",
+        "vi": "Quẹo ngược lại Way Name",
+        "zh-Hans": "调头，上Way Name"
+    }
+}

--- a/test/fixtures/v5/merge/uturn_exit_destination.json
+++ b/test/fixtures/v5/merge/uturn_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung Richtung Destination 1",
+        "en": "Make a U-turn towards Destination 1",
+        "es": "Haz un cambio de sentido hacia Destination 1",
+        "fr": "Fair demi-tour en direction de Destination 1",
+        "id": "Putar balik menuju Destination 1",
+        "nl": "Keer om richting Destination 1",
+        "ru": "Развернитесь в направлении Destination 1",
+        "sv": "Gör en U-sväng mot Destination 1",
+        "vi": "Quẹo ngược lại đến Destination 1",
+        "zh-Hans": "调头，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/modes/ferry_fork_left_exit.json
+++ b/test/fixtures/v5/modes/ferry_fork_left_exit.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "left"
+        },
+        "mode": "ferry",
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Fähre nehmen Way Name",
+        "en": "Take the ferry Way Name",
+        "es": "Coge el ferry Way Name",
+        "fr": "Prendre le ferry Way Name",
+        "id": "Naik ferry di Way Name",
+        "nl": "Neem het veer Way Name",
+        "ru": "Погрузитесь на паром Way Name",
+        "sv": "Ta färjan på Way Name",
+        "vi": "Lên phà Way Name",
+        "zh-Hans": "乘坐Way Name轮渡"
+    }
+}

--- a/test/fixtures/v5/modes/ferry_fork_left_exit_destination.json
+++ b/test/fixtures/v5/modes/ferry_fork_left_exit_destination.json
@@ -1,0 +1,24 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "left"
+        },
+        "mode": "ferry",
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Fähre nehmen Richtung Destination 1",
+        "en": "Take the ferry towards Destination 1",
+        "es": "Coge el ferry a Destination 1",
+        "fr": "Prendre le ferry en direction de Destination 1",
+        "id": "Naik ferry menuju Destination 1",
+        "nl": "Neem het veer naar Destination 1",
+        "ru": "Погрузитесь на паром в направлении Destination 1",
+        "sv": "Ta färjan mot Destination 1",
+        "vi": "Lên phà đi Destination 1",
+        "zh-Hans": "乘坐开往Destination 1的轮渡"
+    }
+}

--- a/test/fixtures/v5/modes/ferry_turn_left_exit.json
+++ b/test/fixtures/v5/modes/ferry_turn_left_exit.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "straight"
+        },
+        "mode": "ferry",
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Fähre nehmen Way Name",
+        "en": "Take the ferry Way Name",
+        "es": "Coge el ferry Way Name",
+        "fr": "Prendre le ferry Way Name",
+        "id": "Naik ferry di Way Name",
+        "nl": "Neem het veer Way Name",
+        "ru": "Погрузитесь на паром Way Name",
+        "sv": "Ta färjan på Way Name",
+        "vi": "Lên phà Way Name",
+        "zh-Hans": "乘坐Way Name轮渡"
+    }
+}

--- a/test/fixtures/v5/modes/ferry_turn_left_exit_destination.json
+++ b/test/fixtures/v5/modes/ferry_turn_left_exit_destination.json
@@ -1,0 +1,24 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "straight"
+        },
+        "mode": "ferry",
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Fähre nehmen Richtung Destination 1",
+        "en": "Take the ferry towards Destination 1",
+        "es": "Coge el ferry a Destination 1",
+        "fr": "Prendre le ferry en direction de Destination 1",
+        "id": "Naik ferry menuju Destination 1",
+        "nl": "Neem het veer naar Destination 1",
+        "ru": "Погрузитесь на паром в направлении Destination 1",
+        "sv": "Ta färjan mot Destination 1",
+        "vi": "Lên phà đi Destination 1",
+        "zh-Hans": "乘坐开往Destination 1的轮渡"
+    }
+}

--- a/test/fixtures/v5/new_name/left_exit.json
+++ b/test/fixtures/v5/new_name/left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Links weiterfahren auf Way Name",
+        "en": "Continue left onto Way Name",
+        "es": "Continua izquierda en Way Name",
+        "fr": "Continuer à gauche sur Way Name",
+        "id": "Lanjutkan kiri menuju Way Name",
+        "nl": "Ga links naar Way Name",
+        "ru": "Двигайтесь налево на Way Name",
+        "sv": "Fortsätt vänster på Way Name",
+        "vi": "Chạy tiếp bên trái trên Way Name",
+        "zh-Hans": "继续向左，上Way Name"
+    }
+}

--- a/test/fixtures/v5/new_name/left_exit_destination.json
+++ b/test/fixtures/v5/new_name/left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Links weiterfahren Richtung Destination 1",
+        "en": "Continue left towards Destination 1",
+        "es": "Continua izquierda hacia Destination 1",
+        "fr": "Continuer à gauche en direction de Destination 1",
+        "id": "Lanjutkan kiri menuju Destination 1",
+        "nl": "Ga links richting Destination 1",
+        "ru": "Двигайтесь налево в направлении Destination 1",
+        "sv": "Fortsätt vänster mot Destination 1",
+        "vi": "Chạy tiếp bên trái đến Destination 1",
+        "zh-Hans": "继续向左，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/new_name/right_exit.json
+++ b/test/fixtures/v5/new_name/right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rechts weiterfahren auf Way Name",
+        "en": "Continue right onto Way Name",
+        "es": "Continua derecha en Way Name",
+        "fr": "Continuer à droite sur Way Name",
+        "id": "Lanjutkan kanan menuju Way Name",
+        "nl": "Ga rechts naar Way Name",
+        "ru": "Двигайтесь направо на Way Name",
+        "sv": "Fortsätt höger på Way Name",
+        "vi": "Chạy tiếp bên phải trên Way Name",
+        "zh-Hans": "继续向右，上Way Name"
+    }
+}

--- a/test/fixtures/v5/new_name/right_exit_destination.json
+++ b/test/fixtures/v5/new_name/right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rechts weiterfahren Richtung Destination 1",
+        "en": "Continue right towards Destination 1",
+        "es": "Continua derecha hacia Destination 1",
+        "fr": "Continuer à droite en direction de Destination 1",
+        "id": "Lanjutkan kanan menuju Destination 1",
+        "nl": "Ga rechts richting Destination 1",
+        "ru": "Двигайтесь направо в направлении Destination 1",
+        "sv": "Fortsätt höger mot Destination 1",
+        "vi": "Chạy tiếp bên phải đến Destination 1",
+        "zh-Hans": "继续向右，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/new_name/sharp_left_exit.json
+++ b/test/fixtures/v5/new_name/sharp_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf links auf Way Name",
+        "en": "Take a sharp left onto Way Name",
+        "es": "Gire a la izquierda en Way Name",
+        "fr": "Prendre à gauche sur Way Name",
+        "id": "Belok kiri tajam ke arah Way Name",
+        "nl": "Linksaf naar Way Name",
+        "ru": "Резко поверните налево на Way Name",
+        "sv": "Gör en skarp vänstersväng in på Way Name",
+        "vi": "Quẹo gắt bên trái vào Way Name",
+        "zh-Hans": "继续向左，上Way Name"
+    }
+}

--- a/test/fixtures/v5/new_name/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/new_name/sharp_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf links Richtung Destination 1",
+        "en": "Take a sharp left towards Destination 1",
+        "es": "Gire a la izquierda hacia Destination 1",
+        "fr": "Prendre à gauche en direction de Destination 1",
+        "id": "Belok kiri tajam menuju Destination 1",
+        "nl": "Linksaf richting Destination 1",
+        "ru": "Резко поверните налево и продолжите движение в направлении Destination 1",
+        "sv": "Gör en skarp vänstersväng mot Destination 1",
+        "vi": "Quẹo gắt bên trái đến Destination 1",
+        "zh-Hans": "继续向左，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/new_name/sharp_right_exit.json
+++ b/test/fixtures/v5/new_name/sharp_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts auf Way Name",
+        "en": "Take a sharp right onto Way Name",
+        "es": "Gire a la derecha en Way Name",
+        "fr": "Prendre à droite sur Way Name",
+        "id": "Belok kanan tajam ke arah Way Name",
+        "nl": "Rechtsaf naar Way Name",
+        "ru": "Резко поверните направо на Way Name",
+        "sv": "Gör en skarp högersväng in på Way Name",
+        "vi": "Quẹo gắt bên phải vào Way Name",
+        "zh-Hans": "继续向右，上Way Name"
+    }
+}

--- a/test/fixtures/v5/new_name/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/new_name/sharp_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts Richtung Destination 1",
+        "en": "Take a sharp right towards Destination 1",
+        "es": "Gire a la derecha hacia Destination 1",
+        "fr": "Prendre à droite en direction de Destination 1",
+        "id": "Belok kanan tajam menuju Destination 1",
+        "nl": "Rechtsaf richting Destination 1",
+        "ru": "Резко поверните направо и продолжите движение в направлении Destination 1",
+        "sv": "Gör en skarp högersväng mot Destination 1",
+        "vi": "Quẹo gắt bên phải đến Destination 1",
+        "zh-Hans": "继续向右，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/new_name/slight_left_exit.json
+++ b/test/fixtures/v5/new_name/slight_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht links weiter auf Way Name",
+        "en": "Continue slightly left onto Way Name",
+        "es": "Continua ligeramente a la izquierda en Way Name",
+        "fr": "Continuer légèrement à gauche sur Way Name",
+        "id": "Lanjut dengan agak di kiri ke Way Name",
+        "nl": "Links aanhouden naar Way Name",
+        "ru": "Плавно поверните налево на Way Name",
+        "sv": "Fortsätt med lätt vänstersväng in på Way Name",
+        "vi": "Nghiêng về bên trái vào Way Name",
+        "zh-Hans": "继续向左，上Way Name"
+    }
+}

--- a/test/fixtures/v5/new_name/slight_left_exit_destination.json
+++ b/test/fixtures/v5/new_name/slight_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht links weiter Richtung Destination 1",
+        "en": "Continue slightly left towards Destination 1",
+        "es": "Continua ligeramente a la izquierda hacia Destination 1",
+        "fr": "Continuer légèrement à gauche en direction de Destination 1",
+        "id": "Tetap agak di kiri menuju Destination 1",
+        "nl": "Links aanhouden richting Destination 1",
+        "ru": "Плавно поверните налево в направлении Destination 1",
+        "sv": "Fortsätt med lätt vänstersväng mot Destination 1",
+        "vi": "Nghiêng về bên trái đến Destination 1",
+        "zh-Hans": "继续向左，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/new_name/slight_right_exit.json
+++ b/test/fixtures/v5/new_name/slight_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht rechts weiter auf Way Name",
+        "en": "Continue slightly right onto Way Name",
+        "es": "Continua ligeramente a la derecha en Way Name",
+        "fr": "Continuer légèrement à droite sur Way Name",
+        "id": "Tetap agak di kanan ke Way Name",
+        "nl": "Rechts aanhouden naar Way Name",
+        "ru": "Плавно поверните направо на Way Name",
+        "sv": "Fortsätt med lätt högersväng in på Way Name",
+        "vi": "Nghiêng về bên phải vào Way Name",
+        "zh-Hans": "继续向右，上Way Name"
+    }
+}

--- a/test/fixtures/v5/new_name/slight_right_exit_destination.json
+++ b/test/fixtures/v5/new_name/slight_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht rechts weiter Richtung Destination 1",
+        "en": "Continue slightly right towards Destination 1",
+        "es": "Continua ligeramente a la derecha hacia Destination 1",
+        "fr": "Continuer légèrement à droite en direction de Destination 1",
+        "id": "Tetap agak di kanan menuju Destination 1",
+        "nl": "Rechts aanhouden richting Destination 1",
+        "ru": "Плавно поверните направо в направлении Destination 1",
+        "sv": "Fortsätt med lätt högersväng mot Destination 1",
+        "vi": "Nghiêng về bên phải đến Destination 1",
+        "zh-Hans": "继续向右，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/new_name/straight_exit.json
+++ b/test/fixtures/v5/new_name/straight_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren auf Way Name",
+        "en": "Continue straight onto Way Name",
+        "es": "Continua recto en Way Name",
+        "fr": "Continuer tout droit sur Way Name",
+        "id": "Lanjutkan lurus menuju Way Name",
+        "nl": "Ga rechtdoor naar Way Name",
+        "ru": "Двигайтесь прямо на Way Name",
+        "sv": "Fortsätt rakt fram på Way Name",
+        "vi": "Chạy tiếp bên thẳng trên Way Name",
+        "zh-Hans": "继续直行，上Way Name"
+    }
+}

--- a/test/fixtures/v5/new_name/straight_exit_destination.json
+++ b/test/fixtures/v5/new_name/straight_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren Richtung Destination 1",
+        "en": "Continue straight towards Destination 1",
+        "es": "Continua recto hacia Destination 1",
+        "fr": "Continuer tout droit en direction de Destination 1",
+        "id": "Lanjutkan lurus menuju Destination 1",
+        "nl": "Ga rechtdoor richting Destination 1",
+        "ru": "Двигайтесь прямо в направлении Destination 1",
+        "sv": "Fortsätt rakt fram mot Destination 1",
+        "vi": "Chạy tiếp bên thẳng đến Destination 1",
+        "zh-Hans": "继续直行，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/new_name/uturn_exit.json
+++ b/test/fixtures/v5/new_name/uturn_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung auf Way Name",
+        "en": "Make a U-turn onto Way Name",
+        "es": "Haz un cambio de sentido en Way Name",
+        "fr": "Fair demi-tour sur Way Name",
+        "id": "Putar balik ke arah Way Name",
+        "nl": "Keer om naar Way Name",
+        "ru": "Развернитесь на Way Name",
+        "sv": "Gör en U-sväng in på Way Name",
+        "vi": "Quẹo ngược lại Way Name",
+        "zh-Hans": "调头，上Way Name"
+    }
+}

--- a/test/fixtures/v5/new_name/uturn_exit_destination.json
+++ b/test/fixtures/v5/new_name/uturn_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung Richtung Destination 1",
+        "en": "Make a U-turn towards Destination 1",
+        "es": "Haz un cambio de sentido hacia Destination 1",
+        "fr": "Fair demi-tour en direction de Destination 1",
+        "id": "Putar balik menuju Destination 1",
+        "nl": "Keer om richting Destination 1",
+        "ru": "Развернитесь и продолжите движение в направлении Destination 1",
+        "sv": "Gör en U-sväng mot Destination 1",
+        "vi": "Quẹo ngược lại đến Destination 1",
+        "zh-Hans": "调头，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/notification/left_exit.json
+++ b/test/fixtures/v5/notification/left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Links weiterfahren auf Way Name",
+        "en": "Continue left onto Way Name",
+        "es": "Continua izquierda en Way Name",
+        "fr": "Continuer à gauche sur Way Name",
+        "id": "Lanjutkan kiri menuju Way Name",
+        "nl": "Ga links naar Way Name",
+        "ru": "Двигайтесь налево по Way Name",
+        "sv": "Fortsätt vänster på Way Name",
+        "vi": "Chạy tiếp bên trái trên Way Name",
+        "zh-Hans": "继续向左，上Way Name"
+    }
+}

--- a/test/fixtures/v5/notification/left_exit_destination.json
+++ b/test/fixtures/v5/notification/left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Links weiterfahren Richtung Destination 1",
+        "en": "Continue left towards Destination 1",
+        "es": "Continua izquierda hacia Destination 1",
+        "fr": "Continuer à gauche en direction de Destination 1",
+        "id": "Lanjutkan kiri menuju Destination 1",
+        "nl": "Ga links richting Destination 1",
+        "ru": "Двигайтесь налево в направлении Destination 1",
+        "sv": "Fortsätt vänster mot Destination 1",
+        "vi": "Chạy tiếp bên trái đến Destination 1",
+        "zh-Hans": "继续向左，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/notification/right_exit.json
+++ b/test/fixtures/v5/notification/right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rechts weiterfahren auf Way Name",
+        "en": "Continue right onto Way Name",
+        "es": "Continua derecha en Way Name",
+        "fr": "Continuer à droite sur Way Name",
+        "id": "Lanjutkan kanan menuju Way Name",
+        "nl": "Ga rechts naar Way Name",
+        "ru": "Двигайтесь направо по Way Name",
+        "sv": "Fortsätt höger på Way Name",
+        "vi": "Chạy tiếp bên phải trên Way Name",
+        "zh-Hans": "继续向右，上Way Name"
+    }
+}

--- a/test/fixtures/v5/notification/right_exit_destination.json
+++ b/test/fixtures/v5/notification/right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rechts weiterfahren Richtung Destination 1",
+        "en": "Continue right towards Destination 1",
+        "es": "Continua derecha hacia Destination 1",
+        "fr": "Continuer à droite en direction de Destination 1",
+        "id": "Lanjutkan kanan menuju Destination 1",
+        "nl": "Ga rechts richting Destination 1",
+        "ru": "Двигайтесь направо в направлении Destination 1",
+        "sv": "Fortsätt höger mot Destination 1",
+        "vi": "Chạy tiếp bên phải đến Destination 1",
+        "zh-Hans": "继续向右，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/notification/sharp_left_exit.json
+++ b/test/fixtures/v5/notification/sharp_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf links weiterfahren auf Way Name",
+        "en": "Continue sharp left onto Way Name",
+        "es": "Continua cerrada a la izquierda en Way Name",
+        "fr": "Continuer franchement à gauche sur Way Name",
+        "id": "Lanjutkan tajam kiri menuju Way Name",
+        "nl": "Ga linksaf naar Way Name",
+        "ru": "Двигайтесь налево по Way Name",
+        "sv": "Fortsätt skarp vänster på Way Name",
+        "vi": "Chạy tiếp bên trái gắt trên Way Name",
+        "zh-Hans": "继续向左，上Way Name"
+    }
+}

--- a/test/fixtures/v5/notification/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/notification/sharp_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf links weiterfahren Richtung Destination 1",
+        "en": "Continue sharp left towards Destination 1",
+        "es": "Continua cerrada a la izquierda hacia Destination 1",
+        "fr": "Continuer franchement à gauche en direction de Destination 1",
+        "id": "Lanjutkan tajam kiri menuju Destination 1",
+        "nl": "Ga linksaf richting Destination 1",
+        "ru": "Двигайтесь налево в направлении Destination 1",
+        "sv": "Fortsätt skarp vänster mot Destination 1",
+        "vi": "Chạy tiếp bên trái gắt đến Destination 1",
+        "zh-Hans": "继续向左，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/notification/sharp_right_exit.json
+++ b/test/fixtures/v5/notification/sharp_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts weiterfahren auf Way Name",
+        "en": "Continue sharp right onto Way Name",
+        "es": "Continua cerrada a la derecha en Way Name",
+        "fr": "Continuer franchement à droite sur Way Name",
+        "id": "Lanjutkan tajam kanan menuju Way Name",
+        "nl": "Ga rechtsaf naar Way Name",
+        "ru": "Двигайтесь направо по Way Name",
+        "sv": "Fortsätt skarp höger på Way Name",
+        "vi": "Chạy tiếp bên phải gắt trên Way Name",
+        "zh-Hans": "继续向右，上Way Name"
+    }
+}

--- a/test/fixtures/v5/notification/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/notification/sharp_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts weiterfahren Richtung Destination 1",
+        "en": "Continue sharp right towards Destination 1",
+        "es": "Continua cerrada a la derecha hacia Destination 1",
+        "fr": "Continuer franchement à droite en direction de Destination 1",
+        "id": "Lanjutkan tajam kanan menuju Destination 1",
+        "nl": "Ga rechtsaf richting Destination 1",
+        "ru": "Двигайтесь направо в направлении Destination 1",
+        "sv": "Fortsätt skarp höger mot Destination 1",
+        "vi": "Chạy tiếp bên phải gắt đến Destination 1",
+        "zh-Hans": "继续向右，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/notification/slight_left_exit.json
+++ b/test/fixtures/v5/notification/slight_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht links weiterfahren auf Way Name",
+        "en": "Continue slight left onto Way Name",
+        "es": "Continua ligeramente a la izquierda en Way Name",
+        "fr": "Continuer légèrement à gauche sur Way Name",
+        "id": "Lanjutkan agak ke kiri menuju Way Name",
+        "nl": "Ga links naar Way Name",
+        "ru": "Двигайтесь левее по Way Name",
+        "sv": "Fortsätt lätt vänster på Way Name",
+        "vi": "Chạy tiếp bên trái nghiêng trên Way Name",
+        "zh-Hans": "继续向左，上Way Name"
+    }
+}

--- a/test/fixtures/v5/notification/slight_left_exit_destination.json
+++ b/test/fixtures/v5/notification/slight_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht links weiterfahren Richtung Destination 1",
+        "en": "Continue slight left towards Destination 1",
+        "es": "Continua ligeramente a la izquierda hacia Destination 1",
+        "fr": "Continuer légèrement à gauche en direction de Destination 1",
+        "id": "Lanjutkan agak ke kiri menuju Destination 1",
+        "nl": "Ga links richting Destination 1",
+        "ru": "Двигайтесь левее в направлении Destination 1",
+        "sv": "Fortsätt lätt vänster mot Destination 1",
+        "vi": "Chạy tiếp bên trái nghiêng đến Destination 1",
+        "zh-Hans": "继续向左，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/notification/slight_right_exit.json
+++ b/test/fixtures/v5/notification/slight_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht rechts weiterfahren auf Way Name",
+        "en": "Continue slight right onto Way Name",
+        "es": "Continua ligeramente a la derecha en Way Name",
+        "fr": "Continuer légèrement à droite sur Way Name",
+        "id": "Lanjutkan agak ke kanan menuju Way Name",
+        "nl": "Ga rechts naar Way Name",
+        "ru": "Двигайтесь правее по Way Name",
+        "sv": "Fortsätt lätt höger på Way Name",
+        "vi": "Chạy tiếp bên phải nghiêng trên Way Name",
+        "zh-Hans": "继续向右，上Way Name"
+    }
+}

--- a/test/fixtures/v5/notification/slight_right_exit_destination.json
+++ b/test/fixtures/v5/notification/slight_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht rechts weiterfahren Richtung Destination 1",
+        "en": "Continue slight right towards Destination 1",
+        "es": "Continua ligeramente a la derecha hacia Destination 1",
+        "fr": "Continuer légèrement à droite en direction de Destination 1",
+        "id": "Lanjutkan agak ke kanan menuju Destination 1",
+        "nl": "Ga rechts richting Destination 1",
+        "ru": "Двигайтесь правее в направлении Destination 1",
+        "sv": "Fortsätt lätt höger mot Destination 1",
+        "vi": "Chạy tiếp bên phải nghiêng đến Destination 1",
+        "zh-Hans": "继续向右，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/notification/straight_exit.json
+++ b/test/fixtures/v5/notification/straight_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren auf Way Name",
+        "en": "Continue straight onto Way Name",
+        "es": "Continua recto en Way Name",
+        "fr": "Continuer tout droit sur Way Name",
+        "id": "Lanjutkan lurus menuju Way Name",
+        "nl": "Ga rechtdoor naar Way Name",
+        "ru": "Двигайтесь прямо по Way Name",
+        "sv": "Fortsätt rakt fram på Way Name",
+        "vi": "Chạy tiếp bên thẳng trên Way Name",
+        "zh-Hans": "继续直行，上Way Name"
+    }
+}

--- a/test/fixtures/v5/notification/straight_exit_destination.json
+++ b/test/fixtures/v5/notification/straight_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren Richtung Destination 1",
+        "en": "Continue straight towards Destination 1",
+        "es": "Continua recto hacia Destination 1",
+        "fr": "Continuer tout droit en direction de Destination 1",
+        "id": "Lanjutkan lurus menuju Destination 1",
+        "nl": "Ga rechtdoor richting Destination 1",
+        "ru": "Двигайтесь прямо в направлении Destination 1",
+        "sv": "Fortsätt rakt fram mot Destination 1",
+        "vi": "Chạy tiếp bên thẳng đến Destination 1",
+        "zh-Hans": "继续直行，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/notification/uturn_exit.json
+++ b/test/fixtures/v5/notification/uturn_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung auf Way Name",
+        "en": "Make a U-turn onto Way Name",
+        "es": "Haz un cambio de sentido en Way Name",
+        "fr": "Fair demi-tour sur Way Name",
+        "id": "Putar balik ke arah Way Name",
+        "nl": "Keer om naar Way Name",
+        "ru": "Развернитесь на Way Name",
+        "sv": "Gör en U-sväng in på Way Name",
+        "vi": "Quẹo ngược lại Way Name",
+        "zh-Hans": "调头，上Way Name"
+    }
+}

--- a/test/fixtures/v5/notification/uturn_exit_destination.json
+++ b/test/fixtures/v5/notification/uturn_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung Richtung Destination 1",
+        "en": "Make a U-turn towards Destination 1",
+        "es": "Haz un cambio de sentido hacia Destination 1",
+        "fr": "Fair demi-tour en direction de Destination 1",
+        "id": "Putar balik menuju Destination 1",
+        "nl": "Keer om richting Destination 1",
+        "ru": "Развернитесь и продолжите движение в направлении Destination 1",
+        "sv": "Gör en U-sväng mot Destination 1",
+        "vi": "Quẹo ngược lại đến Destination 1",
+        "zh-Hans": "调头，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/off_ramp/left_exit.json
+++ b/test/fixtures/v5/off_ramp/left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der linken Seite nehmen auf Way Name",
+        "en": "Take exit 4A on the left",
+        "es": "Ve cuesta abajo en la izquierda en Way Name",
+        "fr": "Prendre la sortie à gauche sur Way Name",
+        "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
+        "nl": "Neem de afrit links naar Way Name",
+        "ru": "Сверните на левый съезд на Way Name",
+        "sv": "Ta avfartsrampen till vänster in på Way Name",
+        "vi": "Đi đường nhánh Way Name bên trái",
+        "zh-Hans": "通过左边的匝道驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/off_ramp/left_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der linken Seite nehmen Richtung Destination 1",
+        "en": "Take exit 4A on the left towards Destination 1",
+        "es": "Ve cuesta abajo en la izquierda hacia Destination 1",
+        "fr": "Prendre la sortie à gauche en direction de Destination 1",
+        "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
+        "nl": "Neem de afrit links richting Destination 1",
+        "ru": "Сверните на правый съезд в направлении Destination 1",
+        "sv": "Ta avfartsrampen till vänster mot Destination 1",
+        "vi": "Đi đường nhánh bên trái đến Destination 1",
+        "zh-Hans": "通过左边的匝道前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/off_ramp/right_exit.json
+++ b/test/fixtures/v5/off_ramp/right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der rechten Seite nehmen auf Way Name",
+        "en": "Take exit 4A",
+        "es": "Ve cuesta abajo en la derecha en Way Name",
+        "fr": "Prendre la sortie à droite sur Way Name",
+        "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
+        "nl": "Neem de afrit rechts naar Way Name",
+        "ru": "Сверните на правый съезд на Way Name",
+        "sv": "Ta avfartsrampen till höger in på Way Name",
+        "vi": "Đi đường nhánh Way Name bên phải",
+        "zh-Hans": "通过右边的匝道驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/off_ramp/right_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der rechten Seite nehmen Richtung Destination 1",
+        "en": "Take exit 4A towards Destination 1",
+        "es": "Ve cuesta abajo en la derecha hacia Destination 1",
+        "fr": "Prendre la sortie à droite en direction de Destination 1",
+        "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
+        "nl": "Neem de afrit rechts richting Destination 1",
+        "ru": "Сверните на правый съезд в направлении Destination 1",
+        "sv": "Ta avfartsrampen till höger mot Destination 1",
+        "vi": "Đi đường nhánh bên phải đến Destination 1",
+        "zh-Hans": "通过右边的匝道前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/off_ramp/right_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/right_exit_destination.json
@@ -10,7 +10,7 @@
     },
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen Richtung Destination 1",
-        "en": "Take exit 4A towards Destination 1",
+        "en": "Take exit 4A on the right towards Destination 1",
         "es": "Ve cuesta abajo en la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",

--- a/test/fixtures/v5/off_ramp/sharp_left_exit.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der linken Seite nehmen auf Way Name",
+        "en": "Take exit 4A on the left",
+        "es": "Ve cuesta abajo en la izquierda en Way Name",
+        "fr": "Prendre la sortie à gauche sur Way Name",
+        "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
+        "nl": "Neem de afrit links naar Way Name",
+        "ru": "Поверните на левый съезд на Way Name",
+        "sv": "Ta avfartsrampen till vänster in på Way Name",
+        "vi": "Đi đường nhánh Way Name bên trái",
+        "zh-Hans": "通过匝道驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/off_ramp/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der linken Seite nehmen Richtung Destination 1",
+        "en": "Take exit 4A on the left towards Destination 1",
+        "es": "Ve cuesta abajo en la izquierda hacia Destination 1",
+        "fr": "Prendre la sortie à gauche en direction de Destination 1",
+        "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
+        "nl": "Neem de afrit links richting Destination 1",
+        "ru": "Поверните на левый съезд в направлении Destination 1",
+        "sv": "Ta avfartsrampen till vänster mot Destination 1",
+        "vi": "Đi đường nhánh bên trái đến Destination 1",
+        "zh-Hans": "通过匝道前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/off_ramp/sharp_right_exit.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der rechten Seite nehmen auf Way Name",
+        "en": "Take exit 4A",
+        "es": "Ve cuesta abajo en la derecha en Way Name",
+        "fr": "Prendre la sortie à droite sur Way Name",
+        "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
+        "nl": "Neem de afrit rechts naar Way Name",
+        "ru": "Поверните на правый съезд на Way Name",
+        "sv": "Ta avfartsrampen till höger in på Way Name",
+        "vi": "Đi đường nhánh Way Name bên phải",
+        "zh-Hans": "通过匝道驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/off_ramp/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_exit_destination.json
@@ -10,7 +10,7 @@
     },
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen Richtung Destination 1",
-        "en": "Take exit 4A towards Destination 1",
+        "en": "Take exit 4A on the right towards Destination 1",
         "es": "Ve cuesta abajo en la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",

--- a/test/fixtures/v5/off_ramp/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der rechten Seite nehmen Richtung Destination 1",
+        "en": "Take exit 4A towards Destination 1",
+        "es": "Ve cuesta abajo en la derecha hacia Destination 1",
+        "fr": "Prendre la sortie à droite en direction de Destination 1",
+        "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
+        "nl": "Neem de afrit rechts richting Destination 1",
+        "ru": "Поверните на правый съезд в направлении Destination 1",
+        "sv": "Ta avfartsrampen till höger mot Destination 1",
+        "vi": "Đi đường nhánh bên phải đến Destination 1",
+        "zh-Hans": "通过匝道前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/off_ramp/slight_left_exit.json
+++ b/test/fixtures/v5/off_ramp/slight_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der linken Seite nehmen auf Way Name",
+        "en": "Take exit 4A on the left",
+        "es": "Ve cuesta abajo en la izquierda en Way Name",
+        "fr": "Prendre la sortie à gauche sur Way Name",
+        "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
+        "nl": "Neem de afrit links naar Way Name",
+        "ru": "Плавно сверните на левый съезд на Way Name",
+        "sv": "Ta avfartsrampen till vänster in på Way Name",
+        "vi": "Đi đường nhánh Way Name bên trái",
+        "zh-Hans": "通过匝道驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/off_ramp/slight_left_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/slight_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der linken Seite nehmen Richtung Destination 1",
+        "en": "Take exit 4A on the left towards Destination 1",
+        "es": "Ve cuesta abajo en la izquierda hacia Destination 1",
+        "fr": "Prendre la sortie à gauche en direction de Destination 1",
+        "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
+        "nl": "Neem de afrit links richting Destination 1",
+        "ru": "Плавно сверните на левый съезд в направлении Destination 1",
+        "sv": "Ta avfartsrampen till vänster mot Destination 1",
+        "vi": "Đi đường nhánh bên trái đến Destination 1",
+        "zh-Hans": "通过匝道前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/off_ramp/slight_right_exit.json
+++ b/test/fixtures/v5/off_ramp/slight_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der rechten Seite nehmen auf Way Name",
+        "en": "Take exit 4A",
+        "es": "Ve cuesta abajo en la derecha en Way Name",
+        "fr": "Prendre la sortie à droite sur Way Name",
+        "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
+        "nl": "Neem de afrit rechts naar Way Name",
+        "ru": "Плавно сверните на правый съезд на Way Name",
+        "sv": "Ta avfartsrampen till höger in på Way Name",
+        "vi": "Đi đường nhánh Way Name bên phải",
+        "zh-Hans": "通过匝道驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/off_ramp/slight_right_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/slight_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der rechten Seite nehmen Richtung Destination 1",
+        "en": "Take exit 4A towards Destination 1",
+        "es": "Ve cuesta abajo en la derecha hacia Destination 1",
+        "fr": "Prendre la sortie à droite en direction de Destination 1",
+        "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
+        "nl": "Neem de afrit rechts richting Destination 1",
+        "ru": "Плавно сверните на правый съезд в направлении Destination 1",
+        "sv": "Ta avfartsrampen till höger mot Destination 1",
+        "vi": "Đi đường nhánh bên phải đến Destination 1",
+        "zh-Hans": "通过匝道前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/off_ramp/slight_right_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/slight_right_exit_destination.json
@@ -10,7 +10,7 @@
     },
     "instructions": {
         "de": "Rampe auf der rechten Seite nehmen Richtung Destination 1",
-        "en": "Take exit 4A towards Destination 1",
+        "en": "Take exit 4A on the right towards Destination 1",
         "es": "Ve cuesta abajo en la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",

--- a/test/fixtures/v5/off_ramp/straight_exit.json
+++ b/test/fixtures/v5/off_ramp/straight_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe nehmen auf Way Name",
+        "en": "Take exit 4A",
+        "es": "Ve cuesta abajo en Way Name",
+        "fr": "Prendre la sortie sur Way Name",
+        "id": "Ambil jalan melandai ke Way Name",
+        "nl": "Neem de afrit naar Way Name",
+        "ru": "Сверните на съезд на Way Name",
+        "sv": "Ta avfartsrampen in på Way Name",
+        "vi": "Đi đường nhánh Way Name",
+        "zh-Hans": "通过匝道驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/off_ramp/straight_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/straight_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe nehmen Richtung Destination 1",
+        "en": "Take exit 4A towards Destination 1",
+        "es": "Ve cuesta abajo hacia Destination 1",
+        "fr": "Prendre la sortie en direction de Destination 1",
+        "id": "Ambil jalan melandai menuju Destination 1",
+        "nl": "Neem de afrit richting Destination 1",
+        "ru": "Сверните на съезд в направлении Destination 1",
+        "sv": "Ta avfartsrampen mot Destination 1",
+        "vi": "Đi đường nhánh đến Destination 1",
+        "zh-Hans": "通过匝道前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/off_ramp/uturn_exit.json
+++ b/test/fixtures/v5/off_ramp/uturn_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe nehmen auf Way Name",
+        "en": "Take exit 4A",
+        "es": "Ve cuesta abajo en Way Name",
+        "fr": "Prendre la sortie sur Way Name",
+        "id": "Ambil jalan melandai ke Way Name",
+        "nl": "Neem de afrit naar Way Name",
+        "ru": "Сверните на съезд на Way Name",
+        "sv": "Ta avfartsrampen in på Way Name",
+        "vi": "Đi đường nhánh Way Name",
+        "zh-Hans": "通过匝道驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/off_ramp/uturn_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/uturn_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe nehmen Richtung Destination 1",
+        "en": "Take exit 4A towards Destination 1",
+        "es": "Ve cuesta abajo hacia Destination 1",
+        "fr": "Prendre la sortie en direction de Destination 1",
+        "id": "Ambil jalan melandai menuju Destination 1",
+        "nl": "Neem de afrit richting Destination 1",
+        "ru": "Сверните на съезд в направлении Destination 1",
+        "sv": "Ta avfartsrampen mot Destination 1",
+        "vi": "Đi đường nhánh đến Destination 1",
+        "zh-Hans": "通过匝道前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/on_ramp/left_exit.json
+++ b/test/fixtures/v5/on_ramp/left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der linken Seite nehmen auf Way Name",
+        "en": "Take the ramp on the left onto Way Name",
+        "es": "Ve cuesta abajo en la izquierda en Way Name",
+        "fr": "Prendre la sortie à gauche sur Way Name",
+        "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
+        "nl": "Neem de oprit links naar Way Name",
+        "ru": "Сверните на левый въезд на Way Name",
+        "sv": "Ta påfartsrampen till vänster in på Way Name",
+        "vi": "Đi đường nhánh Way Name bên trái",
+        "zh-Hans": "通过左边的匝道驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/on_ramp/left_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der linken Seite nehmen Richtung Destination 1",
+        "en": "Take the ramp on the left towards Destination 1",
+        "es": "Ve cuesta abajo en la izquierda hacia Destination 1",
+        "fr": "Prendre la sortie à gauche en direction de Destination 1",
+        "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
+        "nl": "Neem de oprit links richting Destination 1",
+        "ru": "Сверните на левый въезд на автомагистраль в направлении Destination 1",
+        "sv": "Ta påfartsrampen till vänster mot Destination 1",
+        "vi": "Đi đường nhánh bên trái đến Destination 1",
+        "zh-Hans": "通过左边的匝道前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/on_ramp/right_exit.json
+++ b/test/fixtures/v5/on_ramp/right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der rechten Seite nehmen auf Way Name",
+        "en": "Take the ramp on the right onto Way Name",
+        "es": "Ve cuesta abajo en la derecha en Way Name",
+        "fr": "Prendre la sortie à droite sur Way Name",
+        "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
+        "nl": "Neem de oprit rechts naar Way Name",
+        "ru": "Сверните на правый въезд на Way Name",
+        "sv": "Ta påfartsrampen till höger in på Way Name",
+        "vi": "Đi đường nhánh Way Name bên phải",
+        "zh-Hans": "通过右边的匝道驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/on_ramp/right_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der rechten Seite nehmen Richtung Destination 1",
+        "en": "Take the ramp on the right towards Destination 1",
+        "es": "Ve cuesta abajo en la derecha hacia Destination 1",
+        "fr": "Prendre la sortie à droite en direction de Destination 1",
+        "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
+        "nl": "Neem de oprit rechts richting Destination 1",
+        "ru": "Сверните на правый въезд на автомагистраль в направлении Destination 1",
+        "sv": "Ta påfartsrampen till höger mot Destination 1",
+        "vi": "Đi đường nhánh bên phải đến Destination 1",
+        "zh-Hans": "通过右边的匝道前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/on_ramp/sharp_left_exit.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der linken Seite nehmen auf Way Name",
+        "en": "Take the ramp on the left onto Way Name",
+        "es": "Ve cuesta abajo en la izquierda en Way Name",
+        "fr": "Prendre la sortie à gauche sur Way Name",
+        "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
+        "nl": "Neem de oprit links naar Way Name",
+        "ru": "Поверните на левый въезд на Way Name",
+        "sv": "Ta påfartsrampen till vänster in på Way Name",
+        "vi": "Đi đường nhánh Way Name bên trái",
+        "zh-Hans": "通过匝道驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/on_ramp/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der linken Seite nehmen Richtung Destination 1",
+        "en": "Take the ramp on the left towards Destination 1",
+        "es": "Ve cuesta abajo en la izquierda hacia Destination 1",
+        "fr": "Prendre la sortie à gauche en direction de Destination 1",
+        "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
+        "nl": "Neem de oprit links richting Destination 1",
+        "ru": "Поверните на левый въезд на автомагистраль в направлении Destination 1",
+        "sv": "Ta påfartsrampen till vänster mot Destination 1",
+        "vi": "Đi đường nhánh bên trái đến Destination 1",
+        "zh-Hans": "通过匝道前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/on_ramp/sharp_right_exit.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der rechten Seite nehmen auf Way Name",
+        "en": "Take the ramp on the right onto Way Name",
+        "es": "Ve cuesta abajo en la derecha en Way Name",
+        "fr": "Prendre la sortie à droite sur Way Name",
+        "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
+        "nl": "Neem de oprit rechts naar Way Name",
+        "ru": "Поверните на правый въезд на Way Name",
+        "sv": "Ta påfartsrampen till höger in på Way Name",
+        "vi": "Đi đường nhánh Way Name bên phải",
+        "zh-Hans": "通过匝道驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/on_ramp/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der rechten Seite nehmen Richtung Destination 1",
+        "en": "Take the ramp on the right towards Destination 1",
+        "es": "Ve cuesta abajo en la derecha hacia Destination 1",
+        "fr": "Prendre la sortie à droite en direction de Destination 1",
+        "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
+        "nl": "Neem de oprit rechts richting Destination 1",
+        "ru": "Поверните на правый въезд на автомагистраль в направлении Destination 1",
+        "sv": "Ta påfartsrampen till höger mot Destination 1",
+        "vi": "Đi đường nhánh bên phải đến Destination 1",
+        "zh-Hans": "通过匝道前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/on_ramp/slight_left_exit.json
+++ b/test/fixtures/v5/on_ramp/slight_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der linken Seite nehmen auf Way Name",
+        "en": "Take the ramp on the left onto Way Name",
+        "es": "Ve cuesta abajo en la izquierda en Way Name",
+        "fr": "Prendre la sortie à gauche sur Way Name",
+        "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
+        "nl": "Neem de oprit links naar Way Name",
+        "ru": "Перестройтесь левее на Way Name",
+        "sv": "Ta påfartsrampen till vänster in på Way Name",
+        "vi": "Đi đường nhánh Way Name bên trái",
+        "zh-Hans": "通过匝道驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/on_ramp/slight_left_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/slight_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der linken Seite nehmen Richtung Destination 1",
+        "en": "Take the ramp on the left towards Destination 1",
+        "es": "Ve cuesta abajo en la izquierda hacia Destination 1",
+        "fr": "Prendre la sortie à gauche en direction de Destination 1",
+        "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
+        "nl": "Neem de oprit links richting Destination 1",
+        "ru": "Перестройтесь левее на автомагистраль в направлении Destination 1",
+        "sv": "Ta påfartsrampen till vänster mot Destination 1",
+        "vi": "Đi đường nhánh bên trái đến Destination 1",
+        "zh-Hans": "通过匝道前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/on_ramp/slight_right_exit.json
+++ b/test/fixtures/v5/on_ramp/slight_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der rechten Seite nehmen auf Way Name",
+        "en": "Take the ramp on the right onto Way Name",
+        "es": "Ve cuesta abajo en la derecha en Way Name",
+        "fr": "Prendre la sortie à droite sur Way Name",
+        "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
+        "nl": "Neem de oprit rechts naar Way Name",
+        "ru": "Перестройтесь правее на Way Name",
+        "sv": "Ta påfartsrampen till höger in på Way Name",
+        "vi": "Đi đường nhánh Way Name bên phải",
+        "zh-Hans": "通过匝道驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/on_ramp/slight_right_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/slight_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe auf der rechten Seite nehmen Richtung Destination 1",
+        "en": "Take the ramp on the right towards Destination 1",
+        "es": "Ve cuesta abajo en la derecha hacia Destination 1",
+        "fr": "Prendre la sortie à droite en direction de Destination 1",
+        "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
+        "nl": "Neem de oprit rechts richting Destination 1",
+        "ru": "Перестройтесь правее на автомагистраль в направлении Destination 1",
+        "sv": "Ta påfartsrampen till höger mot Destination 1",
+        "vi": "Đi đường nhánh bên phải đến Destination 1",
+        "zh-Hans": "通过匝道前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/on_ramp/straight_exit.json
+++ b/test/fixtures/v5/on_ramp/straight_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe nehmen auf Way Name",
+        "en": "Take the ramp onto Way Name",
+        "es": "Ve cuesta abajo en Way Name",
+        "fr": "Prendre la sortie sur Way Name",
+        "id": "Ambil jalan melandai ke Way Name",
+        "nl": "Neem de oprit naar Way Name",
+        "ru": "Сверните на въезд на Way Name",
+        "sv": "Ta påfartsrampen in på Way Name",
+        "vi": "Đi đường nhánh Way Name",
+        "zh-Hans": "通过匝道驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/on_ramp/straight_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/straight_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe nehmen Richtung Destination 1",
+        "en": "Take the ramp towards Destination 1",
+        "es": "Ve cuesta abajo hacia Destination 1",
+        "fr": "Prendre la sortie en direction de Destination 1",
+        "id": "Ambil jalan melandai menuju Destination 1",
+        "nl": "Neem de oprit richting Destination 1",
+        "ru": "Сверните на въезд на автомагистраль в направлении Destination 1",
+        "sv": "Ta påfartsrampen mot Destination 1",
+        "vi": "Đi đường nhánh đến Destination 1",
+        "zh-Hans": "通过匝道前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/on_ramp/uturn_exit.json
+++ b/test/fixtures/v5/on_ramp/uturn_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe nehmen auf Way Name",
+        "en": "Take the ramp onto Way Name",
+        "es": "Ve cuesta abajo en Way Name",
+        "fr": "Prendre la sortie sur Way Name",
+        "id": "Ambil jalan melandai ke Way Name",
+        "nl": "Neem de oprit naar Way Name",
+        "ru": "Сверните на въезд на Way Name",
+        "sv": "Ta påfartsrampen in på Way Name",
+        "vi": "Đi đường nhánh Way Name",
+        "zh-Hans": "通过匝道驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/on_ramp/uturn_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/uturn_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rampe nehmen Richtung Destination 1",
+        "en": "Take the ramp towards Destination 1",
+        "es": "Ve cuesta abajo hacia Destination 1",
+        "fr": "Prendre la sortie en direction de Destination 1",
+        "id": "Ambil jalan melandai menuju Destination 1",
+        "nl": "Neem de oprit richting Destination 1",
+        "ru": "Сверните на въезд на автомагистраль в направлении Destination 1",
+        "sv": "Ta påfartsrampen mot Destination 1",
+        "vi": "Đi đường nhánh đến Destination 1",
+        "zh-Hans": "通过匝道前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/rotary/default_exit.json
+++ b/test/fixtures/v5/rotary/default_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "modifier": "left",
+            "type": "rotary"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "In den Kreisverkehr fahren und auf Way Name verlassen",
+        "en": "Enter the rotary and exit onto Way Name",
+        "es": "Entra en la rotonda y sal en Way Name",
+        "fr": "Entrer dans le rond-point et sortir par Way Name",
+        "id": "Masuk bundaran dan keluar arah Way Name",
+        "nl": "Verlaat het knooppunt naar Way Name",
+        "ru": "На круговой развязке сверните на Way Name",
+        "sv": "Kör in i rondellen och ta av mot Way Name",
+        "vi": "Đi vào bùng binh và ra tại Way Name",
+        "zh-Hans": "通过环岛后驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/rotary/default_exit_destination.json
+++ b/test/fixtures/v5/rotary/default_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "modifier": "left",
+            "type": "rotary"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "In den Kreisverkehr fahren und Richtung Destination 1 verlassen",
+        "en": "Enter the rotary and exit towards Destination 1",
+        "es": "Entra en la rotonda y sal hacia Destination 1",
+        "fr": "Entrer dans le rond-point et sortir en direction de Destination 1",
+        "id": "Masuk bundaran dan keluar menuju Destination 1",
+        "nl": "Verlaat het knooppunt richting Destination 1",
+        "ru": "На круговой развязке сверните в направлении Destination 1",
+        "sv": "Kör in i rondellen och ta av mot Destination 1",
+        "vi": "Vào bùng binh và ra để đi Destination 1",
+        "zh-Hans": "通过环岛前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/rotary/exit_1_exit.json
+++ b/test/fixtures/v5/rotary/exit_1_exit.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "modifier": "left",
+            "type": "rotary",
+            "exit": 1
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "In den Kreisverkehr fahren und erste Ausfahrt nehmen auf Way Name",
+        "en": "Enter the rotary and take the 1st exit onto Way Name",
+        "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
+        "fr": "Entrer dans le rond-point et prendre la première sortie sur Way Name",
+        "id": "Masuk bundaran dan ambil jalan keluar 1 arah Way Name",
+        "nl": "Ga het knooppunt op en neem afslag 1e naar Way Name",
+        "ru": "На круговой развязке сверните на первый съезд на Way Name",
+        "sv": "Kör in i rondellen och ta avfart 1:a mot Way Name",
+        "vi": "Đi vào bùng binh và ra tại đường đầu tiên tức Way Name",
+        "zh-Hans": "进入环岛后从第一出口驶出进入Way Name"
+    }
+}

--- a/test/fixtures/v5/rotary/exit_1_exit_destination.json
+++ b/test/fixtures/v5/rotary/exit_1_exit_destination.json
@@ -1,0 +1,24 @@
+{
+    "step": {
+        "maneuver": {
+            "modifier": "left",
+            "type": "rotary",
+            "exit": 1
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "In den Kreisverkehr fahren und erste Ausfahrt nehmen Richtung Destination 1",
+        "en": "Enter the rotary and take the 1st exit towards Destination 1",
+        "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
+        "fr": "Entrer dans le rond-point et prendre la première sortie en direction de Destination 1",
+        "id": "Masuk bundaran dan ambil jalan keluar 1 menuju Destination 1",
+        "nl": "Ga het knooppunt op en neem afslag 1e richting Destination 1",
+        "ru": "На круговой развязке сверните на первый съезд в направлении Destination 1",
+        "sv": "Kör in i rondellen och ta avfart 1:a mot Destination 1",
+        "vi": "Đi vào bùng binh và ra tại đường đầu tiên đến Destination 1",
+        "zh-Hans": "进入环岛后从第一出口驶出前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/rotary/name_exit.json
+++ b/test/fixtures/v5/rotary/name_exit.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "modifier": "left",
+            "type": "rotary"
+        },
+        "name": "Way Name",
+        "rotary_name": "Rotary Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "In Rotary Name fahren und auf Way Name verlassen",
+        "en": "Enter Rotary Name and exit onto Way Name",
+        "es": "Entra en Rotary Name y sal en Way Name",
+        "fr": "Entrer dans le rond-point Rotary Name et sortir par Way Name",
+        "id": "Masuk Rotary Name dan keluar arah Way Name",
+        "nl": "Verlaat het knooppunt Rotary Name naar Way Name",
+        "ru": "На Rotary Name с круговым движением сверните на Way Name",
+        "sv": "Kör in i Rotary Name och ta av mot Way Name",
+        "vi": "Đi vào Rotary Name và ra tại Way Name",
+        "zh-Hans": "通过Rotary Name环岛后驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/rotary/name_exit_exit.json
+++ b/test/fixtures/v5/rotary/name_exit_exit.json
@@ -1,0 +1,24 @@
+{
+    "step": {
+        "maneuver": {
+            "modifier": "left",
+            "type": "rotary",
+            "exit": 2
+        },
+        "name": "Way Name",
+        "rotary_name": "Rotary Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "In den Kreisverkehr fahren und zweite Ausfahrt nehmen auf Way Name",
+        "en": "Enter Rotary Name and take the 2nd exit onto Way Name",
+        "es": "Entra en Rotary Name y coge la 2ª salida en Way Name",
+        "fr": "Entrer dans le rond-point Rotary Name et prendre la seconde sortie sur Way Name",
+        "id": "Masuk Rotary Name dan ambil jalan keluar 2 arah Way Name",
+        "nl": "Ga het knooppunt Rotary Name op en neem afslag 2e naar Way Name",
+        "ru": "На Rotary Name с круговым движением сверните на второй съезд на Way Name",
+        "sv": "Kör in i Rotary Name och ta avfart 2:a mot Way Name",
+        "vi": "Đi vào Rotary Name và ra tại đường thứ 2 tức Way Name",
+        "zh-Hans": "进入Rotary Name环岛后从第二出口驶出进入Way Name"
+    }
+}

--- a/test/fixtures/v5/rotary/name_exit_exit_destination.json
+++ b/test/fixtures/v5/rotary/name_exit_exit_destination.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "modifier": "left",
+            "type": "rotary",
+            "exit": 2
+        },
+        "name": "Way Name",
+        "rotary_name": "Rotary Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "In den Kreisverkehr fahren und zweite Ausfahrt nehmen Richtung Destination 1",
+        "en": "Enter Rotary Name and take the 2nd exit towards Destination 1",
+        "es": "Entra en Rotary Name y coge la 2ª salida hacia Destination 1",
+        "fr": "Entrer dans le rond-point Rotary Name et prendre la seconde sortie en direction de Destination 1",
+        "id": "Masuk Rotary Name dan ambil jalan keluar 2 menuju Destination 1",
+        "nl": "Ga het knooppunt Rotary Name op en neem afslag 2e richting Destination 1",
+        "ru": "На Rotary Name с круговым движением сверните на второй съезд в направлении Destination 1",
+        "sv": "Kör in i Rotary Name och ta avfart 2:a mot Destination 1",
+        "vi": "Đi vào Rotary Name và ra tại đường thứ 2 đến Destination 1",
+        "zh-Hans": "进入Rotary Name环岛后从第二出口驶出前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/roundabout/default_exit.json
+++ b/test/fixtures/v5/roundabout/default_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "modifier": "left",
+            "type": "roundabout"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "In den Kreisverkehr fahren und auf Way Name verlassen",
+        "en": "Enter the roundabout and exit onto Way Name",
+        "es": "Entra en la rotonda y sal en Way Name",
+        "fr": "Entrer dans le rond-point et sortir par Way Name",
+        "id": "Masuk bundaran dan keluar arah Way Name",
+        "nl": "Verlaat de rotonde naar Way Name",
+        "ru": "На круговой развязке сверните на Way Name",
+        "sv": "Kör in i rondellen och ta av mot Way Name",
+        "vi": "Đi vào vòng xuyến và ra tại Way Name",
+        "zh-Hans": "通过环岛后驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout/default_exit_destination.json
+++ b/test/fixtures/v5/roundabout/default_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "modifier": "left",
+            "type": "roundabout"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "In den Kreisverkehr fahren und Richtung Destination 1 verlassen",
+        "en": "Enter the roundabout and exit towards Destination 1",
+        "es": "Entra en la rotonda y sal hacia Destination 1",
+        "fr": "Entrer dans le rond-point et sortir en direction de Destination 1",
+        "id": "Masuk bundaran dan keluar menuju Destination 1",
+        "nl": "Verlaat de rotonde richting Destination 1",
+        "ru": "На круговой развязке сверните в направлении Destination 1",
+        "sv": "Kör in i rondellen och ta av mot Destination 1",
+        "vi": "Đi vào vòng xuyến và ra để đi Destination 1",
+        "zh-Hans": "通过环岛后前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/roundabout/exit_exit.json
+++ b/test/fixtures/v5/roundabout/exit_exit.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "modifier": "left",
+            "type": "roundabout",
+            "exit": 1
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "In den Kreisverkehr fahren und erste Ausfahrt nehmen auf Way Name",
+        "en": "Enter the roundabout and take the 1st exit onto Way Name",
+        "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
+        "fr": "Entrer dans le rond-point et prendre la première sortie sur Way Name",
+        "id": "Masuk bundaran dan ambil jalan keluar 1 arah Way Name",
+        "nl": "Ga de rotonde op en neem afslag 1e naar Way Name",
+        "ru": "На круговой развязке сверните на первый съезд на Way Name",
+        "sv": "Kör in i rondellen och ta avfart 1:a mot Way Name",
+        "vi": "Đi vào vòng xuyến và ra tại đường đầu tiên tức Way Name",
+        "zh-Hans": "进入环岛后从第一出口驶出前往Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout/exit_exit_destination.json
+++ b/test/fixtures/v5/roundabout/exit_exit_destination.json
@@ -1,0 +1,24 @@
+{
+    "step": {
+        "maneuver": {
+            "modifier": "left",
+            "type": "roundabout",
+            "exit": 1
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "In den Kreisverkehr fahren und erste Ausfahrt nehmen Richtung Destination 1",
+        "en": "Enter the roundabout and take the 1st exit towards Destination 1",
+        "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
+        "fr": "Entrer dans le rond-point et prendre la première sortie en direction de Destination 1",
+        "id": "Masuk bundaran dan ambil jalan keluar 1 menuju Destination 1",
+        "nl": "Ga de rotonde op en neem afslag 1e richting Destination 1",
+        "ru": "На круговой развязке сверните на первый съезд в направлении Destination 1",
+        "sv": "Kör in i rondellen och ta avfart 1:a mot Destination 1",
+        "vi": "Đi vào vòng xuyến và ra tại đường đầu tiên đến Destination 1",
+        "zh-Hans": "进入环岛后从第一出口驶出前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/left_exit.json
+++ b/test/fixtures/v5/roundabout_turn/left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Am Kreisverkehr links auf Way Name",
+        "en": "At the roundabout turn left onto Way Name",
+        "es": "En la rotonda gira a la izquierda en Way Name",
+        "fr": "Au rond-point, tourner à gauche sur Way Name",
+        "id": "Di bundaran, belok kiri arah Way Name",
+        "nl": "Ga links op de rotonde naar Way Name",
+        "ru": "На круговой развязке сверните налево на Way Name",
+        "sv": "Vid rondellen sväng vänster in på Way Name",
+        "vi": "Quẹo trái tại vòng xuyến để vào Way Name",
+        "zh-Hans": "在环岛左转，上Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/left_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Am Kreisverkehr links Richtung Destination 1",
+        "en": "At the roundabout turn left towards Destination 1",
+        "es": "En la rotonda gira a la izquierda hacia Destination 1",
+        "fr": "Au rond-point, tourner à gauche en direction de Destination 1",
+        "id": "Di bundaran, belok kiri menuju Destination 1",
+        "nl": "Ga links op de rotonde richting Destination 1",
+        "ru": "На круговой развязке сверните налево в направлении Destination 1",
+        "sv": "Vid rondellen sväng vänster mot Destination 1",
+        "vi": "Quẹo trái tại vòng xuyến để đi Destination 1",
+        "zh-Hans": "在环岛左转，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/right_exit.json
+++ b/test/fixtures/v5/roundabout_turn/right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Am Kreisverkehr rechts auf Way Name",
+        "en": "At the roundabout turn right onto Way Name",
+        "es": "En la rotonda gira a la derecha en Way Name",
+        "fr": "Au rond-point, tourner à droite sur Way Name",
+        "id": "Di bundaran belok kanan ke arah Way Name",
+        "nl": "Ga rechts op de rotonde naar Way Name",
+        "ru": "На круговой развязке сверните направо на Way Name",
+        "sv": "Vid rondellen sväng höger in på Way Name",
+        "vi": "Quẹo phải ti vòng xuyến để vào Way Name",
+        "zh-Hans": "在环岛右转，上Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/right_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Am Kreisverkehr rechts Richtung Destination 1",
+        "en": "At the roundabout turn right towards Destination 1",
+        "es": "En la rotonda gira a la derecha hacia Destination 1",
+        "fr": "Au rond-point, tourner à droite en direction de Destination 1",
+        "id": "Di bundaran belok kanan menuju Destination 1",
+        "nl": "Ga rechts op de rotonde richting Destination 1",
+        "ru": "На круговой развязке сверните направо в направлении Destination 1",
+        "sv": "Vid rondellen sväng höger mot Destination 1",
+        "vi": "Quẹo phải tại vòng xuyến để đi Destination 1",
+        "zh-Hans": "在环岛右转，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/sharp_left_exit.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Am Kreisverkehr scharf links auf Way Name",
+        "en": "At the roundabout make a sharp left onto Way Name",
+        "es": "En la rotonda siga cerrada a la izquierda en Way Name",
+        "fr": "Au rond-point, tourner franchement à gauche sur Way Name",
+        "id": "Di bundaran, lakukan tajam kiri ke arah Way Name",
+        "nl": "Ga linksaf op de rotonde naar Way Name",
+        "ru": "На круговой развязке двигайтесь налево на Way Name",
+        "sv": "Vid rondellen sväng skarp vänster in på Way Name",
+        "vi": "Đi bên trái gắt tại vòng xuyến để vào Way Name",
+        "zh-Hans": "在环岛向左行驶，上Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Am Kreisverkehr scharf links Richtung Destination 1",
+        "en": "At the roundabout make a sharp left towards Destination 1",
+        "es": "En la rotonda siga cerrada a la izquierda hacia Destination 1",
+        "fr": "Au rond-point, tourner franchement à gauche en direction de Destination 1",
+        "id": "Di bundaran, lakukan tajam kiri menuju Destination 1",
+        "nl": "Ga linksaf op de rotonde richting Destination 1",
+        "ru": "На круговой развязке двигайтесь налево в направлении Destination 1",
+        "sv": "Vid rondellen sväng skarp vänster mot Destination 1",
+        "vi": "Đi bên trái gắt tại vòng xuyến để đi Destination 1",
+        "zh-Hans": "在环岛向左行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/sharp_right_exit.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Am Kreisverkehr scharf rechts auf Way Name",
+        "en": "At the roundabout make a sharp right onto Way Name",
+        "es": "En la rotonda siga cerrada a la derecha en Way Name",
+        "fr": "Au rond-point, tourner franchement à droite sur Way Name",
+        "id": "Di bundaran, lakukan tajam kanan ke arah Way Name",
+        "nl": "Ga rechtsaf op de rotonde naar Way Name",
+        "ru": "На круговой развязке двигайтесь направо на Way Name",
+        "sv": "Vid rondellen sväng skarp höger in på Way Name",
+        "vi": "Đi bên phải gắt tại vòng xuyến để vào Way Name",
+        "zh-Hans": "在环岛向右行驶，上Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Am Kreisverkehr scharf rechts Richtung Destination 1",
+        "en": "At the roundabout make a sharp right towards Destination 1",
+        "es": "En la rotonda siga cerrada a la derecha hacia Destination 1",
+        "fr": "Au rond-point, tourner franchement à droite en direction de Destination 1",
+        "id": "Di bundaran, lakukan tajam kanan menuju Destination 1",
+        "nl": "Ga rechtsaf op de rotonde richting Destination 1",
+        "ru": "На круговой развязке двигайтесь направо в направлении Destination 1",
+        "sv": "Vid rondellen sväng skarp höger mot Destination 1",
+        "vi": "Đi bên phải gắt tại vòng xuyến để đi Destination 1",
+        "zh-Hans": "在环岛向右行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/slight_left_exit.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Am Kreisverkehr leicht links auf Way Name",
+        "en": "At the roundabout make a slight left onto Way Name",
+        "es": "En la rotonda siga ligeramente a la izquierda en Way Name",
+        "fr": "Au rond-point, tourner légèrement à gauche sur Way Name",
+        "id": "Di bundaran, lakukan agak ke kiri ke arah Way Name",
+        "nl": "Ga links op de rotonde naar Way Name",
+        "ru": "На круговой развязке двигайтесь левее на Way Name",
+        "sv": "Vid rondellen sväng lätt vänster in på Way Name",
+        "vi": "Đi bên trái nghiêng tại vòng xuyến để vào Way Name",
+        "zh-Hans": "在环岛向左行驶，上Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/slight_left_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Am Kreisverkehr leicht links Richtung Destination 1",
+        "en": "At the roundabout make a slight left towards Destination 1",
+        "es": "En la rotonda siga ligeramente a la izquierda hacia Destination 1",
+        "fr": "Au rond-point, tourner légèrement à gauche en direction de Destination 1",
+        "id": "Di bundaran, lakukan agak ke kiri menuju Destination 1",
+        "nl": "Ga links op de rotonde richting Destination 1",
+        "ru": "На круговой развязке двигайтесь левее в направлении Destination 1",
+        "sv": "Vid rondellen sväng lätt vänster mot Destination 1",
+        "vi": "Đi bên trái nghiêng tại vòng xuyến để đi Destination 1",
+        "zh-Hans": "在环岛向左行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/slight_right_exit.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Am Kreisverkehr leicht rechts auf Way Name",
+        "en": "At the roundabout make a slight right onto Way Name",
+        "es": "En la rotonda siga ligeramente a la derecha en Way Name",
+        "fr": "Au rond-point, tourner légèrement à droite sur Way Name",
+        "id": "Di bundaran, lakukan agak ke kanan ke arah Way Name",
+        "nl": "Ga rechts op de rotonde naar Way Name",
+        "ru": "На круговой развязке двигайтесь правее на Way Name",
+        "sv": "Vid rondellen sväng lätt höger in på Way Name",
+        "vi": "Đi bên phải nghiêng tại vòng xuyến để vào Way Name",
+        "zh-Hans": "在环岛向右行驶，上Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/slight_right_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Am Kreisverkehr leicht rechts Richtung Destination 1",
+        "en": "At the roundabout make a slight right towards Destination 1",
+        "es": "En la rotonda siga ligeramente a la derecha hacia Destination 1",
+        "fr": "Au rond-point, tourner légèrement à droite en direction de Destination 1",
+        "id": "Di bundaran, lakukan agak ke kanan menuju Destination 1",
+        "nl": "Ga rechts op de rotonde richting Destination 1",
+        "ru": "На круговой развязке двигайтесь правее в направлении Destination 1",
+        "sv": "Vid rondellen sväng lätt höger mot Destination 1",
+        "vi": "Đi bên phải nghiêng tại vòng xuyến để đi Destination 1",
+        "zh-Hans": "在环岛向右行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/straight_exit.json
+++ b/test/fixtures/v5/roundabout_turn/straight_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Am Kreisverkehr geradeaus weiterfahren auf Way Name",
+        "en": "At the roundabout continue straight onto Way Name",
+        "es": "En la rotonda continua recto en Way Name",
+        "fr": "Au rond-point, continuer tout droit sur Way Name",
+        "id": "Di bundaran tetap lurus ke arah Way Name",
+        "nl": "Rechtdoor op de rotonde naar Way Name",
+        "ru": "На круговой развязке двигайтесь по Way Name",
+        "sv": "Vid rondellen fortsätt rakt fram in på Way Name",
+        "vi": "Chạy thẳng tại vòng xuyến để chạy tiếp trên Way Name",
+        "zh-Hans": "在环岛继续直行，上Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/straight_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/straight_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Am Kreisverkehr geradeaus weiterfahren Richtung Destination 1",
+        "en": "At the roundabout continue straight towards Destination 1",
+        "es": "En la rotonda continua recto hacia Destination 1",
+        "fr": "Au rond-point, continuer tout droit en direction de Destination 1",
+        "id": "Di bundaran tetap lurus menuju Destination 1",
+        "nl": "Rechtdoor op de rotonde richting Destination 1",
+        "ru": "На круговой развязке двигайтесь в направлении Destination 1",
+        "sv": "Vid rondellen fortsätt rakt fram mot Destination 1",
+        "vi": "Chạy thẳng tại vòng xuyến để đi Destination 1",
+        "zh-Hans": "在环岛继续直行，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/uturn_exit.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Am Kreisverkehr 180°-Wendung auf Way Name",
+        "en": "At the roundabout make a U-turn onto Way Name",
+        "es": "En la rotonda siga cambio de sentido en Way Name",
+        "fr": "Au rond-point, tourner demi-tour sur Way Name",
+        "id": "Di bundaran, lakukan putar balik ke arah Way Name",
+        "nl": "Ga omkeren op de rotonde naar Way Name",
+        "ru": "На круговой развязке двигайтесь на разворот на Way Name",
+        "sv": "Vid rondellen sväng U-sväng in på Way Name",
+        "vi": "Đi bên ngược tại vòng xuyến để vào Way Name",
+        "zh-Hans": "在环岛调头行驶，上Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/uturn_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Am Kreisverkehr 180°-Wendung Richtung Destination 1",
+        "en": "At the roundabout make a U-turn towards Destination 1",
+        "es": "En la rotonda siga cambio de sentido hacia Destination 1",
+        "fr": "Au rond-point, tourner demi-tour en direction de Destination 1",
+        "id": "Di bundaran, lakukan putar balik menuju Destination 1",
+        "nl": "Ga omkeren op de rotonde richting Destination 1",
+        "ru": "На круговой развязке двигайтесь на разворот в направлении Destination 1",
+        "sv": "Vid rondellen sväng U-sväng mot Destination 1",
+        "vi": "Đi bên ngược tại vòng xuyến để đi Destination 1",
+        "zh-Hans": "在环岛调头行驶，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/turn/left_exit.json
+++ b/test/fixtures/v5/turn/left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Links abbiegen auf Way Name",
+        "en": "Turn left onto Way Name",
+        "es": "Gire a la izquierda en Way Name",
+        "fr": "Tourner à gauche sur Way Name",
+        "id": "Belok kiri ke Way Name",
+        "nl": "Ga linksaf naar Way Name",
+        "ru": "Поверните налево на Way Name",
+        "sv": "Sväng vänster in på Way Name",
+        "vi": "Quẹo trái vào Way Name",
+        "zh-Hans": "左转，上Way Name"
+    }
+}

--- a/test/fixtures/v5/turn/left_exit_destination.json
+++ b/test/fixtures/v5/turn/left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Links abbiegen Richtung Destination 1",
+        "en": "Turn left towards Destination 1",
+        "es": "Gire a la izquierda hacia Destination 1",
+        "fr": "Tourner à gauche en direction de Destination 1",
+        "id": "Belok kiri menuju Destination 1",
+        "nl": "Ga linksaf richting Destination 1",
+        "ru": "Поверните налево в направлении Destination 1",
+        "sv": "Sväng vänster mot Destination 1",
+        "vi": "Quẹo trái đến Destination 1",
+        "zh-Hans": "左转，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/turn/right_exit.json
+++ b/test/fixtures/v5/turn/right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rechts abbiegen auf Way Name",
+        "en": "Turn right onto Way Name",
+        "es": "Gire a la derecha en Way Name",
+        "fr": "Tourner à droite sur Way Name",
+        "id": "Belok kanan ke Way Name",
+        "nl": "Ga rechtsaf naar Way Name",
+        "ru": "Поверните направо на Way Name",
+        "sv": "Sväng höger in på Way Name",
+        "vi": "Quẹo phải vào Way Name",
+        "zh-Hans": "右转，上Way Name"
+    }
+}

--- a/test/fixtures/v5/turn/right_exit_destination.json
+++ b/test/fixtures/v5/turn/right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Rechts abbiegen Richtung Destination 1",
+        "en": "Turn right towards Destination 1",
+        "es": "Gire a la derecha hacia Destination 1",
+        "fr": "Tourner à droite en direction de Destination 1",
+        "id": "Belok kanan menuju Destination 1",
+        "nl": "Ga rechtsaf richting Destination 1",
+        "ru": "Поверните направо в направлении Destination 1",
+        "sv": "Sväng höger mot Destination 1",
+        "vi": "Quẹo phải đến Destination 1",
+        "zh-Hans": "右转，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/turn/sharp_left_exit.json
+++ b/test/fixtures/v5/turn/sharp_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf links abbiegen auf Way Name",
+        "en": "Make a sharp left onto Way Name",
+        "es": "Siga cerrada a la izquierda en Way Name",
+        "fr": "Tourner franchement à gauche sur Way Name",
+        "id": "Lakukan tajam kiri ke arah Way Name",
+        "nl": "Ga linksaf naar Way Name",
+        "ru": "Двигайтесь налево на Way Name",
+        "sv": "Sväng åt skarp vänster in på Way Name",
+        "vi": "Quẹo trái gắt vào Way Name",
+        "zh-Hans": "向左转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/turn/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/turn/sharp_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf links abbiegen Richtung Destination 1",
+        "en": "Make a sharp left towards Destination 1",
+        "es": "Siga cerrada a la izquierda hacia Destination 1",
+        "fr": "Tourner franchement à gauche en direction de Destination 1",
+        "id": "Lakukan tajam kiri menuju Destination 1",
+        "nl": "Ga linksaf richting Destination 1",
+        "ru": "Двигайтесь налево в направлении Destination 1",
+        "sv": "Sväng åt skarp vänster mot Destination 1",
+        "vi": "Quẹo trái gắt đến Destination 1",
+        "zh-Hans": "向左转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/turn/sharp_right_exit.json
+++ b/test/fixtures/v5/turn/sharp_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts abbiegen auf Way Name",
+        "en": "Make a sharp right onto Way Name",
+        "es": "Siga cerrada a la derecha en Way Name",
+        "fr": "Tourner franchement à droite sur Way Name",
+        "id": "Lakukan tajam kanan ke arah Way Name",
+        "nl": "Ga rechtsaf naar Way Name",
+        "ru": "Двигайтесь направо на Way Name",
+        "sv": "Sväng åt skarp höger in på Way Name",
+        "vi": "Quẹo phải gắt vào Way Name",
+        "zh-Hans": "向右转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/turn/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/turn/sharp_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts abbiegen Richtung Destination 1",
+        "en": "Make a sharp right towards Destination 1",
+        "es": "Siga cerrada a la derecha hacia Destination 1",
+        "fr": "Tourner franchement à droite en direction de Destination 1",
+        "id": "Lakukan tajam kanan menuju Destination 1",
+        "nl": "Ga rechtsaf richting Destination 1",
+        "ru": "Двигайтесь направо в направлении Destination 1",
+        "sv": "Sväng åt skarp höger mot Destination 1",
+        "vi": "Quẹo phải gắt đến Destination 1",
+        "zh-Hans": "向右转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/turn/slight_left_exit.json
+++ b/test/fixtures/v5/turn/slight_left_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht links abbiegen auf Way Name",
+        "en": "Make a slight left onto Way Name",
+        "es": "Siga ligeramente a la izquierda en Way Name",
+        "fr": "Tourner légèrement à gauche sur Way Name",
+        "id": "Lakukan agak ke kiri ke arah Way Name",
+        "nl": "Ga links naar Way Name",
+        "ru": "Двигайтесь левее на Way Name",
+        "sv": "Sväng åt lätt vänster in på Way Name",
+        "vi": "Quẹo trái nghiêng vào Way Name",
+        "zh-Hans": "向左转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/turn/slight_left_exit_destination.json
+++ b/test/fixtures/v5/turn/slight_left_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht links abbiegen Richtung Destination 1",
+        "en": "Make a slight left towards Destination 1",
+        "es": "Siga ligeramente a la izquierda hacia Destination 1",
+        "fr": "Tourner légèrement à gauche en direction de Destination 1",
+        "id": "Lakukan agak ke kiri menuju Destination 1",
+        "nl": "Ga links richting Destination 1",
+        "ru": "Двигайтесь левее в направлении Destination 1",
+        "sv": "Sväng åt lätt vänster mot Destination 1",
+        "vi": "Quẹo trái nghiêng đến Destination 1",
+        "zh-Hans": "向左转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/turn/slight_right_exit.json
+++ b/test/fixtures/v5/turn/slight_right_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht rechts abbiegen auf Way Name",
+        "en": "Make a slight right onto Way Name",
+        "es": "Siga ligeramente a la derecha en Way Name",
+        "fr": "Tourner légèrement à droite sur Way Name",
+        "id": "Lakukan agak ke kanan ke arah Way Name",
+        "nl": "Ga rechts naar Way Name",
+        "ru": "Двигайтесь правее на Way Name",
+        "sv": "Sväng åt lätt höger in på Way Name",
+        "vi": "Quẹo phải nghiêng vào Way Name",
+        "zh-Hans": "向右转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/turn/slight_right_exit_destination.json
+++ b/test/fixtures/v5/turn/slight_right_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Leicht rechts abbiegen Richtung Destination 1",
+        "en": "Make a slight right towards Destination 1",
+        "es": "Siga ligeramente a la derecha hacia Destination 1",
+        "fr": "Tourner légèrement à droite en direction de Destination 1",
+        "id": "Lakukan agak ke kanan menuju Destination 1",
+        "nl": "Ga rechts richting Destination 1",
+        "ru": "Двигайтесь правее в направлении Destination 1",
+        "sv": "Sväng åt lätt höger mot Destination 1",
+        "vi": "Quẹo phải nghiêng đến Destination 1",
+        "zh-Hans": "向右转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/turn/straight_exit.json
+++ b/test/fixtures/v5/turn/straight_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren auf Way Name",
+        "en": "Go straight onto Way Name",
+        "es": "Ve recto en Way Name",
+        "fr": "Aller tout droit sur Way Name",
+        "id": "Lurus arah Way Name",
+        "nl": "Ga rechtdoor naar Way Name",
+        "ru": "Двигайтесь по Way Name",
+        "sv": "Kör rakt fram in på Way Name",
+        "vi": "Chạy thẳng vào Way Name",
+        "zh-Hans": "直行，上Way Name"
+    }
+}

--- a/test/fixtures/v5/turn/straight_exit_destination.json
+++ b/test/fixtures/v5/turn/straight_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren Richtung Destination 1",
+        "en": "Go straight towards Destination 1",
+        "es": "Ve recto hacia Destination 1",
+        "fr": "Aller tout droit en direction de Destination 1",
+        "id": "Lurus menuju Destination 1",
+        "nl": "Ga rechtdoor richting Destination 1",
+        "ru": "Двигайтесь в направлении Destination 1",
+        "sv": "Kör rakt fram mot Destination 1",
+        "vi": "Chạy thẳng đến Destination 1",
+        "zh-Hans": "直行，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/turn/uturn_exit.json
+++ b/test/fixtures/v5/turn/uturn_exit.json
@@ -1,0 +1,22 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung abbiegen auf Way Name",
+        "en": "Make a U-turn onto Way Name",
+        "es": "Siga cambio de sentido en Way Name",
+        "fr": "Tourner demi-tour sur Way Name",
+        "id": "Lakukan putar balik ke arah Way Name",
+        "nl": "Ga omkeren naar Way Name",
+        "ru": "Двигайтесь на разворот на Way Name",
+        "sv": "Sväng åt U-sväng in på Way Name",
+        "vi": "Quẹo ngược vào Way Name",
+        "zh-Hans": "调头转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/turn/uturn_exit_destination.json
+++ b/test/fixtures/v5/turn/uturn_exit_destination.json
@@ -1,0 +1,23 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A,4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung abbiegen Richtung Destination 1",
+        "en": "Make a U-turn towards Destination 1",
+        "es": "Siga cambio de sentido hacia Destination 1",
+        "fr": "Tourner demi-tour en direction de Destination 1",
+        "id": "Lakukan putar balik menuju Destination 1",
+        "nl": "Ga omkeren richting Destination 1",
+        "ru": "Двигайтесь на разворот в направлении Destination 1",
+        "sv": "Sväng åt U-sväng mot Destination 1",
+        "vi": "Quẹo ngược đến Destination 1",
+        "zh-Hans": "调头转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures_test.js
+++ b/test/fixtures_test.js
@@ -75,6 +75,21 @@ tape.test('verify existance/update fixtures', function(assert) {
             destinations: 'Destination 1,Destination 2'
         });
         checkOrWrite(step, `${basePath}_destination`);
+
+        // exit
+        step = Object.assign(clone(baseStep), {
+            name: 'Way Name',
+            exits: '4A,4B'
+        });
+        checkOrWrite(step, `${basePath}_exit`);
+
+        // exit + destination
+        step = Object.assign(clone(baseStep), {
+            name: 'Way Name',
+            destinations: 'Destination 1,Destination 2',
+            exits: '4A,4B'
+        });
+        checkOrWrite(step, `${basePath}_exit_destination`);
     }
 
     ['modes', 'other', 'arrive_waypoint', 'arrive_waypoint_last'].concat(constants.types).forEach((type) => {


### PR DESCRIPTION
This adds support for the [upcoming exits support in OSRM](https://github.com/Project-OSRM/osrm-backend/pull/4215). We are introducing "Take exit {exit}" text here but it's applied pretty narrowly right now - it is only used for off ramps that are tagged with exit information.

Fixes https://github.com/Project-OSRM/osrm-text-instructions/issues/114