### PR TITLE
Remove extra word "straight" for `new name` maneuvers

### DIFF
--- a/languages/translations/en.json
+++ b/languages/translations/en.json
@@ -196,6 +196,11 @@
                 "name": "Continue {modifier} onto {way_name}",
                 "destination": "Continue {modifier} towards {destination}"
             },
+            "straight": {
+                "default": "Continue straight",
+                "name": "Continue onto {way_name}",
+                "destination": "Continue towards {destination}"
+            },
             "sharp left": {
                 "default": "Take a sharp left",
                 "name": "Take a sharp left onto {way_name}",

--- a/test/fixtures/v5/new_name/straight_destination.json
+++ b/test/fixtures/v5/new_name/straight_destination.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Geradeaus weiterfahren Richtung Destination 1",
-        "en": "Continue straight towards Destination 1",
+        "en": "Continue towards Destination 1",
         "es": "Continua recto hacia Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "id": "Lanjutkan lurus menuju Destination 1",

--- a/test/fixtures/v5/new_name/straight_exit.json
+++ b/test/fixtures/v5/new_name/straight_exit.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Geradeaus weiterfahren auf Way Name",
-        "en": "Continue straight onto Way Name",
+        "en": "Continue onto Way Name",
         "es": "Continua recto en Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "id": "Lanjutkan lurus menuju Way Name",

--- a/test/fixtures/v5/new_name/straight_exit_destination.json
+++ b/test/fixtures/v5/new_name/straight_exit_destination.json
@@ -10,7 +10,7 @@
     },
     "instructions": {
         "de": "Geradeaus weiterfahren Richtung Destination 1",
-        "en": "Continue straight towards Destination 1",
+        "en": "Continue towards Destination 1",
         "es": "Continua recto hacia Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "id": "Lanjutkan lurus menuju Destination 1",

--- a/test/fixtures/v5/new_name/straight_name.json
+++ b/test/fixtures/v5/new_name/straight_name.json
@@ -8,7 +8,7 @@
     },
     "instructions": {
         "de": "Geradeaus weiterfahren auf Way Name",
-        "en": "Continue straight onto Way Name",
+        "en": "Continue onto Way Name",
         "es": "Continua recto en Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "id": "Lanjutkan lurus menuju Way Name",


### PR DESCRIPTION
This updates `new name` maneuvers to match `continue` maneuvers when the modifier is `straight`.