### PR TITLE
Add phrases for post instruction processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
+# 0.6.0
+
+- Adds `phrase` types to the English localiztion. [#141](https://github.com/Project-OSRM/osrm-text-instructions/pull/141)
+- Adds `distance`, `name` and `namedistance` options to the continue and continue straight instructions. [#141](https://github.com/Project-OSRM/osrm-text-instructions/pull/141)
+- Adds `tokenize` to the top level api so that external users can fill in osrm-text-instructions template strings. [#141](https://github.com/Project-OSRM/osrm-text-instructions/pull/141)
+
 # 0.5.4 2017-09-06
 
 - Improves the wording of "continue" instructions. [#142](https://github.com/Project-OSRM/osrm-text-instructions/pull/142)

--- a/index.js
+++ b/index.js
@@ -180,23 +180,31 @@ module.exports = function(version, _options) {
 
             // Replace tokens
             // NOOP if they don't exist
-            instruction = instruction
-                .replace('{way_name}', wayName)
-                .replace('{destination}', (step.destinations || '').split(',')[0])
-                .replace('{exit}', (step.exits || '').split(';')[0])
-                .replace('{exit_number}', this.ordinalize(language, step.maneuver.exit || 1))
-                .replace('{rotary_name}', step.rotary_name)
-                .replace('{lane_instruction}', laneInstruction)
-                .replace('{modifier}', instructions[language][version].constants.modifier[modifier])
-                .replace('{direction}', this.directionFromDegree(language, step.maneuver.bearing_after))
-                .replace('{nth}', nthWaypoint)
-                .replace(/ {2}/g, ' '); // remove excess spaces
+            var replaceTokens = {
+                'way_name': wayName,
+                'destination': (step.destinations || '').split(',')[0],
+                'exit': (step.exits || '').split(';')[0],
+                'exit_number': this.ordinalize(language, step.maneuver.exit || 1),
+                'rotary_name': step.rotary_name,
+                'lane_instruction': laneInstruction,
+                'modifier': instructions[language][version].constants.modifier[modifier],
+                'direction': this.directionFromDegree(language, step.maneuver.bearing_after),
+                'nth': nthWaypoint
+            };
+
+            return this.tokenize(instruction, replaceTokens, language);
+        },
+        tokenize: function(instruction, tokens, language) {
+            var output =  Object.keys(tokens).reduce(function(memo, token) {
+                return memo.replace('{' + token + '}', tokens[token]);
+            }, instruction)
+            .replace(/ {2}/g, ' '); // remove excess spaces
 
             if (instructions[language].meta.capitalizeFirstLetter) {
-                instruction = this.capitalizeFirstLetter(instruction);
+                return this.capitalizeFirstLetter(output);
             }
 
-            return instruction;
+            return output;
         }
     };
 };

--- a/languages/translations/de.json
+++ b/languages/translations/de.json
@@ -50,6 +50,7 @@
                 "destination": "Fähre nehmen Richtung {destination}"
             }
         },
+        "phrase": {},
         "arrive": {
             "default": {
                 "default": "Sie haben Ihr {nth} Ziel erreicht"

--- a/languages/translations/en.json
+++ b/languages/translations/en.json
@@ -50,6 +50,11 @@
                 "destination": "Take the ferry towards {destination}"
             }
         },
+        "phrase": {
+            "two linked by distance": "{instruction_one} then in {distance} {instruction_two}",
+            "two linked": "{instruction_one} then {instruction_two}",
+            "one in distance": "In {distance}, {instruction_one}"
+        },
         "arrive": {
             "default": {
                 "default": "You have arrived at your {nth} destination"
@@ -81,12 +86,15 @@
                 "default": "Continue {modifier}",
                 "name": "Continue {modifier} to stay on {way_name}",
                 "destination": "Continue {modifier} towards {destination}",
-                "exit": "Continue {modifier} onto {way_name}"
+                "exit": "Continue {modifier} onto {way_name}",
+                "distance": "Continue for {distance}",
+                "namedistance": "Continue on {way_name} for {distance}"
             },
             "straight": {
                 "default": "Continue straight",
                 "name": "Continue straight to stay on {way_name}",
-                "destination": "Continue towards {destination}"
+                "destination": "Continue towards {destination}",
+                "distance": "Continue straight for {distance}"
             },
             "slight left": {
                 "default": "Continue slightly left",

--- a/languages/translations/es.json
+++ b/languages/translations/es.json
@@ -50,6 +50,7 @@
                 "destination": "Coge el ferry a  {destination}"
             }
         },
+        "phrase": {},
         "arrive": {
             "default": {
                 "default": "Has llegado a tu {nth} destino"

--- a/languages/translations/fr.json
+++ b/languages/translations/fr.json
@@ -50,6 +50,7 @@
                 "destination": "Prendre le ferry en direction de {destination}"
             }
         },
+        "phrase": {},
         "arrive": {
             "default": {
                 "default": "Vous êtes arrivés à votre {nth} destination"

--- a/languages/translations/id.json
+++ b/languages/translations/id.json
@@ -50,6 +50,7 @@
                 "destination": "Naik ferry menuju {destination}"
             }
         },
+        "phrase": {},
         "arrive": {
             "default": {
                 "default": "Anda telah tiba di tujuan ke-{nth}"

--- a/languages/translations/it.json
+++ b/languages/translations/it.json
@@ -50,6 +50,7 @@
                 "destination": "Prendi il traghetto verso {destination}"
             }
         },
+        "phrase": {},
         "arrive": {
             "default": {
                 "default": "Sei arrivato alla tua {nth} destinazione"

--- a/languages/translations/nl.json
+++ b/languages/translations/nl.json
@@ -50,6 +50,7 @@
                 "destination": "Neem het veer naar {destination}"
             }
         },
+        "phrase": {},
         "arrive": {
             "default": {
                 "default": "Je bent gearriveerd op de {nth} bestemming."

--- a/languages/translations/pl.json
+++ b/languages/translations/pl.json
@@ -50,6 +50,7 @@
                 "destination": "Weź prom w kierunku {destination}"
             }
         },
+        "phrase": {},
         "arrive": {
             "default": {
                 "default": "Dojechano do miejsca docelowego {nth}"

--- a/languages/translations/pt-BR.json
+++ b/languages/translations/pt-BR.json
@@ -50,6 +50,7 @@
                 "destination": "Pegue a balsa sentido {destination}"
             }
         },
+        "phrase": {},
         "arrive": {
             "default": {
                 "default": "Você chegou ao seu {nth} destino"

--- a/languages/translations/ru.json
+++ b/languages/translations/ru.json
@@ -50,6 +50,7 @@
                 "destination": "Погрузитесь на паром в направлении {destination}"
             }
         },
+        "phrase": {},
         "arrive": {
             "default": {
                 "default": "Вы прибыли в {nth} пункт назначения"

--- a/languages/translations/sv.json
+++ b/languages/translations/sv.json
@@ -50,6 +50,7 @@
                 "destination": "Ta färjan mot {destination}"
             }
         },
+        "phrase": {},
         "arrive": {
             "default": {
                 "default": "Du är framme vid din {nth} destination"

--- a/languages/translations/uk.json
+++ b/languages/translations/uk.json
@@ -50,6 +50,7 @@
                 "destination": "Скористайтесь поромом у напрямку {destination}"
             }
         },
+        "phrase": {},
         "arrive": {
             "default": {
                 "default": "Ви прибули у ваш {nth} пункт призначення"

--- a/languages/translations/vi.json
+++ b/languages/translations/vi.json
@@ -50,6 +50,7 @@
                 "destination": "Lên phà đi {destination}"
             }
         },
+        "phrase": {},
         "arrive": {
             "default": {
                 "default": "Đến nơi {nth}"

--- a/languages/translations/zh-Hans.json
+++ b/languages/translations/zh-Hans.json
@@ -50,6 +50,7 @@
                 "destination": "乘坐开往{destination}的轮渡"
             }
         },
+        "phrase": {},
         "arrive": {
             "default": {
                 "default": "您已经到达您的{nth}个目的地"

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -4,6 +4,38 @@ var tape = require('tape');
 
 var instructions = require('../index');
 
+tape.test('v5 tokenize', function(assert) {
+    var v5Instructions = instructions('v5');
+
+    var tokenString = 'Can {first} {second}';
+
+    var hasBoth = v5Instructions.tokenize(tokenString, {
+        first: 'osrm',
+        second: 'do routing'
+    }, 'en');
+    assert.equal(hasBoth, 'Can osrm do routing', 'does find and replace');
+
+    var hasFirst = v5Instructions.tokenize(tokenString, {
+        first: 'osrm',
+        second: ''
+    }, 'en');
+    assert.equal(hasFirst, 'Can osrm ', 'does find and replace and does not drop trailing spaces');
+
+    var hasSecond = v5Instructions.tokenize(tokenString, {
+        second: 'swim',
+        first: ''
+    }, 'en');
+    assert.equal(hasSecond, 'Can swim', 'does find and replace and drops internal extra spaces');
+
+    var missingSecond = v5Instructions.tokenize(tokenString, {
+        first: 'osrm'
+    }, 'en');
+    assert.equal(missingSecond, 'Can osrm {second}', 'does not replace tokens which are not provided');
+
+
+    assert.end();
+});
+
 tape.test('v5 directionFromDegree', function(assert) {
     var v5Instructions = instructions('v5');
 


### PR DESCRIPTION
There are times when one wants to link two instructions or prefix them with a message. These `phrases` should be translated with the same level of detail as the rest of this project, so I think they should live here. That said, I'm not quite sure how they should be added to the translation files so currently I've only added these to `en.json`.

This PR adds a `phases` to `v5` of the translations along with these new continue phrases.

- continue.default.distance
- continue.default.namedistance
- continue.straight.distance

# Issue

I think this will close https://github.com/Project-OSRM/osrm-text-instructions/issues/88.

## Tasklist

 - [x] Add changelog entry
 - [ ] Review
