### PR TITLE
"Continue onto" --> "Continue to stay on"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
+# 0.5.4 2017-09-06
+
+- Improves the wording of "continue" instructions. [#142](https://github.com/Project-OSRM/osrm-text-instructions/pull/142)
+
 # 0.5.3 2017-08-25
 
 - Adds Brazilian Portuguese, Italian, and Ukrainian localizations. [#137](https://github.com/Project-OSRM/osrm-text-instructions/pull/137)

--- a/languages/translations/en.json
+++ b/languages/translations/en.json
@@ -100,7 +100,7 @@
             },
             "uturn": {
                 "default": "Make a U-turn",
-                "name": "Make a U-turn to stay on {way_name}",
+                "name": "Make a U-turn and continue on {way_name}",
                 "destination": "Make a U-turn towards {destination}"
             }
         },

--- a/languages/translations/en.json
+++ b/languages/translations/en.json
@@ -80,7 +80,8 @@
             "default": {
                 "default": "Continue {modifier}",
                 "name": "Continue {modifier} to stay on {way_name}",
-                "destination": "Continue {modifier} towards {destination}"
+                "destination": "Continue {modifier} towards {destination}",
+                "exit": "Continue {modifier} onto {way_name}"
             },
             "straight": {
                 "default": "Continue straight",

--- a/languages/translations/en.json
+++ b/languages/translations/en.json
@@ -79,27 +79,27 @@
         "continue": {
             "default": {
                 "default": "Continue {modifier}",
-                "name": "Continue {modifier} onto {way_name}",
+                "name": "Continue {modifier} to stay on {way_name}",
                 "destination": "Continue {modifier} towards {destination}"
             },
             "straight": {
                 "default": "Continue straight",
-                "name": "Continue onto {way_name}",
+                "name": "Continue straight to stay on {way_name}",
                 "destination": "Continue towards {destination}"
             },
             "slight left": {
                 "default": "Continue slightly left",
-                "name": "Continue slightly left onto {way_name}",
+                "name": "Continue slightly left to stay on {way_name}",
                 "destination": "Continue slightly left towards {destination}"
             },
             "slight right": {
                 "default": "Continue slightly right",
-                "name": "Continue slightly right onto {way_name}",
+                "name": "Continue slightly right to stay on {way_name}",
                 "destination": "Continue slightly right towards {destination}"
             },
             "uturn": {
                 "default": "Make a U-turn",
-                "name": "Make a U-turn onto {way_name}",
+                "name": "Make a U-turn to stay on {way_name}",
                 "destination": "Make a U-turn towards {destination}"
             }
         },

--- a/test/fixtures/v5/continue/left_name.json
+++ b/test/fixtures/v5/continue/left_name.json
@@ -8,7 +8,7 @@
     },
     "instructions": {
         "de": "Links weiterfahren auf Way Name",
-        "en": "Continue left onto Way Name",
+        "en": "Continue left to stay on Way Name",
         "es": "Continúe izquierda en Way Name",
         "fr": "Continuer à gauche sur Way Name",
         "id": "Terus kiri ke Way Name",

--- a/test/fixtures/v5/continue/right_name.json
+++ b/test/fixtures/v5/continue/right_name.json
@@ -8,7 +8,7 @@
     },
     "instructions": {
         "de": "Rechts weiterfahren auf Way Name",
-        "en": "Continue right onto Way Name",
+        "en": "Continue right to stay on Way Name",
         "es": "Continúe derecha en Way Name",
         "fr": "Continuer à droite sur Way Name",
         "id": "Terus kanan ke Way Name",

--- a/test/fixtures/v5/continue/sharp_left_name.json
+++ b/test/fixtures/v5/continue/sharp_left_name.json
@@ -8,7 +8,7 @@
     },
     "instructions": {
         "de": "Scharf links weiterfahren auf Way Name",
-        "en": "Continue sharp left onto Way Name",
+        "en": "Continue sharp left to stay on Way Name",
         "es": "Continúe cerrada a la izquierda en Way Name",
         "fr": "Continuer franchement à gauche sur Way Name",
         "id": "Terus tajam kiri ke Way Name",

--- a/test/fixtures/v5/continue/sharp_right_name.json
+++ b/test/fixtures/v5/continue/sharp_right_name.json
@@ -8,7 +8,7 @@
     },
     "instructions": {
         "de": "Scharf rechts weiterfahren auf Way Name",
-        "en": "Continue sharp right onto Way Name",
+        "en": "Continue sharp right to stay on Way Name",
         "es": "Continúe cerrada a la derecha en Way Name",
         "fr": "Continuer franchement à droite sur Way Name",
         "id": "Terus tajam kanan ke Way Name",

--- a/test/fixtures/v5/continue/slight_left_exit.json
+++ b/test/fixtures/v5/continue/slight_left_exit.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Leicht links weiter auf Way Name",
-        "en": "Continue slightly left onto Way Name",
+        "en": "Continue slightly left to stay on Way Name",
         "es": "Continúe ligeramente a la izquierda en Way Name",
         "fr": "Continuer légèrement à gauche sur Way Name",
         "id": "Tetap agak di kiri ke Way Name",

--- a/test/fixtures/v5/continue/slight_left_name.json
+++ b/test/fixtures/v5/continue/slight_left_name.json
@@ -8,7 +8,7 @@
     },
     "instructions": {
         "de": "Leicht links weiter auf Way Name",
-        "en": "Continue slightly left onto Way Name",
+        "en": "Continue slightly left to stay on Way Name",
         "es": "Continúe ligeramente a la izquierda en Way Name",
         "fr": "Continuer légèrement à gauche sur Way Name",
         "id": "Tetap agak di kiri ke Way Name",

--- a/test/fixtures/v5/continue/slight_right_exit.json
+++ b/test/fixtures/v5/continue/slight_right_exit.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Leicht rechts weiter auf Way Name",
-        "en": "Continue slightly right onto Way Name",
+        "en": "Continue slightly right to stay on Way Name",
         "es": "Continúe ligeramente a la derecha en Way Name",
         "fr": "Continuer légèrement à droite sur Way Name",
         "id": "Tetap agak di kanan ke Way Name",

--- a/test/fixtures/v5/continue/slight_right_name.json
+++ b/test/fixtures/v5/continue/slight_right_name.json
@@ -8,7 +8,7 @@
     },
     "instructions": {
         "de": "Leicht rechts weiter auf Way Name",
-        "en": "Continue slightly right onto Way Name",
+        "en": "Continue slightly right to stay on Way Name",
         "es": "Continúe ligeramente a la derecha en Way Name",
         "fr": "Continuer légèrement à droite sur Way Name",
         "id": "Tetap agak di kanan ke Way Name",

--- a/test/fixtures/v5/continue/straight_exit.json
+++ b/test/fixtures/v5/continue/straight_exit.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Geradeaus weiterfahren auf Way Name",
-        "en": "Continue onto Way Name",
+        "en": "Continue straight to stay on Way Name",
         "es": "Continúe en Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "id": "Terus ke Way Name",

--- a/test/fixtures/v5/continue/straight_name.json
+++ b/test/fixtures/v5/continue/straight_name.json
@@ -8,7 +8,7 @@
     },
     "instructions": {
         "de": "Geradeaus weiterfahren auf Way Name",
-        "en": "Continue onto Way Name",
+        "en": "Continue straight to stay on Way Name",
         "es": "Continúe en Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "id": "Terus ke Way Name",

--- a/test/fixtures/v5/continue/uturn_exit.json
+++ b/test/fixtures/v5/continue/uturn_exit.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "180°-Wendung auf Way Name",
-        "en": "Make a U-turn onto Way Name",
+        "en": "Make a U-turn and continue on Way Name",
         "es": "Haz un cambio de sentido en Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "id": "Putar balik ke arah Way Name",

--- a/test/fixtures/v5/continue/uturn_name.json
+++ b/test/fixtures/v5/continue/uturn_name.json
@@ -8,7 +8,7 @@
     },
     "instructions": {
         "de": "180°-Wendung auf Way Name",
-        "en": "Make a U-turn onto Way Name",
+        "en": "Make a U-turn and continue on Way Name",
         "es": "Haz un cambio de sentido en Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "id": "Putar balik ke arah Way Name",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_left.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Links weiterfahren auf Cool highway",
-        "en": "Continue left onto Cool highway",
+        "en": "Continue left to stay on Cool highway",
         "es": "Continúe izquierda en Cool highway",
         "fr": "Continuer à gauche sur Cool highway",
         "id": "Terus kiri ke Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_right.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Rechts weiterfahren auf Cool highway",
-        "en": "Continue right onto Cool highway",
+        "en": "Continue right to stay on Cool highway",
         "es": "Continúe derecha en Cool highway",
         "fr": "Continuer à droite sur Cool highway",
         "id": "Terus kanan ke Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_sharp left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_sharp left.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Scharf links weiterfahren auf Cool highway",
-        "en": "Continue sharp left onto Cool highway",
+        "en": "Continue sharp left to stay on Cool highway",
         "es": "Continúe cerrada a la izquierda en Cool highway",
         "fr": "Continuer franchement à gauche sur Cool highway",
         "id": "Terus tajam kiri ke Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_sharp right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_sharp right.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Scharf rechts weiterfahren auf Cool highway",
-        "en": "Continue sharp right onto Cool highway",
+        "en": "Continue sharp right to stay on Cool highway",
         "es": "Continúe cerrada a la derecha en Cool highway",
         "fr": "Continuer franchement à droite sur Cool highway",
         "id": "Terus tajam kanan ke Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_slight left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_slight left.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Leicht links weiter auf Cool highway",
-        "en": "Continue slightly left onto Cool highway",
+        "en": "Continue slightly left to stay on Cool highway",
         "es": "Continúe ligeramente a la izquierda en Cool highway",
         "fr": "Continuer légèrement à gauche sur Cool highway",
         "id": "Tetap agak di kiri ke Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_slight right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_slight right.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Leicht rechts weiter auf Cool highway",
-        "en": "Continue slightly right onto Cool highway",
+        "en": "Continue slightly right to stay on Cool highway",
         "es": "Continúe ligeramente a la derecha en Cool highway",
         "fr": "Continuer légèrement à droite sur Cool highway",
         "id": "Tetap agak di kanan ke Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_straight.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_straight.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Geradeaus weiterfahren auf Cool highway",
-        "en": "Continue onto Cool highway",
+        "en": "Continue straight to stay on Cool highway",
         "es": "Continúe en Cool highway",
         "fr": "Continuer tout droit sur Cool highway",
         "id": "Terus ke Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_uturn.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_uturn.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "180°-Wendung auf Cool highway",
-        "en": "Make a U-turn onto Cool highway",
+        "en": "Make a U-turn and continue on Cool highway",
         "es": "Haz un cambio de sentido en Cool highway",
         "fr": "Faire demi-tour sur Cool highway",
         "id": "Putar balik ke arah Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_number_left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_left.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Links weiterfahren auf Ref1",
-        "en": "Continue left onto Ref1",
+        "en": "Continue left to stay on Ref1",
         "es": "Continúe izquierda en Ref1",
         "fr": "Continuer à gauche sur Ref1",
         "id": "Terus kiri ke Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_right.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Rechts weiterfahren auf Ref1",
-        "en": "Continue right onto Ref1",
+        "en": "Continue right to stay on Ref1",
         "es": "Continúe derecha en Ref1",
         "fr": "Continuer à droite sur Ref1",
         "id": "Terus kanan ke Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_sharp left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_sharp left.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Scharf links weiterfahren auf Ref1",
-        "en": "Continue sharp left onto Ref1",
+        "en": "Continue sharp left to stay on Ref1",
         "es": "Continúe cerrada a la izquierda en Ref1",
         "fr": "Continuer franchement à gauche sur Ref1",
         "id": "Terus tajam kiri ke Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_sharp right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_sharp right.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Scharf rechts weiterfahren auf Ref1",
-        "en": "Continue sharp right onto Ref1",
+        "en": "Continue sharp right to stay on Ref1",
         "es": "Continúe cerrada a la derecha en Ref1",
         "fr": "Continuer franchement à droite sur Ref1",
         "id": "Terus tajam kanan ke Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_slight left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_slight left.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Leicht links weiter auf Ref1",
-        "en": "Continue slightly left onto Ref1",
+        "en": "Continue slightly left to stay on Ref1",
         "es": "Continúe ligeramente a la izquierda en Ref1",
         "fr": "Continuer légèrement à gauche sur Ref1",
         "id": "Tetap agak di kiri ke Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_slight right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_slight right.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Leicht rechts weiter auf Ref1",
-        "en": "Continue slightly right onto Ref1",
+        "en": "Continue slightly right to stay on Ref1",
         "es": "Continúe ligeramente a la derecha en Ref1",
         "fr": "Continuer légèrement à droite sur Ref1",
         "id": "Tetap agak di kanan ke Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_straight.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_straight.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Geradeaus weiterfahren auf Ref1",
-        "en": "Continue onto Ref1",
+        "en": "Continue straight to stay on Ref1",
         "es": "Continúe en Ref1",
         "fr": "Continuer tout droit sur Ref1",
         "id": "Terus ke Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_uturn.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_uturn.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "180°-Wendung auf Ref1",
-        "en": "Make a U-turn onto Ref1",
+        "en": "Make a U-turn and continue on Ref1",
         "es": "Haz un cambio de sentido en Ref1",
         "fr": "Faire demi-tour sur Ref1",
         "id": "Putar balik ke arah Ref1",

--- a/test/fixtures/v5/other/way_name_class_ferry_left.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_left.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Links weiterfahren auf Cool highway (Ref1)",
-        "en": "Continue left onto Cool highway (Ref1)",
+        "en": "Continue left to stay on Cool highway (Ref1)",
         "es": "Continúe izquierda en Cool highway (Ref1)",
         "fr": "Continuer à gauche sur Cool highway (Ref1)",
         "id": "Terus kiri ke Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_right.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_right.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Rechts weiterfahren auf Cool highway (Ref1)",
-        "en": "Continue right onto Cool highway (Ref1)",
+        "en": "Continue right to stay on Cool highway (Ref1)",
         "es": "Continúe derecha en Cool highway (Ref1)",
         "fr": "Continuer à droite sur Cool highway (Ref1)",
         "id": "Terus kanan ke Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_sharp left.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_sharp left.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Scharf links weiterfahren auf Cool highway (Ref1)",
-        "en": "Continue sharp left onto Cool highway (Ref1)",
+        "en": "Continue sharp left to stay on Cool highway (Ref1)",
         "es": "Continúe cerrada a la izquierda en Cool highway (Ref1)",
         "fr": "Continuer franchement à gauche sur Cool highway (Ref1)",
         "id": "Terus tajam kiri ke Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_sharp right.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_sharp right.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Scharf rechts weiterfahren auf Cool highway (Ref1)",
-        "en": "Continue sharp right onto Cool highway (Ref1)",
+        "en": "Continue sharp right to stay on Cool highway (Ref1)",
         "es": "Continúe cerrada a la derecha en Cool highway (Ref1)",
         "fr": "Continuer franchement à droite sur Cool highway (Ref1)",
         "id": "Terus tajam kanan ke Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_slight left.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_slight left.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Leicht links weiter auf Cool highway (Ref1)",
-        "en": "Continue slightly left onto Cool highway (Ref1)",
+        "en": "Continue slightly left to stay on Cool highway (Ref1)",
         "es": "Continúe ligeramente a la izquierda en Cool highway (Ref1)",
         "fr": "Continuer légèrement à gauche sur Cool highway (Ref1)",
         "id": "Tetap agak di kiri ke Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_slight right.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_slight right.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Leicht rechts weiter auf Cool highway (Ref1)",
-        "en": "Continue slightly right onto Cool highway (Ref1)",
+        "en": "Continue slightly right to stay on Cool highway (Ref1)",
         "es": "Continúe ligeramente a la derecha en Cool highway (Ref1)",
         "fr": "Continuer légèrement à droite sur Cool highway (Ref1)",
         "id": "Tetap agak di kanan ke Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_straight.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_straight.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Geradeaus weiterfahren auf Cool highway (Ref1)",
-        "en": "Continue onto Cool highway (Ref1)",
+        "en": "Continue straight to stay on Cool highway (Ref1)",
         "es": "Continúe en Cool highway (Ref1)",
         "fr": "Continuer tout droit sur Cool highway (Ref1)",
         "id": "Terus ke Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_uturn.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_uturn.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "180°-Wendung auf Cool highway (Ref1)",
-        "en": "Make a U-turn onto Cool highway (Ref1)",
+        "en": "Make a U-turn and continue on Cool highway (Ref1)",
         "es": "Haz un cambio de sentido en Cool highway (Ref1)",
         "fr": "Faire demi-tour sur Cool highway (Ref1)",
         "id": "Putar balik ke arah Cool highway (Ref1)",


### PR DESCRIPTION
# Issue

Closes #41 -- rephrases instruction from "continue onto" to "continue to stay on" when continuing. Note that I added a special condition for exits.

## Tasklist

 - [x] update language in `en.json`
 - [x] Add changelog entry
 - [ ] Test with osrm-frontend (?)
 - [ ] Review by @willwhite and/or @bsudekum and/or @1ec5? (not sure who to tag here) 