### PR TITLE
Add commas to linked phrases

### DIFF
--- a/languages/translations/en.json
+++ b/languages/translations/en.json
@@ -51,8 +51,8 @@
             }
         },
         "phrase": {
-            "two linked by distance": "{instruction_one} then in {distance} {instruction_two}",
-            "two linked": "{instruction_one} then {instruction_two}",
+            "two linked by distance": "{instruction_one}, then in {distance}, {instruction_two}",
+            "two linked": "{instruction_one}, then {instruction_two}",
             "one in distance": "In {distance}, {instruction_one}",
             "name and ref": "{name} ({ref})"
         },

--- a/languages/translations/en.json
+++ b/languages/translations/en.json
@@ -51,7 +51,7 @@
             }
         },
         "phrase": {
-            "two linked by distance": "{instruction_one}, then in {distance}, {instruction_two}",
+            "two linked by distance": "{instruction_one}, then, in {distance}, {instruction_two}",
             "two linked": "{instruction_one}, then {instruction_two}",
             "one in distance": "In {distance}, {instruction_one}",
             "name and ref": "{name} ({ref})"

--- a/test/fixtures/v5/phrase/two_linked.json
+++ b/test/fixtures/v5/phrase/two_linked.json
@@ -5,7 +5,7 @@
     },
     "phrases": {
         "de": "Do this danach Do that",
-        "en": "Do this then Do that",
+        "en": "Do this, then Do that",
         "es": "Do this, entonces Do that",
         "fr": "Do this then Do that",
         "id": "Do this then Do that",

--- a/test/fixtures/v5/phrase/two_linked_by_distance.json
+++ b/test/fixtures/v5/phrase/two_linked_by_distance.json
@@ -6,7 +6,7 @@
     },
     "phrases": {
         "de": "Do this danach in 0 units Do that",
-        "en": "Do this then in 0 units Do that",
+        "en": "Do this, then in 0 units, Do that",
         "es": "Do this, entonces a 0 units, Do that",
         "fr": "Do this then in 0 units Do that",
         "id": "Do this then in 0 units Do that",

--- a/test/fixtures/v5/phrase/two_linked_by_distance.json
+++ b/test/fixtures/v5/phrase/two_linked_by_distance.json
@@ -6,7 +6,7 @@
     },
     "phrases": {
         "de": "Do this danach in 0 units Do that",
-        "en": "Do this, then in 0 units, Do that",
+        "en": "Do this, then, in 0 units, Do that",
         "es": "Do this, entonces a 0 units, Do that",
         "fr": "Do this then in 0 units Do that",
         "id": "Do this then in 0 units Do that",


### PR DESCRIPTION
Added commas to the linked phrase strings, for a more natural cadence and consistency with the iOS navigation SDK:

https://github.com/mapbox/mapbox-navigation-ios/blob/447ccaa73d4e1d8a7578e40d86cb5e59df5f2d56/MapboxCoreNavigation/Resources/Base.lproj/Localizable.strings#L7-L11

Once #146 lands, the stub translations and test fixtures will need to be updated.

/cc @mcwhittemore @lyzidiamond