### PR TITLE
Make parentheses around ref localizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. For change 
 - Adds `phrase` types to the English localiztion. [#141](https://github.com/Project-OSRM/osrm-text-instructions/pull/141)
 - Adds `distance`, `name` and `namedistance` options to the continue and continue straight instructions. [#141](https://github.com/Project-OSRM/osrm-text-instructions/pull/141)
 - Adds `tokenize` to the top level api so that external users can fill in osrm-text-instructions template strings. [#141](https://github.com/Project-OSRM/osrm-text-instructions/pull/141)
+- Made the format of name-and-ref combinations localizable. [#148](https://github.com/Project-OSRM/osrm-text-instructions/pull/141)
 
 # 0.5.4 2017-09-06
 

--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ module.exports = function(version, _options) {
             }
 
             if (name && ref && name !== ref && !wayMotorway) {
-                let phrase = instructions[language][version].phrase['name and ref'] ||
+                var phrase = instructions[language][version].phrase['name and ref'] ||
                     instructions.en[version].phrase['name and ref'];
                 wayName = this.tokenize(phrase, {
                     name: name,

--- a/index.js
+++ b/index.js
@@ -148,7 +148,12 @@ module.exports = function(version, _options) {
             }
 
             if (name && ref && name !== ref && !wayMotorway) {
-                wayName = name + ' (' + ref + ')';
+                let phrase = instructions[language][version].phrase['name and ref'] ||
+                    instructions.en[version].phrase['name and ref'];
+                wayName = this.tokenize(phrase, {
+                    name: name,
+                    ref: ref
+                }, language);
             } else if (name && ref && wayMotorway && (/\d/).test(ref)) {
                 wayName = ref;
             } else if (!name && ref) {

--- a/languages/translations/en.json
+++ b/languages/translations/en.json
@@ -53,7 +53,8 @@
         "phrase": {
             "two linked by distance": "{instruction_one} then in {distance} {instruction_two}",
             "two linked": "{instruction_one} then {instruction_two}",
-            "one in distance": "In {distance}, {instruction_one}"
+            "one in distance": "In {distance}, {instruction_one}",
+            "name and ref": "{name} ({ref})"
         },
         "arrive": {
             "default": {


### PR DESCRIPTION
Added a format string for a name-ref combination, [for consistency with the iOS navigation SDK](https://github.com/mapbox/mapbox-navigation-ios/blob/447ccaa73d4e1d8a7578e40d86cb5e59df5f2d56/MapboxCoreNavigation/Resources/Base.lproj/Localizable.strings#L14).

This string is primarily meant for display. For example, Chinese uses different characters for the parentheses. However, it may affect speech synthesis in some text-to-speech engines. I’m open to moving the string to a different section of the translations file than `phrase`.

Fixes #131.

/cc @mcwhittemore @bsudekum