### PR TITLE
Swap arguments to tokenize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
+# master
+
+- `language` is now the first argument of `tokenize` instead of the last. [#149](https://github.com/Project-OSRM/osrm-text-instructions/pull/149)
+
 # 0.6.1
 
 - Updates `continue` maneuvers in en to read as turns when the road you are staying on turns at the intersection. [#145](https://github.com/Project-OSRM/osrm-text-instructions/pull/145)

--- a/index.js
+++ b/index.js
@@ -192,9 +192,9 @@ module.exports = function(version, _options) {
                 'nth': nthWaypoint
             };
 
-            return this.tokenize(instruction, replaceTokens, language);
+            return this.tokenize(language, instruction, replaceTokens);
         },
-        tokenize: function(instruction, tokens, language) {
+        tokenize: function(language, instruction, tokens) {
             var output =  Object.keys(tokens).reduce(function(memo, token) {
                 return memo.replace('{' + token + '}', tokens[token]);
             }, instruction)

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -9,27 +9,27 @@ tape.test('v5 tokenize', function(assert) {
 
     var tokenString = 'Can {first} {second}';
 
-    var hasBoth = v5Instructions.tokenize(tokenString, {
+    var hasBoth = v5Instructions.tokenize('en', tokenString, {
         first: 'osrm',
         second: 'do routing'
-    }, 'en');
+    });
     assert.equal(hasBoth, 'Can osrm do routing', 'does find and replace');
 
-    var hasFirst = v5Instructions.tokenize(tokenString, {
+    var hasFirst = v5Instructions.tokenize('en', tokenString, {
         first: 'osrm',
         second: ''
-    }, 'en');
+    });
     assert.equal(hasFirst, 'Can osrm ', 'does find and replace and does not drop trailing spaces');
 
-    var hasSecond = v5Instructions.tokenize(tokenString, {
+    var hasSecond = v5Instructions.tokenize('en', tokenString, {
         second: 'swim',
         first: ''
-    }, 'en');
+    });
     assert.equal(hasSecond, 'Can swim', 'does find and replace and drops internal extra spaces');
 
-    var missingSecond = v5Instructions.tokenize(tokenString, {
+    var missingSecond = v5Instructions.tokenize('en', tokenString, {
         first: 'osrm'
-    }, 'en');
+    });
     assert.equal(missingSecond, 'Can osrm {second}', 'does not replace tokens which are not provided');
 
 


### PR DESCRIPTION
For consistency with `compile()`, let’s have `language` be the first argument instead of the last. It reads better this way anyhow: since `tokens` is often an inline object literal, it’s easy to forget to specify the language afterwards.

/ref https://github.com/Project-OSRM/osrm-text-instructions/pull/146#issuecomment-328217729
/cc @mcwhittemore