### PR TITLE
Add exit rotary/roundabout

### DIFF
--- a/test/constants.js
+++ b/test/constants.js
@@ -14,6 +14,8 @@ constants.types = [
     'rotary',
     'roundabout',
     'roundabout turn',
+    'exit roundabout',
+    'exit rotary',
     'turn',
     'use lane'
 ];

--- a/test/fixtures/v5/exit_rotary/left_default.json
+++ b/test/fixtures/v5/exit_rotary/left_default.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "left"
+        },
+        "name": ""
+    },
+    "instructions": {
+        "de": "Links abbiegen",
+        "en": "Turn left",
+        "es": "Gire a la izquierda",
+        "fr": "Tourner à gauche",
+        "id": "Belok kiri",
+        "it": "Svolta a sinistra",
+        "nl": "Ga linksaf",
+        "pl": "Skręć w lewo",
+        "pt-BR": "Vire à esquerda",
+        "ru": "Поверните налево",
+        "sv": "Sväng vänster",
+        "uk": "Поверніть ліворуч",
+        "vi": "Quẹo trái",
+        "zh-Hans": "左转"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/left_destination.json
+++ b/test/fixtures/v5/exit_rotary/left_destination.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2"
+    },
+    "instructions": {
+        "de": "Links abbiegen Richtung Destination 1",
+        "en": "Turn left towards Destination 1",
+        "es": "Gire a la izquierda hacia Destination 1",
+        "fr": "Tourner à gauche en direction de Destination 1",
+        "id": "Belok kiri menuju Destination 1",
+        "it": "Svolta a sinistra verso Destination 1",
+        "nl": "Ga linksaf richting Destination 1",
+        "pl": "Skręć w lewo w kierunku Destination 1",
+        "pt-BR": "Vire à esquerda sentido Destination 1",
+        "ru": "Поверните налево в направлении Destination 1",
+        "sv": "Sväng vänster mot Destination 1",
+        "uk": "Поверніть ліворуч у напрямку Destination 1",
+        "vi": "Quẹo trái đến Destination 1",
+        "zh-Hans": "左转，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/left_exit.json
+++ b/test/fixtures/v5/exit_rotary/left_exit.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Links abbiegen auf Way Name",
+        "en": "Turn left onto Way Name",
+        "es": "Gire a la izquierda en Way Name",
+        "fr": "Tourner à gauche sur Way Name",
+        "id": "Belok kiri ke Way Name",
+        "it": "Svolta a sinistra in Way Name",
+        "nl": "Ga linksaf naar Way Name",
+        "pl": "Skręć w lewo na Way Name",
+        "pt-BR": "Vire à esquerda em Way Name",
+        "ru": "Поверните налево на Way Name",
+        "sv": "Sväng vänster in på Way Name",
+        "uk": "Поверніть ліворуч на Way Name",
+        "vi": "Quẹo trái vào Way Name",
+        "zh-Hans": "左转，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/left_exit_destination.json
@@ -1,0 +1,27 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Links abbiegen Richtung Destination 1",
+        "en": "Turn left towards Destination 1",
+        "es": "Gire a la izquierda hacia Destination 1",
+        "fr": "Tourner à gauche en direction de Destination 1",
+        "id": "Belok kiri menuju Destination 1",
+        "it": "Svolta a sinistra verso Destination 1",
+        "nl": "Ga linksaf richting Destination 1",
+        "pl": "Skręć w lewo w kierunku Destination 1",
+        "pt-BR": "Vire à esquerda sentido Destination 1",
+        "ru": "Поверните налево в направлении Destination 1",
+        "sv": "Sväng vänster mot Destination 1",
+        "uk": "Поверніть ліворуч у напрямку Destination 1",
+        "vi": "Quẹo trái đến Destination 1",
+        "zh-Hans": "左转，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/left_name.json
+++ b/test/fixtures/v5/exit_rotary/left_name.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "left"
+        },
+        "name": "Way Name"
+    },
+    "instructions": {
+        "de": "Links abbiegen auf Way Name",
+        "en": "Turn left onto Way Name",
+        "es": "Gire a la izquierda en Way Name",
+        "fr": "Tourner à gauche sur Way Name",
+        "id": "Belok kiri ke Way Name",
+        "it": "Svolta a sinistra in Way Name",
+        "nl": "Ga linksaf naar Way Name",
+        "pl": "Skręć w lewo na Way Name",
+        "pt-BR": "Vire à esquerda em Way Name",
+        "ru": "Поверните налево на Way Name",
+        "sv": "Sväng vänster in på Way Name",
+        "uk": "Поверніть ліворуч на Way Name",
+        "vi": "Quẹo trái vào Way Name",
+        "zh-Hans": "左转，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/right_default.json
+++ b/test/fixtures/v5/exit_rotary/right_default.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "right"
+        },
+        "name": ""
+    },
+    "instructions": {
+        "de": "Rechts abbiegen",
+        "en": "Turn right",
+        "es": "Gire a la derecha",
+        "fr": "Tourner à droite",
+        "id": "Belok kanan",
+        "it": "Gira a destra",
+        "nl": "Ga rechtsaf",
+        "pl": "Skręć w prawo",
+        "pt-BR": "Vire à direita",
+        "ru": "Поверните направо",
+        "sv": "Sväng höger",
+        "uk": "Поверніть праворуч",
+        "vi": "Quẹo phải",
+        "zh-Hans": "右转"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/right_destination.json
+++ b/test/fixtures/v5/exit_rotary/right_destination.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2"
+    },
+    "instructions": {
+        "de": "Rechts abbiegen Richtung Destination 1",
+        "en": "Turn right towards Destination 1",
+        "es": "Gire a la derecha hacia Destination 1",
+        "fr": "Tourner à droite en direction de Destination 1",
+        "id": "Belok kanan menuju Destination 1",
+        "it": "Svolta a destra verso Destination 1",
+        "nl": "Ga rechtsaf richting Destination 1",
+        "pl": "Skręć w prawo w kierunku Destination 1",
+        "pt-BR": "Vire à direita sentido Destination 1",
+        "ru": "Поверните направо в направлении Destination 1",
+        "sv": "Sväng höger mot Destination 1",
+        "uk": "Поверніть праворуч у напрямку Destination 1",
+        "vi": "Quẹo phải đến Destination 1",
+        "zh-Hans": "右转，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/right_exit.json
+++ b/test/fixtures/v5/exit_rotary/right_exit.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Rechts abbiegen auf Way Name",
+        "en": "Turn right onto Way Name",
+        "es": "Gire a la derecha en Way Name",
+        "fr": "Tourner à droite sur Way Name",
+        "id": "Belok kanan ke Way Name",
+        "it": "Svolta a destra in Way Name",
+        "nl": "Ga rechtsaf naar Way Name",
+        "pl": "Skręć w prawo na Way Name",
+        "pt-BR": "Vire à direita em Way Name",
+        "ru": "Поверните направо на Way Name",
+        "sv": "Sväng höger in på Way Name",
+        "uk": "Поверніть праворуч на Way Name",
+        "vi": "Quẹo phải vào Way Name",
+        "zh-Hans": "右转，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/right_exit_destination.json
@@ -1,0 +1,27 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Rechts abbiegen Richtung Destination 1",
+        "en": "Turn right towards Destination 1",
+        "es": "Gire a la derecha hacia Destination 1",
+        "fr": "Tourner à droite en direction de Destination 1",
+        "id": "Belok kanan menuju Destination 1",
+        "it": "Svolta a destra verso Destination 1",
+        "nl": "Ga rechtsaf richting Destination 1",
+        "pl": "Skręć w prawo w kierunku Destination 1",
+        "pt-BR": "Vire à direita sentido Destination 1",
+        "ru": "Поверните направо в направлении Destination 1",
+        "sv": "Sväng höger mot Destination 1",
+        "uk": "Поверніть праворуч у напрямку Destination 1",
+        "vi": "Quẹo phải đến Destination 1",
+        "zh-Hans": "右转，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/right_name.json
+++ b/test/fixtures/v5/exit_rotary/right_name.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "right"
+        },
+        "name": "Way Name"
+    },
+    "instructions": {
+        "de": "Rechts abbiegen auf Way Name",
+        "en": "Turn right onto Way Name",
+        "es": "Gire a la derecha en Way Name",
+        "fr": "Tourner à droite sur Way Name",
+        "id": "Belok kanan ke Way Name",
+        "it": "Svolta a destra in Way Name",
+        "nl": "Ga rechtsaf naar Way Name",
+        "pl": "Skręć w prawo na Way Name",
+        "pt-BR": "Vire à direita em Way Name",
+        "ru": "Поверните направо на Way Name",
+        "sv": "Sväng höger in på Way Name",
+        "uk": "Поверніть праворуч на Way Name",
+        "vi": "Quẹo phải vào Way Name",
+        "zh-Hans": "右转，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/sharp_left_default.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_default.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "sharp left"
+        },
+        "name": ""
+    },
+    "instructions": {
+        "de": "Scharf links abbiegen",
+        "en": "Make a sharp left",
+        "es": "Siga cerrada a la izquierda",
+        "fr": "Tourner franchement à gauche",
+        "id": "Lakukan tajam kiri",
+        "it": "Fai una sinistra",
+        "nl": "Ga linksaf",
+        "pl": "Ostro w lewo",
+        "pt-BR": "Siga acentuadamente à esquerda",
+        "ru": "Двигайтесь налево",
+        "sv": "Sväng vänster",
+        "uk": "Рухайтесь різко ліворуч",
+        "vi": "Quẹo trái gắt",
+        "zh-Hans": "向左转弯"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/sharp_left_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_destination.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2"
+    },
+    "instructions": {
+        "de": "Scharf links abbiegen Richtung Destination 1",
+        "en": "Make a sharp left towards Destination 1",
+        "es": "Siga cerrada a la izquierda hacia Destination 1",
+        "fr": "Tourner franchement à gauche en direction de Destination 1",
+        "id": "Lakukan tajam kiri menuju Destination 1",
+        "it": "Fai una sinistra verso Destination 1",
+        "nl": "Ga linksaf richting Destination 1",
+        "pl": "Ostro w lewo w kierunku Destination 1",
+        "pt-BR": "Siga acentuadamente à esquerda sentido Destination 1",
+        "ru": "Двигайтесь налево в направлении Destination 1",
+        "sv": "Sväng vänster mot Destination 1",
+        "uk": "Рухайтесь різко ліворуч в напрямку Destination 1",
+        "vi": "Quẹo trái gắt đến Destination 1",
+        "zh-Hans": "向左转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/sharp_left_exit.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_exit.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Scharf links abbiegen auf Way Name",
+        "en": "Make a sharp left onto Way Name",
+        "es": "Siga cerrada a la izquierda en Way Name",
+        "fr": "Tourner franchement à gauche sur Way Name",
+        "id": "Lakukan tajam kiri ke arah Way Name",
+        "it": "Fai una sinistra in Way Name",
+        "nl": "Ga linksaf naar Way Name",
+        "pl": "Ostro w lewo na Way Name",
+        "pt-BR": "Siga acentuadamente à esquerda em Way Name",
+        "ru": "Двигайтесь налево на Way Name",
+        "sv": "Sväng vänster in på Way Name",
+        "uk": "Рухайтесь різко ліворуч на Way Name",
+        "vi": "Quẹo trái gắt vào Way Name",
+        "zh-Hans": "向左转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_exit_destination.json
@@ -1,0 +1,27 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Scharf links abbiegen Richtung Destination 1",
+        "en": "Make a sharp left towards Destination 1",
+        "es": "Siga cerrada a la izquierda hacia Destination 1",
+        "fr": "Tourner franchement à gauche en direction de Destination 1",
+        "id": "Lakukan tajam kiri menuju Destination 1",
+        "it": "Fai una sinistra verso Destination 1",
+        "nl": "Ga linksaf richting Destination 1",
+        "pl": "Ostro w lewo w kierunku Destination 1",
+        "pt-BR": "Siga acentuadamente à esquerda sentido Destination 1",
+        "ru": "Двигайтесь налево в направлении Destination 1",
+        "sv": "Sväng vänster mot Destination 1",
+        "uk": "Рухайтесь різко ліворуч в напрямку Destination 1",
+        "vi": "Quẹo trái gắt đến Destination 1",
+        "zh-Hans": "向左转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/sharp_left_name.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_name.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name"
+    },
+    "instructions": {
+        "de": "Scharf links abbiegen auf Way Name",
+        "en": "Make a sharp left onto Way Name",
+        "es": "Siga cerrada a la izquierda en Way Name",
+        "fr": "Tourner franchement à gauche sur Way Name",
+        "id": "Lakukan tajam kiri ke arah Way Name",
+        "it": "Fai una sinistra in Way Name",
+        "nl": "Ga linksaf naar Way Name",
+        "pl": "Ostro w lewo na Way Name",
+        "pt-BR": "Siga acentuadamente à esquerda em Way Name",
+        "ru": "Двигайтесь налево на Way Name",
+        "sv": "Sväng vänster in på Way Name",
+        "uk": "Рухайтесь різко ліворуч на Way Name",
+        "vi": "Quẹo trái gắt vào Way Name",
+        "zh-Hans": "向左转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/sharp_right_default.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_default.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "sharp right"
+        },
+        "name": ""
+    },
+    "instructions": {
+        "de": "Scharf rechts abbiegen",
+        "en": "Make a sharp right",
+        "es": "Siga cerrada a la derecha",
+        "fr": "Tourner franchement à droite",
+        "id": "Lakukan tajam kanan",
+        "it": "Fai una destra",
+        "nl": "Ga rechtsaf",
+        "pl": "Ostro w prawo",
+        "pt-BR": "Siga acentuadamente à direita",
+        "ru": "Двигайтесь направо",
+        "sv": "Sväng höger",
+        "uk": "Рухайтесь різко праворуч",
+        "vi": "Quẹo phải gắt",
+        "zh-Hans": "向右转弯"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/sharp_right_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_destination.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2"
+    },
+    "instructions": {
+        "de": "Scharf rechts abbiegen Richtung Destination 1",
+        "en": "Make a sharp right towards Destination 1",
+        "es": "Siga cerrada a la derecha hacia Destination 1",
+        "fr": "Tourner franchement à droite en direction de Destination 1",
+        "id": "Lakukan tajam kanan menuju Destination 1",
+        "it": "Fai una destra verso Destination 1",
+        "nl": "Ga rechtsaf richting Destination 1",
+        "pl": "Ostro w prawo w kierunku Destination 1",
+        "pt-BR": "Siga acentuadamente à direita sentido Destination 1",
+        "ru": "Двигайтесь направо в направлении Destination 1",
+        "sv": "Sväng höger mot Destination 1",
+        "uk": "Рухайтесь різко праворуч в напрямку Destination 1",
+        "vi": "Quẹo phải gắt đến Destination 1",
+        "zh-Hans": "向右转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/sharp_right_exit.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_exit.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts abbiegen auf Way Name",
+        "en": "Make a sharp right onto Way Name",
+        "es": "Siga cerrada a la derecha en Way Name",
+        "fr": "Tourner franchement à droite sur Way Name",
+        "id": "Lakukan tajam kanan ke arah Way Name",
+        "it": "Fai una destra in Way Name",
+        "nl": "Ga rechtsaf naar Way Name",
+        "pl": "Ostro w prawo na Way Name",
+        "pt-BR": "Siga acentuadamente à direita em Way Name",
+        "ru": "Двигайтесь направо на Way Name",
+        "sv": "Sväng höger in på Way Name",
+        "uk": "Рухайтесь різко праворуч на Way Name",
+        "vi": "Quẹo phải gắt vào Way Name",
+        "zh-Hans": "向右转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_exit_destination.json
@@ -1,0 +1,27 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts abbiegen Richtung Destination 1",
+        "en": "Make a sharp right towards Destination 1",
+        "es": "Siga cerrada a la derecha hacia Destination 1",
+        "fr": "Tourner franchement à droite en direction de Destination 1",
+        "id": "Lakukan tajam kanan menuju Destination 1",
+        "it": "Fai una destra verso Destination 1",
+        "nl": "Ga rechtsaf richting Destination 1",
+        "pl": "Ostro w prawo w kierunku Destination 1",
+        "pt-BR": "Siga acentuadamente à direita sentido Destination 1",
+        "ru": "Двигайтесь направо в направлении Destination 1",
+        "sv": "Sväng höger mot Destination 1",
+        "uk": "Рухайтесь різко праворуч в напрямку Destination 1",
+        "vi": "Quẹo phải gắt đến Destination 1",
+        "zh-Hans": "向右转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/sharp_right_name.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_name.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name"
+    },
+    "instructions": {
+        "de": "Scharf rechts abbiegen auf Way Name",
+        "en": "Make a sharp right onto Way Name",
+        "es": "Siga cerrada a la derecha en Way Name",
+        "fr": "Tourner franchement à droite sur Way Name",
+        "id": "Lakukan tajam kanan ke arah Way Name",
+        "it": "Fai una destra in Way Name",
+        "nl": "Ga rechtsaf naar Way Name",
+        "pl": "Ostro w prawo na Way Name",
+        "pt-BR": "Siga acentuadamente à direita em Way Name",
+        "ru": "Двигайтесь направо на Way Name",
+        "sv": "Sväng höger in på Way Name",
+        "uk": "Рухайтесь різко праворуч на Way Name",
+        "vi": "Quẹo phải gắt vào Way Name",
+        "zh-Hans": "向右转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/slight_left_default.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_default.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "slight left"
+        },
+        "name": ""
+    },
+    "instructions": {
+        "de": "Leicht links abbiegen",
+        "en": "Make a slight left",
+        "es": "Siga ligeramente a la izquierda",
+        "fr": "Tourner légèrement à gauche",
+        "id": "Lakukan agak ke kiri",
+        "it": "Fai una sinistra leggermente",
+        "nl": "Ga links",
+        "pl": "Łagodnie w lewo",
+        "pt-BR": "Siga ligeiramente à esquerda",
+        "ru": "Двигайтесь левее",
+        "sv": "Sväng vänster",
+        "uk": "Рухайтесь плавно ліворуч",
+        "vi": "Quẹo trái nghiêng",
+        "zh-Hans": "向左转弯"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/slight_left_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_destination.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2"
+    },
+    "instructions": {
+        "de": "Leicht links abbiegen Richtung Destination 1",
+        "en": "Make a slight left towards Destination 1",
+        "es": "Siga ligeramente a la izquierda hacia Destination 1",
+        "fr": "Tourner légèrement à gauche en direction de Destination 1",
+        "id": "Lakukan agak ke kiri menuju Destination 1",
+        "it": "Fai una sinistra leggermente verso Destination 1",
+        "nl": "Ga links richting Destination 1",
+        "pl": "Łagodnie w lewo w kierunku Destination 1",
+        "pt-BR": "Siga ligeiramente à esquerda sentido Destination 1",
+        "ru": "Двигайтесь левее в направлении Destination 1",
+        "sv": "Sväng vänster mot Destination 1",
+        "uk": "Рухайтесь плавно ліворуч в напрямку Destination 1",
+        "vi": "Quẹo trái nghiêng đến Destination 1",
+        "zh-Hans": "向左转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/slight_left_exit.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_exit.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Leicht links abbiegen auf Way Name",
+        "en": "Make a slight left onto Way Name",
+        "es": "Siga ligeramente a la izquierda en Way Name",
+        "fr": "Tourner légèrement à gauche sur Way Name",
+        "id": "Lakukan agak ke kiri ke arah Way Name",
+        "it": "Fai una sinistra leggermente in Way Name",
+        "nl": "Ga links naar Way Name",
+        "pl": "Łagodnie w lewo na Way Name",
+        "pt-BR": "Siga ligeiramente à esquerda em Way Name",
+        "ru": "Двигайтесь левее на Way Name",
+        "sv": "Sväng vänster in på Way Name",
+        "uk": "Рухайтесь плавно ліворуч на Way Name",
+        "vi": "Quẹo trái nghiêng vào Way Name",
+        "zh-Hans": "向左转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/slight_left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_exit_destination.json
@@ -1,0 +1,27 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Leicht links abbiegen Richtung Destination 1",
+        "en": "Make a slight left towards Destination 1",
+        "es": "Siga ligeramente a la izquierda hacia Destination 1",
+        "fr": "Tourner légèrement à gauche en direction de Destination 1",
+        "id": "Lakukan agak ke kiri menuju Destination 1",
+        "it": "Fai una sinistra leggermente verso Destination 1",
+        "nl": "Ga links richting Destination 1",
+        "pl": "Łagodnie w lewo w kierunku Destination 1",
+        "pt-BR": "Siga ligeiramente à esquerda sentido Destination 1",
+        "ru": "Двигайтесь левее в направлении Destination 1",
+        "sv": "Sväng vänster mot Destination 1",
+        "uk": "Рухайтесь плавно ліворуч в напрямку Destination 1",
+        "vi": "Quẹo trái nghiêng đến Destination 1",
+        "zh-Hans": "向左转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/slight_left_name.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_name.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "slight left"
+        },
+        "name": "Way Name"
+    },
+    "instructions": {
+        "de": "Leicht links abbiegen auf Way Name",
+        "en": "Make a slight left onto Way Name",
+        "es": "Siga ligeramente a la izquierda en Way Name",
+        "fr": "Tourner légèrement à gauche sur Way Name",
+        "id": "Lakukan agak ke kiri ke arah Way Name",
+        "it": "Fai una sinistra leggermente in Way Name",
+        "nl": "Ga links naar Way Name",
+        "pl": "Łagodnie w lewo na Way Name",
+        "pt-BR": "Siga ligeiramente à esquerda em Way Name",
+        "ru": "Двигайтесь левее на Way Name",
+        "sv": "Sväng vänster in på Way Name",
+        "uk": "Рухайтесь плавно ліворуч на Way Name",
+        "vi": "Quẹo trái nghiêng vào Way Name",
+        "zh-Hans": "向左转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/slight_right_default.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_default.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "slight right"
+        },
+        "name": ""
+    },
+    "instructions": {
+        "de": "Leicht rechts abbiegen",
+        "en": "Make a slight right",
+        "es": "Siga ligeramente a la derecha",
+        "fr": "Tourner légèrement à droite",
+        "id": "Lakukan agak ke kanan",
+        "it": "Fai una destra leggermente",
+        "nl": "Ga rechts",
+        "pl": "Łagodnie w prawo",
+        "pt-BR": "Siga ligeiramente à direita",
+        "ru": "Двигайтесь правее",
+        "sv": "Sväng höger",
+        "uk": "Рухайтесь плавно праворуч",
+        "vi": "Quẹo phải nghiêng",
+        "zh-Hans": "向右转弯"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/slight_right_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_destination.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2"
+    },
+    "instructions": {
+        "de": "Leicht rechts abbiegen Richtung Destination 1",
+        "en": "Make a slight right towards Destination 1",
+        "es": "Siga ligeramente a la derecha hacia Destination 1",
+        "fr": "Tourner légèrement à droite en direction de Destination 1",
+        "id": "Lakukan agak ke kanan menuju Destination 1",
+        "it": "Fai una destra leggermente verso Destination 1",
+        "nl": "Ga rechts richting Destination 1",
+        "pl": "Łagodnie w prawo w kierunku Destination 1",
+        "pt-BR": "Siga ligeiramente à direita sentido Destination 1",
+        "ru": "Двигайтесь правее в направлении Destination 1",
+        "sv": "Sväng höger mot Destination 1",
+        "uk": "Рухайтесь плавно праворуч в напрямку Destination 1",
+        "vi": "Quẹo phải nghiêng đến Destination 1",
+        "zh-Hans": "向右转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/slight_right_exit.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_exit.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Leicht rechts abbiegen auf Way Name",
+        "en": "Make a slight right onto Way Name",
+        "es": "Siga ligeramente a la derecha en Way Name",
+        "fr": "Tourner légèrement à droite sur Way Name",
+        "id": "Lakukan agak ke kanan ke arah Way Name",
+        "it": "Fai una destra leggermente in Way Name",
+        "nl": "Ga rechts naar Way Name",
+        "pl": "Łagodnie w prawo na Way Name",
+        "pt-BR": "Siga ligeiramente à direita em Way Name",
+        "ru": "Двигайтесь правее на Way Name",
+        "sv": "Sväng höger in på Way Name",
+        "uk": "Рухайтесь плавно праворуч на Way Name",
+        "vi": "Quẹo phải nghiêng vào Way Name",
+        "zh-Hans": "向右转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/slight_right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_exit_destination.json
@@ -1,0 +1,27 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Leicht rechts abbiegen Richtung Destination 1",
+        "en": "Make a slight right towards Destination 1",
+        "es": "Siga ligeramente a la derecha hacia Destination 1",
+        "fr": "Tourner légèrement à droite en direction de Destination 1",
+        "id": "Lakukan agak ke kanan menuju Destination 1",
+        "it": "Fai una destra leggermente verso Destination 1",
+        "nl": "Ga rechts richting Destination 1",
+        "pl": "Łagodnie w prawo w kierunku Destination 1",
+        "pt-BR": "Siga ligeiramente à direita sentido Destination 1",
+        "ru": "Двигайтесь правее в направлении Destination 1",
+        "sv": "Sväng höger mot Destination 1",
+        "uk": "Рухайтесь плавно праворуч в напрямку Destination 1",
+        "vi": "Quẹo phải nghiêng đến Destination 1",
+        "zh-Hans": "向右转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/slight_right_name.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_name.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "slight right"
+        },
+        "name": "Way Name"
+    },
+    "instructions": {
+        "de": "Leicht rechts abbiegen auf Way Name",
+        "en": "Make a slight right onto Way Name",
+        "es": "Siga ligeramente a la derecha en Way Name",
+        "fr": "Tourner légèrement à droite sur Way Name",
+        "id": "Lakukan agak ke kanan ke arah Way Name",
+        "it": "Fai una destra leggermente in Way Name",
+        "nl": "Ga rechts naar Way Name",
+        "pl": "Łagodnie w prawo na Way Name",
+        "pt-BR": "Siga ligeiramente à direita em Way Name",
+        "ru": "Двигайтесь правее на Way Name",
+        "sv": "Sväng höger in på Way Name",
+        "uk": "Рухайтесь плавно праворуч на Way Name",
+        "vi": "Quẹo phải nghiêng vào Way Name",
+        "zh-Hans": "向右转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/straight_default.json
+++ b/test/fixtures/v5/exit_rotary/straight_default.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "straight"
+        },
+        "name": ""
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren",
+        "en": "Go straight",
+        "es": "Ve recto",
+        "fr": "Aller tout droit",
+        "id": "Lurus",
+        "it": "Prosegui dritto",
+        "nl": "Ga rechtdoor",
+        "pl": "Jedź prosto",
+        "pt-BR": "Siga reto",
+        "ru": "Двигайтесь прямо",
+        "sv": "Kör rakt fram",
+        "uk": "Рухайтесь прямо",
+        "vi": "Chạy thẳng",
+        "zh-Hans": "直行"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/straight_destination.json
+++ b/test/fixtures/v5/exit_rotary/straight_destination.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren Richtung Destination 1",
+        "en": "Go straight towards Destination 1",
+        "es": "Ve recto hacia Destination 1",
+        "fr": "Aller tout droit en direction de Destination 1",
+        "id": "Lurus menuju Destination 1",
+        "it": "Continua verso Destination 1",
+        "nl": "Ga rechtdoor richting Destination 1",
+        "pl": "Jedź prosto w kierunku Destination 1",
+        "pt-BR": "Siga reto sentido Destination 1",
+        "ru": "Двигайтесь в направлении Destination 1",
+        "sv": "Kör rakt fram mot Destination 1",
+        "uk": "Рухайтесь прямо у напрямку Destination 1",
+        "vi": "Chạy thẳng đến Destination 1",
+        "zh-Hans": "直行，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/straight_exit.json
+++ b/test/fixtures/v5/exit_rotary/straight_exit.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren auf Way Name",
+        "en": "Go straight onto Way Name",
+        "es": "Ve recto en Way Name",
+        "fr": "Aller tout droit sur Way Name",
+        "id": "Lurus arah Way Name",
+        "it": "Continua su Way Name",
+        "nl": "Ga rechtdoor naar Way Name",
+        "pl": "Jedź prosto na Way Name",
+        "pt-BR": "Siga reto em Way Name",
+        "ru": "Двигайтесь по Way Name",
+        "sv": "Kör rakt fram in på Way Name",
+        "uk": "Рухайтесь прямо по Way Name",
+        "vi": "Chạy thẳng vào Way Name",
+        "zh-Hans": "直行，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/straight_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/straight_exit_destination.json
@@ -1,0 +1,27 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren Richtung Destination 1",
+        "en": "Go straight towards Destination 1",
+        "es": "Ve recto hacia Destination 1",
+        "fr": "Aller tout droit en direction de Destination 1",
+        "id": "Lurus menuju Destination 1",
+        "it": "Continua verso Destination 1",
+        "nl": "Ga rechtdoor richting Destination 1",
+        "pl": "Jedź prosto w kierunku Destination 1",
+        "pt-BR": "Siga reto sentido Destination 1",
+        "ru": "Двигайтесь в направлении Destination 1",
+        "sv": "Kör rakt fram mot Destination 1",
+        "uk": "Рухайтесь прямо у напрямку Destination 1",
+        "vi": "Chạy thẳng đến Destination 1",
+        "zh-Hans": "直行，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/straight_name.json
+++ b/test/fixtures/v5/exit_rotary/straight_name.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "straight"
+        },
+        "name": "Way Name"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren auf Way Name",
+        "en": "Go straight onto Way Name",
+        "es": "Ve recto en Way Name",
+        "fr": "Aller tout droit sur Way Name",
+        "id": "Lurus arah Way Name",
+        "it": "Continua su Way Name",
+        "nl": "Ga rechtdoor naar Way Name",
+        "pl": "Jedź prosto na Way Name",
+        "pt-BR": "Siga reto em Way Name",
+        "ru": "Двигайтесь по Way Name",
+        "sv": "Kör rakt fram in på Way Name",
+        "uk": "Рухайтесь прямо по Way Name",
+        "vi": "Chạy thẳng vào Way Name",
+        "zh-Hans": "直行，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/uturn_default.json
+++ b/test/fixtures/v5/exit_rotary/uturn_default.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "uturn"
+        },
+        "name": ""
+    },
+    "instructions": {
+        "de": "180°-Wendung abbiegen",
+        "en": "Make a U-turn",
+        "es": "Siga cambio de sentido",
+        "fr": "Tourner demi-tour",
+        "id": "Lakukan putar balik",
+        "it": "Fai una inversione a U",
+        "nl": "Ga omkeren",
+        "pl": "Zawróć",
+        "pt-BR": "Siga retorno",
+        "ru": "Двигайтесь на разворот",
+        "sv": "Sväng U-sväng",
+        "uk": "Рухайтесь розворот",
+        "vi": "Quẹo ngược",
+        "zh-Hans": "调头转弯"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/uturn_destination.json
+++ b/test/fixtures/v5/exit_rotary/uturn_destination.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2"
+    },
+    "instructions": {
+        "de": "180°-Wendung abbiegen Richtung Destination 1",
+        "en": "Make a U-turn towards Destination 1",
+        "es": "Siga cambio de sentido hacia Destination 1",
+        "fr": "Tourner demi-tour en direction de Destination 1",
+        "id": "Lakukan putar balik menuju Destination 1",
+        "it": "Fai una inversione a U verso Destination 1",
+        "nl": "Ga omkeren richting Destination 1",
+        "pl": "Zawróć w kierunku Destination 1",
+        "pt-BR": "Siga retorno sentido Destination 1",
+        "ru": "Двигайтесь на разворот в направлении Destination 1",
+        "sv": "Sväng U-sväng mot Destination 1",
+        "uk": "Рухайтесь розворот в напрямку Destination 1",
+        "vi": "Quẹo ngược đến Destination 1",
+        "zh-Hans": "调头转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/uturn_exit.json
+++ b/test/fixtures/v5/exit_rotary/uturn_exit.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung abbiegen auf Way Name",
+        "en": "Make a U-turn onto Way Name",
+        "es": "Siga cambio de sentido en Way Name",
+        "fr": "Tourner demi-tour sur Way Name",
+        "id": "Lakukan putar balik ke arah Way Name",
+        "it": "Fai una inversione a U in Way Name",
+        "nl": "Ga omkeren naar Way Name",
+        "pl": "Zawróć na Way Name",
+        "pt-BR": "Siga retorno em Way Name",
+        "ru": "Двигайтесь на разворот на Way Name",
+        "sv": "Sväng U-sväng in på Way Name",
+        "uk": "Рухайтесь розворот на Way Name",
+        "vi": "Quẹo ngược vào Way Name",
+        "zh-Hans": "调头转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/uturn_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/uturn_exit_destination.json
@@ -1,0 +1,27 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung abbiegen Richtung Destination 1",
+        "en": "Make a U-turn towards Destination 1",
+        "es": "Siga cambio de sentido hacia Destination 1",
+        "fr": "Tourner demi-tour en direction de Destination 1",
+        "id": "Lakukan putar balik menuju Destination 1",
+        "it": "Fai una inversione a U verso Destination 1",
+        "nl": "Ga omkeren richting Destination 1",
+        "pl": "Zawróć w kierunku Destination 1",
+        "pt-BR": "Siga retorno sentido Destination 1",
+        "ru": "Двигайтесь на разворот в направлении Destination 1",
+        "sv": "Sväng U-sväng mot Destination 1",
+        "uk": "Рухайтесь розворот в напрямку Destination 1",
+        "vi": "Quẹo ngược đến Destination 1",
+        "zh-Hans": "调头转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/uturn_name.json
+++ b/test/fixtures/v5/exit_rotary/uturn_name.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "uturn"
+        },
+        "name": "Way Name"
+    },
+    "instructions": {
+        "de": "180°-Wendung abbiegen auf Way Name",
+        "en": "Make a U-turn onto Way Name",
+        "es": "Siga cambio de sentido en Way Name",
+        "fr": "Tourner demi-tour sur Way Name",
+        "id": "Lakukan putar balik ke arah Way Name",
+        "it": "Fai una inversione a U in Way Name",
+        "nl": "Ga omkeren naar Way Name",
+        "pl": "Zawróć na Way Name",
+        "pt-BR": "Siga retorno em Way Name",
+        "ru": "Двигайтесь на разворот на Way Name",
+        "sv": "Sväng U-sväng in på Way Name",
+        "uk": "Рухайтесь розворот на Way Name",
+        "vi": "Quẹo ngược vào Way Name",
+        "zh-Hans": "调头转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/left_default.json
+++ b/test/fixtures/v5/exit_roundabout/left_default.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "left"
+        },
+        "name": ""
+    },
+    "instructions": {
+        "de": "Links abbiegen",
+        "en": "Turn left",
+        "es": "Gire a la izquierda",
+        "fr": "Tourner à gauche",
+        "id": "Belok kiri",
+        "it": "Svolta a sinistra",
+        "nl": "Ga linksaf",
+        "pl": "Skręć w lewo",
+        "pt-BR": "Vire à esquerda",
+        "ru": "Поверните налево",
+        "sv": "Sväng vänster",
+        "uk": "Поверніть ліворуч",
+        "vi": "Quẹo trái",
+        "zh-Hans": "左转"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/left_destination.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2"
+    },
+    "instructions": {
+        "de": "Links abbiegen Richtung Destination 1",
+        "en": "Turn left towards Destination 1",
+        "es": "Gire a la izquierda hacia Destination 1",
+        "fr": "Tourner à gauche en direction de Destination 1",
+        "id": "Belok kiri menuju Destination 1",
+        "it": "Svolta a sinistra verso Destination 1",
+        "nl": "Ga linksaf richting Destination 1",
+        "pl": "Skręć w lewo w kierunku Destination 1",
+        "pt-BR": "Vire à esquerda sentido Destination 1",
+        "ru": "Поверните налево в направлении Destination 1",
+        "sv": "Sväng vänster mot Destination 1",
+        "uk": "Поверніть ліворуч у напрямку Destination 1",
+        "vi": "Quẹo trái đến Destination 1",
+        "zh-Hans": "左转，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/left_exit.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Links abbiegen auf Way Name",
+        "en": "Turn left onto Way Name",
+        "es": "Gire a la izquierda en Way Name",
+        "fr": "Tourner à gauche sur Way Name",
+        "id": "Belok kiri ke Way Name",
+        "it": "Svolta a sinistra in Way Name",
+        "nl": "Ga linksaf naar Way Name",
+        "pl": "Skręć w lewo na Way Name",
+        "pt-BR": "Vire à esquerda em Way Name",
+        "ru": "Поверните налево на Way Name",
+        "sv": "Sväng vänster in på Way Name",
+        "uk": "Поверніть ліворуч на Way Name",
+        "vi": "Quẹo trái vào Way Name",
+        "zh-Hans": "左转，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/left_exit_destination.json
@@ -1,0 +1,27 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Links abbiegen Richtung Destination 1",
+        "en": "Turn left towards Destination 1",
+        "es": "Gire a la izquierda hacia Destination 1",
+        "fr": "Tourner à gauche en direction de Destination 1",
+        "id": "Belok kiri menuju Destination 1",
+        "it": "Svolta a sinistra verso Destination 1",
+        "nl": "Ga linksaf richting Destination 1",
+        "pl": "Skręć w lewo w kierunku Destination 1",
+        "pt-BR": "Vire à esquerda sentido Destination 1",
+        "ru": "Поверните налево в направлении Destination 1",
+        "sv": "Sväng vänster mot Destination 1",
+        "uk": "Поверніть ліворуч у напрямку Destination 1",
+        "vi": "Quẹo trái đến Destination 1",
+        "zh-Hans": "左转，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/left_name.json
+++ b/test/fixtures/v5/exit_roundabout/left_name.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "left"
+        },
+        "name": "Way Name"
+    },
+    "instructions": {
+        "de": "Links abbiegen auf Way Name",
+        "en": "Turn left onto Way Name",
+        "es": "Gire a la izquierda en Way Name",
+        "fr": "Tourner à gauche sur Way Name",
+        "id": "Belok kiri ke Way Name",
+        "it": "Svolta a sinistra in Way Name",
+        "nl": "Ga linksaf naar Way Name",
+        "pl": "Skręć w lewo na Way Name",
+        "pt-BR": "Vire à esquerda em Way Name",
+        "ru": "Поверните налево на Way Name",
+        "sv": "Sväng vänster in på Way Name",
+        "uk": "Поверніть ліворуч на Way Name",
+        "vi": "Quẹo trái vào Way Name",
+        "zh-Hans": "左转，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/right_default.json
+++ b/test/fixtures/v5/exit_roundabout/right_default.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "right"
+        },
+        "name": ""
+    },
+    "instructions": {
+        "de": "Rechts abbiegen",
+        "en": "Turn right",
+        "es": "Gire a la derecha",
+        "fr": "Tourner à droite",
+        "id": "Belok kanan",
+        "it": "Gira a destra",
+        "nl": "Ga rechtsaf",
+        "pl": "Skręć w prawo",
+        "pt-BR": "Vire à direita",
+        "ru": "Поверните направо",
+        "sv": "Sväng höger",
+        "uk": "Поверніть праворуч",
+        "vi": "Quẹo phải",
+        "zh-Hans": "右转"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/right_destination.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2"
+    },
+    "instructions": {
+        "de": "Rechts abbiegen Richtung Destination 1",
+        "en": "Turn right towards Destination 1",
+        "es": "Gire a la derecha hacia Destination 1",
+        "fr": "Tourner à droite en direction de Destination 1",
+        "id": "Belok kanan menuju Destination 1",
+        "it": "Svolta a destra verso Destination 1",
+        "nl": "Ga rechtsaf richting Destination 1",
+        "pl": "Skręć w prawo w kierunku Destination 1",
+        "pt-BR": "Vire à direita sentido Destination 1",
+        "ru": "Поверните направо в направлении Destination 1",
+        "sv": "Sväng höger mot Destination 1",
+        "uk": "Поверніть праворуч у напрямку Destination 1",
+        "vi": "Quẹo phải đến Destination 1",
+        "zh-Hans": "右转，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/right_exit.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Rechts abbiegen auf Way Name",
+        "en": "Turn right onto Way Name",
+        "es": "Gire a la derecha en Way Name",
+        "fr": "Tourner à droite sur Way Name",
+        "id": "Belok kanan ke Way Name",
+        "it": "Svolta a destra in Way Name",
+        "nl": "Ga rechtsaf naar Way Name",
+        "pl": "Skręć w prawo na Way Name",
+        "pt-BR": "Vire à direita em Way Name",
+        "ru": "Поверните направо на Way Name",
+        "sv": "Sväng höger in på Way Name",
+        "uk": "Поверніть праворуч на Way Name",
+        "vi": "Quẹo phải vào Way Name",
+        "zh-Hans": "右转，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/right_exit_destination.json
@@ -1,0 +1,27 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Rechts abbiegen Richtung Destination 1",
+        "en": "Turn right towards Destination 1",
+        "es": "Gire a la derecha hacia Destination 1",
+        "fr": "Tourner à droite en direction de Destination 1",
+        "id": "Belok kanan menuju Destination 1",
+        "it": "Svolta a destra verso Destination 1",
+        "nl": "Ga rechtsaf richting Destination 1",
+        "pl": "Skręć w prawo w kierunku Destination 1",
+        "pt-BR": "Vire à direita sentido Destination 1",
+        "ru": "Поверните направо в направлении Destination 1",
+        "sv": "Sväng höger mot Destination 1",
+        "uk": "Поверніть праворуч у напрямку Destination 1",
+        "vi": "Quẹo phải đến Destination 1",
+        "zh-Hans": "右转，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/right_name.json
+++ b/test/fixtures/v5/exit_roundabout/right_name.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "right"
+        },
+        "name": "Way Name"
+    },
+    "instructions": {
+        "de": "Rechts abbiegen auf Way Name",
+        "en": "Turn right onto Way Name",
+        "es": "Gire a la derecha en Way Name",
+        "fr": "Tourner à droite sur Way Name",
+        "id": "Belok kanan ke Way Name",
+        "it": "Svolta a destra in Way Name",
+        "nl": "Ga rechtsaf naar Way Name",
+        "pl": "Skręć w prawo na Way Name",
+        "pt-BR": "Vire à direita em Way Name",
+        "ru": "Поверните направо на Way Name",
+        "sv": "Sväng höger in på Way Name",
+        "uk": "Поверніть праворуч на Way Name",
+        "vi": "Quẹo phải vào Way Name",
+        "zh-Hans": "右转，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/sharp_left_default.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_default.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "sharp left"
+        },
+        "name": ""
+    },
+    "instructions": {
+        "de": "Scharf links abbiegen",
+        "en": "Make a sharp left",
+        "es": "Siga cerrada a la izquierda",
+        "fr": "Tourner franchement à gauche",
+        "id": "Lakukan tajam kiri",
+        "it": "Fai una sinistra",
+        "nl": "Ga linksaf",
+        "pl": "Ostro w lewo",
+        "pt-BR": "Siga acentuadamente à esquerda",
+        "ru": "Двигайтесь налево",
+        "sv": "Sväng vänster",
+        "uk": "Рухайтесь різко ліворуч",
+        "vi": "Quẹo trái gắt",
+        "zh-Hans": "向左转弯"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/sharp_left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_destination.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2"
+    },
+    "instructions": {
+        "de": "Scharf links abbiegen Richtung Destination 1",
+        "en": "Make a sharp left towards Destination 1",
+        "es": "Siga cerrada a la izquierda hacia Destination 1",
+        "fr": "Tourner franchement à gauche en direction de Destination 1",
+        "id": "Lakukan tajam kiri menuju Destination 1",
+        "it": "Fai una sinistra verso Destination 1",
+        "nl": "Ga linksaf richting Destination 1",
+        "pl": "Ostro w lewo w kierunku Destination 1",
+        "pt-BR": "Siga acentuadamente à esquerda sentido Destination 1",
+        "ru": "Двигайтесь налево в направлении Destination 1",
+        "sv": "Sväng vänster mot Destination 1",
+        "uk": "Рухайтесь різко ліворуч в напрямку Destination 1",
+        "vi": "Quẹo trái gắt đến Destination 1",
+        "zh-Hans": "向左转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/sharp_left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_exit.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Scharf links abbiegen auf Way Name",
+        "en": "Make a sharp left onto Way Name",
+        "es": "Siga cerrada a la izquierda en Way Name",
+        "fr": "Tourner franchement à gauche sur Way Name",
+        "id": "Lakukan tajam kiri ke arah Way Name",
+        "it": "Fai una sinistra in Way Name",
+        "nl": "Ga linksaf naar Way Name",
+        "pl": "Ostro w lewo na Way Name",
+        "pt-BR": "Siga acentuadamente à esquerda em Way Name",
+        "ru": "Двигайтесь налево на Way Name",
+        "sv": "Sväng vänster in på Way Name",
+        "uk": "Рухайтесь різко ліворуч на Way Name",
+        "vi": "Quẹo trái gắt vào Way Name",
+        "zh-Hans": "向左转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_exit_destination.json
@@ -1,0 +1,27 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Scharf links abbiegen Richtung Destination 1",
+        "en": "Make a sharp left towards Destination 1",
+        "es": "Siga cerrada a la izquierda hacia Destination 1",
+        "fr": "Tourner franchement à gauche en direction de Destination 1",
+        "id": "Lakukan tajam kiri menuju Destination 1",
+        "it": "Fai una sinistra verso Destination 1",
+        "nl": "Ga linksaf richting Destination 1",
+        "pl": "Ostro w lewo w kierunku Destination 1",
+        "pt-BR": "Siga acentuadamente à esquerda sentido Destination 1",
+        "ru": "Двигайтесь налево в направлении Destination 1",
+        "sv": "Sväng vänster mot Destination 1",
+        "uk": "Рухайтесь різко ліворуч в напрямку Destination 1",
+        "vi": "Quẹo trái gắt đến Destination 1",
+        "zh-Hans": "向左转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/sharp_left_name.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_name.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name"
+    },
+    "instructions": {
+        "de": "Scharf links abbiegen auf Way Name",
+        "en": "Make a sharp left onto Way Name",
+        "es": "Siga cerrada a la izquierda en Way Name",
+        "fr": "Tourner franchement à gauche sur Way Name",
+        "id": "Lakukan tajam kiri ke arah Way Name",
+        "it": "Fai una sinistra in Way Name",
+        "nl": "Ga linksaf naar Way Name",
+        "pl": "Ostro w lewo na Way Name",
+        "pt-BR": "Siga acentuadamente à esquerda em Way Name",
+        "ru": "Двигайтесь налево на Way Name",
+        "sv": "Sväng vänster in på Way Name",
+        "uk": "Рухайтесь різко ліворуч на Way Name",
+        "vi": "Quẹo trái gắt vào Way Name",
+        "zh-Hans": "向左转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/sharp_right_default.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_default.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "sharp right"
+        },
+        "name": ""
+    },
+    "instructions": {
+        "de": "Scharf rechts abbiegen",
+        "en": "Make a sharp right",
+        "es": "Siga cerrada a la derecha",
+        "fr": "Tourner franchement à droite",
+        "id": "Lakukan tajam kanan",
+        "it": "Fai una destra",
+        "nl": "Ga rechtsaf",
+        "pl": "Ostro w prawo",
+        "pt-BR": "Siga acentuadamente à direita",
+        "ru": "Двигайтесь направо",
+        "sv": "Sväng höger",
+        "uk": "Рухайтесь різко праворуч",
+        "vi": "Quẹo phải gắt",
+        "zh-Hans": "向右转弯"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/sharp_right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_destination.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2"
+    },
+    "instructions": {
+        "de": "Scharf rechts abbiegen Richtung Destination 1",
+        "en": "Make a sharp right towards Destination 1",
+        "es": "Siga cerrada a la derecha hacia Destination 1",
+        "fr": "Tourner franchement à droite en direction de Destination 1",
+        "id": "Lakukan tajam kanan menuju Destination 1",
+        "it": "Fai una destra verso Destination 1",
+        "nl": "Ga rechtsaf richting Destination 1",
+        "pl": "Ostro w prawo w kierunku Destination 1",
+        "pt-BR": "Siga acentuadamente à direita sentido Destination 1",
+        "ru": "Двигайтесь направо в направлении Destination 1",
+        "sv": "Sväng höger mot Destination 1",
+        "uk": "Рухайтесь різко праворуч в напрямку Destination 1",
+        "vi": "Quẹo phải gắt đến Destination 1",
+        "zh-Hans": "向右转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/sharp_right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_exit.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts abbiegen auf Way Name",
+        "en": "Make a sharp right onto Way Name",
+        "es": "Siga cerrada a la derecha en Way Name",
+        "fr": "Tourner franchement à droite sur Way Name",
+        "id": "Lakukan tajam kanan ke arah Way Name",
+        "it": "Fai una destra in Way Name",
+        "nl": "Ga rechtsaf naar Way Name",
+        "pl": "Ostro w prawo na Way Name",
+        "pt-BR": "Siga acentuadamente à direita em Way Name",
+        "ru": "Двигайтесь направо на Way Name",
+        "sv": "Sväng höger in på Way Name",
+        "uk": "Рухайтесь різко праворуч на Way Name",
+        "vi": "Quẹo phải gắt vào Way Name",
+        "zh-Hans": "向右转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_exit_destination.json
@@ -1,0 +1,27 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Scharf rechts abbiegen Richtung Destination 1",
+        "en": "Make a sharp right towards Destination 1",
+        "es": "Siga cerrada a la derecha hacia Destination 1",
+        "fr": "Tourner franchement à droite en direction de Destination 1",
+        "id": "Lakukan tajam kanan menuju Destination 1",
+        "it": "Fai una destra verso Destination 1",
+        "nl": "Ga rechtsaf richting Destination 1",
+        "pl": "Ostro w prawo w kierunku Destination 1",
+        "pt-BR": "Siga acentuadamente à direita sentido Destination 1",
+        "ru": "Двигайтесь направо в направлении Destination 1",
+        "sv": "Sväng höger mot Destination 1",
+        "uk": "Рухайтесь різко праворуч в напрямку Destination 1",
+        "vi": "Quẹo phải gắt đến Destination 1",
+        "zh-Hans": "向右转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/sharp_right_name.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_name.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name"
+    },
+    "instructions": {
+        "de": "Scharf rechts abbiegen auf Way Name",
+        "en": "Make a sharp right onto Way Name",
+        "es": "Siga cerrada a la derecha en Way Name",
+        "fr": "Tourner franchement à droite sur Way Name",
+        "id": "Lakukan tajam kanan ke arah Way Name",
+        "it": "Fai una destra in Way Name",
+        "nl": "Ga rechtsaf naar Way Name",
+        "pl": "Ostro w prawo na Way Name",
+        "pt-BR": "Siga acentuadamente à direita em Way Name",
+        "ru": "Двигайтесь направо на Way Name",
+        "sv": "Sväng höger in på Way Name",
+        "uk": "Рухайтесь різко праворуч на Way Name",
+        "vi": "Quẹo phải gắt vào Way Name",
+        "zh-Hans": "向右转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/slight_left_default.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_default.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "slight left"
+        },
+        "name": ""
+    },
+    "instructions": {
+        "de": "Leicht links abbiegen",
+        "en": "Make a slight left",
+        "es": "Siga ligeramente a la izquierda",
+        "fr": "Tourner légèrement à gauche",
+        "id": "Lakukan agak ke kiri",
+        "it": "Fai una sinistra leggermente",
+        "nl": "Ga links",
+        "pl": "Łagodnie w lewo",
+        "pt-BR": "Siga ligeiramente à esquerda",
+        "ru": "Двигайтесь левее",
+        "sv": "Sväng vänster",
+        "uk": "Рухайтесь плавно ліворуч",
+        "vi": "Quẹo trái nghiêng",
+        "zh-Hans": "向左转弯"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/slight_left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_destination.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2"
+    },
+    "instructions": {
+        "de": "Leicht links abbiegen Richtung Destination 1",
+        "en": "Make a slight left towards Destination 1",
+        "es": "Siga ligeramente a la izquierda hacia Destination 1",
+        "fr": "Tourner légèrement à gauche en direction de Destination 1",
+        "id": "Lakukan agak ke kiri menuju Destination 1",
+        "it": "Fai una sinistra leggermente verso Destination 1",
+        "nl": "Ga links richting Destination 1",
+        "pl": "Łagodnie w lewo w kierunku Destination 1",
+        "pt-BR": "Siga ligeiramente à esquerda sentido Destination 1",
+        "ru": "Двигайтесь левее в направлении Destination 1",
+        "sv": "Sväng vänster mot Destination 1",
+        "uk": "Рухайтесь плавно ліворуч в напрямку Destination 1",
+        "vi": "Quẹo trái nghiêng đến Destination 1",
+        "zh-Hans": "向左转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/slight_left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_exit.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Leicht links abbiegen auf Way Name",
+        "en": "Make a slight left onto Way Name",
+        "es": "Siga ligeramente a la izquierda en Way Name",
+        "fr": "Tourner légèrement à gauche sur Way Name",
+        "id": "Lakukan agak ke kiri ke arah Way Name",
+        "it": "Fai una sinistra leggermente in Way Name",
+        "nl": "Ga links naar Way Name",
+        "pl": "Łagodnie w lewo na Way Name",
+        "pt-BR": "Siga ligeiramente à esquerda em Way Name",
+        "ru": "Двигайтесь левее на Way Name",
+        "sv": "Sväng vänster in på Way Name",
+        "uk": "Рухайтесь плавно ліворуч на Way Name",
+        "vi": "Quẹo trái nghiêng vào Way Name",
+        "zh-Hans": "向左转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/slight_left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_exit_destination.json
@@ -1,0 +1,27 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Leicht links abbiegen Richtung Destination 1",
+        "en": "Make a slight left towards Destination 1",
+        "es": "Siga ligeramente a la izquierda hacia Destination 1",
+        "fr": "Tourner légèrement à gauche en direction de Destination 1",
+        "id": "Lakukan agak ke kiri menuju Destination 1",
+        "it": "Fai una sinistra leggermente verso Destination 1",
+        "nl": "Ga links richting Destination 1",
+        "pl": "Łagodnie w lewo w kierunku Destination 1",
+        "pt-BR": "Siga ligeiramente à esquerda sentido Destination 1",
+        "ru": "Двигайтесь левее в направлении Destination 1",
+        "sv": "Sväng vänster mot Destination 1",
+        "uk": "Рухайтесь плавно ліворуч в напрямку Destination 1",
+        "vi": "Quẹo trái nghiêng đến Destination 1",
+        "zh-Hans": "向左转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/slight_left_name.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_name.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "slight left"
+        },
+        "name": "Way Name"
+    },
+    "instructions": {
+        "de": "Leicht links abbiegen auf Way Name",
+        "en": "Make a slight left onto Way Name",
+        "es": "Siga ligeramente a la izquierda en Way Name",
+        "fr": "Tourner légèrement à gauche sur Way Name",
+        "id": "Lakukan agak ke kiri ke arah Way Name",
+        "it": "Fai una sinistra leggermente in Way Name",
+        "nl": "Ga links naar Way Name",
+        "pl": "Łagodnie w lewo na Way Name",
+        "pt-BR": "Siga ligeiramente à esquerda em Way Name",
+        "ru": "Двигайтесь левее на Way Name",
+        "sv": "Sväng vänster in på Way Name",
+        "uk": "Рухайтесь плавно ліворуч на Way Name",
+        "vi": "Quẹo trái nghiêng vào Way Name",
+        "zh-Hans": "向左转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/slight_right_default.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_default.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "slight right"
+        },
+        "name": ""
+    },
+    "instructions": {
+        "de": "Leicht rechts abbiegen",
+        "en": "Make a slight right",
+        "es": "Siga ligeramente a la derecha",
+        "fr": "Tourner légèrement à droite",
+        "id": "Lakukan agak ke kanan",
+        "it": "Fai una destra leggermente",
+        "nl": "Ga rechts",
+        "pl": "Łagodnie w prawo",
+        "pt-BR": "Siga ligeiramente à direita",
+        "ru": "Двигайтесь правее",
+        "sv": "Sväng höger",
+        "uk": "Рухайтесь плавно праворуч",
+        "vi": "Quẹo phải nghiêng",
+        "zh-Hans": "向右转弯"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/slight_right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_destination.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2"
+    },
+    "instructions": {
+        "de": "Leicht rechts abbiegen Richtung Destination 1",
+        "en": "Make a slight right towards Destination 1",
+        "es": "Siga ligeramente a la derecha hacia Destination 1",
+        "fr": "Tourner légèrement à droite en direction de Destination 1",
+        "id": "Lakukan agak ke kanan menuju Destination 1",
+        "it": "Fai una destra leggermente verso Destination 1",
+        "nl": "Ga rechts richting Destination 1",
+        "pl": "Łagodnie w prawo w kierunku Destination 1",
+        "pt-BR": "Siga ligeiramente à direita sentido Destination 1",
+        "ru": "Двигайтесь правее в направлении Destination 1",
+        "sv": "Sväng höger mot Destination 1",
+        "uk": "Рухайтесь плавно праворуч в напрямку Destination 1",
+        "vi": "Quẹo phải nghiêng đến Destination 1",
+        "zh-Hans": "向右转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/slight_right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_exit.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Leicht rechts abbiegen auf Way Name",
+        "en": "Make a slight right onto Way Name",
+        "es": "Siga ligeramente a la derecha en Way Name",
+        "fr": "Tourner légèrement à droite sur Way Name",
+        "id": "Lakukan agak ke kanan ke arah Way Name",
+        "it": "Fai una destra leggermente in Way Name",
+        "nl": "Ga rechts naar Way Name",
+        "pl": "Łagodnie w prawo na Way Name",
+        "pt-BR": "Siga ligeiramente à direita em Way Name",
+        "ru": "Двигайтесь правее на Way Name",
+        "sv": "Sväng höger in på Way Name",
+        "uk": "Рухайтесь плавно праворуч на Way Name",
+        "vi": "Quẹo phải nghiêng vào Way Name",
+        "zh-Hans": "向右转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/slight_right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_exit_destination.json
@@ -1,0 +1,27 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Leicht rechts abbiegen Richtung Destination 1",
+        "en": "Make a slight right towards Destination 1",
+        "es": "Siga ligeramente a la derecha hacia Destination 1",
+        "fr": "Tourner légèrement à droite en direction de Destination 1",
+        "id": "Lakukan agak ke kanan menuju Destination 1",
+        "it": "Fai una destra leggermente verso Destination 1",
+        "nl": "Ga rechts richting Destination 1",
+        "pl": "Łagodnie w prawo w kierunku Destination 1",
+        "pt-BR": "Siga ligeiramente à direita sentido Destination 1",
+        "ru": "Двигайтесь правее в направлении Destination 1",
+        "sv": "Sväng höger mot Destination 1",
+        "uk": "Рухайтесь плавно праворуч в напрямку Destination 1",
+        "vi": "Quẹo phải nghiêng đến Destination 1",
+        "zh-Hans": "向右转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/slight_right_name.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_name.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "slight right"
+        },
+        "name": "Way Name"
+    },
+    "instructions": {
+        "de": "Leicht rechts abbiegen auf Way Name",
+        "en": "Make a slight right onto Way Name",
+        "es": "Siga ligeramente a la derecha en Way Name",
+        "fr": "Tourner légèrement à droite sur Way Name",
+        "id": "Lakukan agak ke kanan ke arah Way Name",
+        "it": "Fai una destra leggermente in Way Name",
+        "nl": "Ga rechts naar Way Name",
+        "pl": "Łagodnie w prawo na Way Name",
+        "pt-BR": "Siga ligeiramente à direita em Way Name",
+        "ru": "Двигайтесь правее на Way Name",
+        "sv": "Sväng höger in på Way Name",
+        "uk": "Рухайтесь плавно праворуч на Way Name",
+        "vi": "Quẹo phải nghiêng vào Way Name",
+        "zh-Hans": "向右转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/straight_default.json
+++ b/test/fixtures/v5/exit_roundabout/straight_default.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "straight"
+        },
+        "name": ""
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren",
+        "en": "Go straight",
+        "es": "Ve recto",
+        "fr": "Aller tout droit",
+        "id": "Lurus",
+        "it": "Prosegui dritto",
+        "nl": "Ga rechtdoor",
+        "pl": "Jedź prosto",
+        "pt-BR": "Siga reto",
+        "ru": "Двигайтесь прямо",
+        "sv": "Kör rakt fram",
+        "uk": "Рухайтесь прямо",
+        "vi": "Chạy thẳng",
+        "zh-Hans": "直行"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/straight_destination.json
+++ b/test/fixtures/v5/exit_roundabout/straight_destination.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren Richtung Destination 1",
+        "en": "Go straight towards Destination 1",
+        "es": "Ve recto hacia Destination 1",
+        "fr": "Aller tout droit en direction de Destination 1",
+        "id": "Lurus menuju Destination 1",
+        "it": "Continua verso Destination 1",
+        "nl": "Ga rechtdoor richting Destination 1",
+        "pl": "Jedź prosto w kierunku Destination 1",
+        "pt-BR": "Siga reto sentido Destination 1",
+        "ru": "Двигайтесь в направлении Destination 1",
+        "sv": "Kör rakt fram mot Destination 1",
+        "uk": "Рухайтесь прямо у напрямку Destination 1",
+        "vi": "Chạy thẳng đến Destination 1",
+        "zh-Hans": "直行，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/straight_exit.json
+++ b/test/fixtures/v5/exit_roundabout/straight_exit.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren auf Way Name",
+        "en": "Go straight onto Way Name",
+        "es": "Ve recto en Way Name",
+        "fr": "Aller tout droit sur Way Name",
+        "id": "Lurus arah Way Name",
+        "it": "Continua su Way Name",
+        "nl": "Ga rechtdoor naar Way Name",
+        "pl": "Jedź prosto na Way Name",
+        "pt-BR": "Siga reto em Way Name",
+        "ru": "Двигайтесь по Way Name",
+        "sv": "Kör rakt fram in på Way Name",
+        "uk": "Рухайтесь прямо по Way Name",
+        "vi": "Chạy thẳng vào Way Name",
+        "zh-Hans": "直行，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/straight_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/straight_exit_destination.json
@@ -1,0 +1,27 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren Richtung Destination 1",
+        "en": "Go straight towards Destination 1",
+        "es": "Ve recto hacia Destination 1",
+        "fr": "Aller tout droit en direction de Destination 1",
+        "id": "Lurus menuju Destination 1",
+        "it": "Continua verso Destination 1",
+        "nl": "Ga rechtdoor richting Destination 1",
+        "pl": "Jedź prosto w kierunku Destination 1",
+        "pt-BR": "Siga reto sentido Destination 1",
+        "ru": "Двигайтесь в направлении Destination 1",
+        "sv": "Kör rakt fram mot Destination 1",
+        "uk": "Рухайтесь прямо у напрямку Destination 1",
+        "vi": "Chạy thẳng đến Destination 1",
+        "zh-Hans": "直行，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/straight_name.json
+++ b/test/fixtures/v5/exit_roundabout/straight_name.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "straight"
+        },
+        "name": "Way Name"
+    },
+    "instructions": {
+        "de": "Geradeaus weiterfahren auf Way Name",
+        "en": "Go straight onto Way Name",
+        "es": "Ve recto en Way Name",
+        "fr": "Aller tout droit sur Way Name",
+        "id": "Lurus arah Way Name",
+        "it": "Continua su Way Name",
+        "nl": "Ga rechtdoor naar Way Name",
+        "pl": "Jedź prosto na Way Name",
+        "pt-BR": "Siga reto em Way Name",
+        "ru": "Двигайтесь по Way Name",
+        "sv": "Kör rakt fram in på Way Name",
+        "uk": "Рухайтесь прямо по Way Name",
+        "vi": "Chạy thẳng vào Way Name",
+        "zh-Hans": "直行，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/uturn_default.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_default.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "uturn"
+        },
+        "name": ""
+    },
+    "instructions": {
+        "de": "180°-Wendung abbiegen",
+        "en": "Make a U-turn",
+        "es": "Siga cambio de sentido",
+        "fr": "Tourner demi-tour",
+        "id": "Lakukan putar balik",
+        "it": "Fai una inversione a U",
+        "nl": "Ga omkeren",
+        "pl": "Zawróć",
+        "pt-BR": "Siga retorno",
+        "ru": "Двигайтесь на разворот",
+        "sv": "Sväng U-sväng",
+        "uk": "Рухайтесь розворот",
+        "vi": "Quẹo ngược",
+        "zh-Hans": "调头转弯"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/uturn_destination.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_destination.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2"
+    },
+    "instructions": {
+        "de": "180°-Wendung abbiegen Richtung Destination 1",
+        "en": "Make a U-turn towards Destination 1",
+        "es": "Siga cambio de sentido hacia Destination 1",
+        "fr": "Tourner demi-tour en direction de Destination 1",
+        "id": "Lakukan putar balik menuju Destination 1",
+        "it": "Fai una inversione a U verso Destination 1",
+        "nl": "Ga omkeren richting Destination 1",
+        "pl": "Zawróć w kierunku Destination 1",
+        "pt-BR": "Siga retorno sentido Destination 1",
+        "ru": "Двигайтесь на разворот в направлении Destination 1",
+        "sv": "Sväng U-sväng mot Destination 1",
+        "uk": "Рухайтесь розворот в напрямку Destination 1",
+        "vi": "Quẹo ngược đến Destination 1",
+        "zh-Hans": "调头转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/uturn_exit.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_exit.json
@@ -1,0 +1,26 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung abbiegen auf Way Name",
+        "en": "Make a U-turn onto Way Name",
+        "es": "Siga cambio de sentido en Way Name",
+        "fr": "Tourner demi-tour sur Way Name",
+        "id": "Lakukan putar balik ke arah Way Name",
+        "it": "Fai una inversione a U in Way Name",
+        "nl": "Ga omkeren naar Way Name",
+        "pl": "Zawróć na Way Name",
+        "pt-BR": "Siga retorno em Way Name",
+        "ru": "Двигайтесь на разворот на Way Name",
+        "sv": "Sväng U-sväng in på Way Name",
+        "uk": "Рухайтесь розворот на Way Name",
+        "vi": "Quẹo ngược vào Way Name",
+        "zh-Hans": "调头转弯，上Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/uturn_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_exit_destination.json
@@ -1,0 +1,27 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "destinations": "Destination 1,Destination 2",
+        "exits": "4A;4B"
+    },
+    "instructions": {
+        "de": "180°-Wendung abbiegen Richtung Destination 1",
+        "en": "Make a U-turn towards Destination 1",
+        "es": "Siga cambio de sentido hacia Destination 1",
+        "fr": "Tourner demi-tour en direction de Destination 1",
+        "id": "Lakukan putar balik menuju Destination 1",
+        "it": "Fai una inversione a U verso Destination 1",
+        "nl": "Ga omkeren richting Destination 1",
+        "pl": "Zawróć w kierunku Destination 1",
+        "pt-BR": "Siga retorno sentido Destination 1",
+        "ru": "Двигайтесь на разворот в направлении Destination 1",
+        "sv": "Sväng U-sväng mot Destination 1",
+        "uk": "Рухайтесь розворот в напрямку Destination 1",
+        "vi": "Quẹo ngược đến Destination 1",
+        "zh-Hans": "调头转弯，前往Destination 1"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/uturn_name.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_name.json
@@ -1,0 +1,25 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "uturn"
+        },
+        "name": "Way Name"
+    },
+    "instructions": {
+        "de": "180°-Wendung abbiegen auf Way Name",
+        "en": "Make a U-turn onto Way Name",
+        "es": "Siga cambio de sentido en Way Name",
+        "fr": "Tourner demi-tour sur Way Name",
+        "id": "Lakukan putar balik ke arah Way Name",
+        "it": "Fai una inversione a U in Way Name",
+        "nl": "Ga omkeren naar Way Name",
+        "pl": "Zawróć na Way Name",
+        "pt-BR": "Siga retorno em Way Name",
+        "ru": "Двигайтесь на разворот на Way Name",
+        "sv": "Sväng U-sväng in på Way Name",
+        "uk": "Рухайтесь розворот на Way Name",
+        "vi": "Quẹo ngược vào Way Name",
+        "zh-Hans": "调头转弯，上Way Name"
+    }
+}

--- a/test/fixtures_test.js
+++ b/test/fixtures_test.js
@@ -343,6 +343,8 @@ tape.test('verify existance/update fixtures', function(assert) {
         case 'on ramp':
         case 'off ramp':
         case 'roundabout turn':
+        case 'exit roundabout':
+        case 'exit rotary':
         case 'turn':
             // do variation per modifier
             constants.modifiers.forEach((modifier) => {


### PR DESCRIPTION
Adds handling for new types `exit rotary` and `exit roundabout`. 

This can be handled as a simple turn, no special instruction needed.

/cc @1ec5 @mcwhittemore 