### PR TITLE
Force LF line breaks for JS & JSON files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js text eol=lf
+*.json text eol=lf

--- a/scripts/transifex.js
+++ b/scripts/transifex.js
@@ -39,6 +39,6 @@ languages.supportedCodes.forEach((code) => {
         }
 
         // Write language file
-        fs.writeFileSync(`${__dirname}/../languages/translations/${code}.json`, JSON.stringify(content, null, 4));
+        fs.writeFileSync(`${__dirname}/../languages/translations/${code}.json`, JSON.stringify(content, null, 4) + '\n');
     });
 });


### PR DESCRIPTION
# Issue

Current `ESLint` [settings](https://github.com/Project-OSRM/osrm-text-instructions/blob/master/.eslintrc.json#L76-L79) expect only LF line breaks in JS files; `JSON.stringify()` used by `npm run transifex` and `UPDATE=1 npm test` writes LF line breaks for generated JSON files.

This is the problem for Windows users with default `auto` line breaks option - all files after regeneration became invalid for `ESLint` and changed for `git`.

This PR adds repository option to always checkout JS and JSON files with expected LF line breaks. This is a bit inconvenient to work with them in Windows but makes further life much more easier.
