### PR TITLE
Replace ES5 lambda in Array.some() with Array.indexOf()

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ module.exports = function(version, _options) {
             // the ref should be used instead of the name.
             var wayMotorway = false;
             if (options && options.classes) {
-                wayMotorway = options.classes.some((className) => ['motorway'].indexOf(className) > -1);
+                wayMotorway = options.classes.indexOf('motorway') !== -1;
             }
 
             if (name && ref && name !== ref && !wayMotorway) {


### PR DESCRIPTION
# Issue

Used ES5 lambda function with Array.some() introduced in #129 is incompatible with ES4-based Uglify/Browserify called by OSRM frontend.

This PR replaces Array.some() call with Array.indexOf().
