### PR TITLE
Add Castilian Spanish localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file. For change 
 
 ## master
 
+- Added Castilian Spanish localization. [#163](https://github.com/Project-OSRM/osrm-text-instructions/pull/163)
 - Added Romanian localization. [#105](https://github.com/Project-OSRM/osrm-text-instructions/pull/105)
 - Added Turkish localization. [#158](https://github.com/Project-OSRM/osrm-text-instructions/pull/158)
 

--- a/languages.js
+++ b/languages.js
@@ -3,6 +3,7 @@
 var instructionsDe = require('./languages/translations/de.json');
 var instructionsEn = require('./languages/translations/en.json');
 var instructionsEs = require('./languages/translations/es.json');
+var instructionsEsEs = require('./languages/translations/es-ES.json');
 var instructionsFr = require('./languages/translations/fr.json');
 var instructionsId = require('./languages/translations/id.json');
 var instructionsIt = require('./languages/translations/it.json');
@@ -23,6 +24,7 @@ var instructions = {
     'de': instructionsDe,
     'en': instructionsEn,
     'es': instructionsEs,
+    'es-ES': instructionsEsEs,
     'fr': instructionsFr,
     'id': instructionsId,
     'it': instructionsIt,

--- a/languages/translations/es-ES.json
+++ b/languages/translations/es-ES.json
@@ -1,0 +1,484 @@
+{
+    "meta": {
+        "capitalizeFirstLetter": true
+    },
+    "v5": {
+        "constants": {
+            "ordinalize": {
+                "1": "1ª",
+                "2": "2ª",
+                "3": "3ª",
+                "4": "4ª",
+                "5": "5ª",
+                "6": "6ª",
+                "7": "7ª",
+                "8": "8ª",
+                "9": "9ª",
+                "10": "10ª"
+            },
+            "direction": {
+                "north": "norte",
+                "northeast": "noreste",
+                "east": "este",
+                "southeast": "sureste",
+                "south": "sur",
+                "southwest": "suroeste",
+                "west": "oeste",
+                "northwest": "noroeste"
+            },
+            "modifier": {
+                "left": "a la izquierda",
+                "right": "a la derecha",
+                "sharp left": "cerrada a la izquierda",
+                "sharp right": "cerrada a la derecha",
+                "slight left": "ligeramente a la izquierda",
+                "slight right": "ligeramente a la derecha",
+                "straight": "recto",
+                "uturn": "cambio de sentido"
+            },
+            "lanes": {
+                "xo": "Mantente a la derecha",
+                "ox": "Mantente a la izquierda",
+                "xox": "Mantente en el medio",
+                "oxo": "Mantente a la izquierda o a la derecha"
+            }
+        },
+        "modes": {
+            "ferry": {
+                "default": "Coge el ferry",
+                "name": "Coge el ferry {way_name}",
+                "destination": "Coge el ferry hacia {destination}"
+            }
+        },
+        "phrase": {
+            "two linked by distance": "{instruction_one} y luego en {distance}, {instruction_two}",
+            "two linked": "{instruction_one} y luego {instruction_two}",
+            "one in distance": "A {distance}, {instruction_one}",
+            "name and ref": "{name} ({ref})"
+        },
+        "arrive": {
+            "default": {
+                "default": "Has llegado a tu {nth} destino"
+            },
+            "left": {
+                "default": "Has llegado a tu {nth} destino, a la izquierda"
+            },
+            "right": {
+                "default": "Has llegado a tu {nth} destino, a la derecha"
+            },
+            "sharp left": {
+                "default": "Has llegado a tu {nth} destino, a la izquierda"
+            },
+            "sharp right": {
+                "default": "Has llegado a tu {nth} destino, a la derecha"
+            },
+            "slight right": {
+                "default": "Has llegado a tu {nth} destino, a la derecha"
+            },
+            "slight left": {
+                "default": "Has llegado a tu {nth} destino, a la izquierda"
+            },
+            "straight": {
+                "default": "Has llegado a tu {nth} destino, en frente"
+            }
+        },
+        "continue": {
+            "default": {
+                "default": "Gire a {modifier}",
+                "name": "Cruce a la{modifier}  en {way_name}",
+                "destination": "Gire a {modifier} hacia {destination}",
+                "exit": "Gire a {modifier} en {way_name}"
+            },
+            "straight": {
+                "default": "Continúe recto",
+                "name": "Continúe en {way_name}",
+                "destination": "Continúe hacia {destination}",
+                "distance": "Continúe recto por {distance}",
+                "namedistance": "Continúe recto en {way_name} por {distance}"
+            },
+            "sharp left": {
+                "default": "Gire a la izquierda",
+                "name": "Gire a la izquierda en {way_name}",
+                "destination": "Gire a la izquierda hacia {destination}"
+            },
+            "sharp right": {
+                "default": "Gire a la derecha",
+                "name": "Gire a la derecha en {way_name}",
+                "destination": "Gire a la derecha hacia {destination}"
+            },
+            "slight left": {
+                "default": "Gire a la izquierda",
+                "name": "Doble levemente a la izquierda en {way_name}",
+                "destination": "Gire a la izquierda hacia {destination}"
+            },
+            "slight right": {
+                "default": "Gire a la izquierda",
+                "name": "Doble levemente a la derecha en {way_name}",
+                "destination": "Gire a la izquierda hacia {destination}"
+            },
+            "uturn": {
+                "default": "Haz un cambio de sentido",
+                "name": "Haz un cambio de sentido y continúe en {way_name}",
+                "destination": "Haz un cambio de sentido hacia {destination}"
+            }
+        },
+        "depart": {
+            "default": {
+                "default": "Dirígete al {direction}",
+                "name": "Dirígete al {direction} por {way_name}"
+            }
+        },
+        "end of road": {
+            "default": {
+                "default": "Al final de la calle gira {modifier}",
+                "name": "Al final de la calle gira {modifier} por {way_name}",
+                "destination": "Al final de la calle gira {modifier} hacia {destination}"
+            },
+            "straight": {
+                "default": "Al final de la calle continúa recto",
+                "name": "Al final de la calle continúa recto por {way_name}",
+                "destination": "Al final de la calle continúa recto hacia {destination}"
+            },
+            "uturn": {
+                "default": "Al final de la calle haz un cambio de sentido",
+                "name": "Al final de la calle haz un cambio de sentido en {way_name}",
+                "destination": "Al final de la calle haz un cambio de sentido hacia {destination}"
+            }
+        },
+        "fork": {
+            "default": {
+                "default": "Mantente {modifier} en el cruce",
+                "name": "Mantente {modifier} en el cruce por {way_name}",
+                "destination": "Mantente {modifier} en el cruce hacia {destination}"
+            },
+            "slight left": {
+                "default": "Mantente a la izquierda en el cruce",
+                "name": "Mantente a la izquierda en el cruce por {way_name}",
+                "destination": "Mantente a la izquierda en el cruce hacia {destination}"
+            },
+            "slight right": {
+                "default": "Mantente a la derecha en el cruce",
+                "name": "Mantente a la derecha en el cruce por {way_name}",
+                "destination": "Mantente a la derecha en el cruce hacia {destination}"
+            },
+            "sharp left": {
+                "default": "Gira la izquierda en el cruce",
+                "name": "Gira a la izquierda en el cruce por {way_name}",
+                "destination": "Gira a la izquierda en el cruce hacia {destination}"
+            },
+            "sharp right": {
+                "default": "Gira a la derecha en el cruce",
+                "name": "Gira a la derecha en el cruce por {way_name}",
+                "destination": "Gira a la derecha en el cruce hacia {destination}"
+            },
+            "uturn": {
+                "default": "Haz un cambio de sentido",
+                "name": "Haz un cambio de sentido en {way_name}",
+                "destination": "Haz un cambio de sentido hacia {destination}"
+            }
+        },
+        "merge": {
+            "default": {
+                "default": "Incorpórate {modifier}",
+                "name": "Incorpórate {modifier} por {way_name}",
+                "destination": "Incorpórate {modifier} hacia {destination}"
+            },
+            "slight left": {
+                "default": "Incorpórate a la izquierda",
+                "name": "Incorpórate a la izquierda por {way_name}",
+                "destination": "Incorpórate a la izquierda hacia {destination}"
+            },
+            "slight right": {
+                "default": "Incorpórate a la derecha",
+                "name": "Incorpórate a la derecha por {way_name}",
+                "destination": "Incorpórate a la derecha hacia {destination}"
+            },
+            "sharp left": {
+                "default": "Incorpórate a la izquierda",
+                "name": "Incorpórate a la izquierda por {way_name}",
+                "destination": "Incorpórate a la izquierda hacia {destination}"
+            },
+            "sharp right": {
+                "default": "Incorpórate a la derecha",
+                "name": "Incorpórate a la derecha por {way_name}",
+                "destination": "Incorpórate a la derecha hacia {destination}"
+            },
+            "uturn": {
+                "default": "Haz un cambio de sentido",
+                "name": "Haz un cambio de sentido en {way_name}",
+                "destination": "Haz un cambio de sentido hacia {destination}"
+            }
+        },
+        "new name": {
+            "default": {
+                "default": "Continúa {modifier}",
+                "name": "Continúa {modifier} por {way_name}",
+                "destination": "Continúa {modifier} hacia {destination}"
+            },
+            "straight": {
+                "default": "Continúa recto",
+                "name": "Continúa por {way_name}",
+                "destination": "Continúa hacia {destination}"
+            },
+            "sharp left": {
+                "default": "Gira a la izquierda",
+                "name": "Gira a la izquierda por {way_name}",
+                "destination": "Gira a la izquierda hacia {destination}"
+            },
+            "sharp right": {
+                "default": "Gira a la derecha",
+                "name": "Gira a la derecha por {way_name}",
+                "destination": "Gira a la derecha hacia {destination}"
+            },
+            "slight left": {
+                "default": "Continúa ligeramente por la izquierda",
+                "name": "Continúa ligeramente por la izquierda por {way_name}",
+                "destination": "Continúa ligeramente por la izquierda hacia {destination}"
+            },
+            "slight right": {
+                "default": "Continúa ligeramente por la derecha",
+                "name": "Continúa ligeramente por la derecha por {way_name}",
+                "destination": "Continúa ligeramente por la derecha hacia {destination}"
+            },
+            "uturn": {
+                "default": "Haz un cambio de sentido",
+                "name": "Haz un cambio de sentido en {way_name}",
+                "destination": "Haz un cambio de sentido hacia {destination}"
+            }
+        },
+        "notification": {
+            "default": {
+                "default": "Continúa {modifier}",
+                "name": "Continúa {modifier} por {way_name}",
+                "destination": "Continúa {modifier} hacia {destination}"
+            },
+            "uturn": {
+                "default": "Haz un cambio de sentido",
+                "name": "Haz un cambio de sentido en {way_name}",
+                "destination": "Haz un cambio de sentido hacia {destination}"
+            }
+        },
+        "off ramp": {
+            "default": {
+                "default": "Coge la cuesta abajo",
+                "name": "Coge la cuesta abajo por {way_name}",
+                "destination": "Coge la cuesta abajo hacia {destination}",
+                "exit": "Coge la cuesta abajo {exit}",
+                "exit_destination": "Coge la cuesta abajo {exit} hacia {destination}"
+            },
+            "left": {
+                "default": "Coge la cuesta abajo de la izquierda",
+                "name": "Coge la cuesta abajo de la izquierda por {way_name}",
+                "destination": "Coge la cuesta abajo de la izquierda hacia {destination}",
+                "exit": "Coge la cuesta abajo {exit} a tu izquierda",
+                "exit_destination": "Coge la cuesta abajo {exit} a tu izquierda hacia {destination}"
+            },
+            "right": {
+                "default": "Coge la cuesta abajo de la derecha",
+                "name": "Coge la cuesta abajo de la derecha por {way_name}",
+                "destination": "Coge la cuesta abajo de la derecha hacia {destination}",
+                "exit": "Coge la cuesta abajo {exit}",
+                "exit_destination": "Coge la cuesta abajo {exit} hacia {destination}"
+            },
+            "sharp left": {
+                "default": "Coge la cuesta abajo de la izquierda",
+                "name": "Coge la cuesta abajo de la izquierda por {way_name}",
+                "destination": "Coge la cuesta abajo de la izquierda hacia {destination}",
+                "exit": "Coge la cuesta abajo {exit} a tu izquierda",
+                "exit_destination": "Coge la cuesta abajo {exit} a tu izquierda hacia {destination}"
+            },
+            "sharp right": {
+                "default": "Coge la cuesta abajo de la derecha",
+                "name": "Coge la cuesta abajo de la derecha por {way_name}",
+                "destination": "Coge la cuesta abajo de la derecha hacia {destination}",
+                "exit": "Coge la cuesta abajo {exit}",
+                "exit_destination": "Coge la cuesta abajo {exit} hacia {destination}"
+            },
+            "slight left": {
+                "default": "Coge la cuesta abajo de la izquierda",
+                "name": "Coge la cuesta abajo de la izquierda por {way_name}",
+                "destination": "Coge la cuesta abajo de la izquierda hacia {destination}",
+                "exit": "Coge la cuesta abajo {exit} a tu izquierda",
+                "exit_destination": "Coge la cuesta abajo {exit} a tu izquierda hacia {destination}"
+            },
+            "slight right": {
+                "default": "Coge la cuesta abajo de la derecha",
+                "name": "Coge la cuesta abajo de la derecha por {way_name}",
+                "destination": "Coge la cuesta abajo de la derecha hacia {destination}",
+                "exit": "Coge la cuesta abajo {exit}",
+                "exit_destination": "Coge la cuesta abajo {exit} hacia {destination}"
+            }
+        },
+        "on ramp": {
+            "default": {
+                "default": "Coge la cuesta",
+                "name": "Coge la cuesta por {way_name}",
+                "destination": "Coge la cuesta hacia {destination}"
+            },
+            "left": {
+                "default": "Coge la cuesta de la izquierda",
+                "name": "Coge la cuesta de la izquierda por {way_name}",
+                "destination": "Coge la cuesta de la izquierda hacia {destination}"
+            },
+            "right": {
+                "default": "Coge la cuesta de la derecha",
+                "name": "Coge la cuesta de la derecha por {way_name}",
+                "destination": "Coge la cuesta de la derecha hacia {destination}"
+            },
+            "sharp left": {
+                "default": "Coge la cuesta de la izquierda",
+                "name": "Coge la cuesta de la izquierda por {way_name}",
+                "destination": "Coge la cuesta de la izquierda hacia {destination}"
+            },
+            "sharp right": {
+                "default": "Coge la cuesta de la derecha",
+                "name": "Coge la cuesta de la derecha por {way_name}",
+                "destination": "Coge la cuesta de la derecha hacia {destination}"
+            },
+            "slight left": {
+                "default": "Coge la cuesta de la izquierda",
+                "name": "Coge la cuesta de la izquierda por {way_name}",
+                "destination": "Coge la cuesta de la izquierda hacia {destination}"
+            },
+            "slight right": {
+                "default": "Coge la cuesta de la derecha",
+                "name": "Coge la cuesta de la derecha por {way_name}",
+                "destination": "Coge la cuesta de la derecha hacia {destination}"
+            }
+        },
+        "rotary": {
+            "default": {
+                "default": {
+                    "default": "Incorpórate en la rotonda",
+                    "name": "En la rotonda sal por {way_name}",
+                    "destination": "En la rotonda sal hacia {destination}"
+                },
+                "name": {
+                    "default": "En {rotary_name}",
+                    "name": "En {rotary_name} sal por {way_name}",
+                    "destination": "En {rotary_name} sal hacia {destination}"
+                },
+                "exit": {
+                    "default": "En la rotonda toma la {exit_number} salida",
+                    "name": "En la rotonda toma la {exit_number} salida por {way_name}",
+                    "destination": "En la rotonda toma la {exit_number} salida hacia {destination}"
+                },
+                "name_exit": {
+                    "default": "En {rotary_name} toma la {exit_number} salida",
+                    "name": "En {rotary_name} toma la {exit_number} salida por {way_name}",
+                    "destination": "En {rotary_name} toma la {exit_number} salida hacia {destination}"
+                }
+            }
+        },
+        "roundabout": {
+            "default": {
+                "exit": {
+                    "default": "Entra en la rotonda y toma la {exit_number} salida",
+                    "name": "Entra en la rotonda y toma la {exit_number} salida por {way_name}",
+                    "destination": "Entra en la rotonda y toma la {exit_number} salida hacia {destination}"
+                },
+                "default": {
+                    "default": "Entra en la rotonda",
+                    "name": "Entra en la rotonda y sal por {way_name}",
+                    "destination": "Entra en la rotonda y sal hacia {destination}"
+                }
+            }
+        },
+        "roundabout turn": {
+            "default": {
+                "default": "En la rotonda siga {modifier}",
+                "name": "En la rotonda siga {modifier} por {way_name}",
+                "destination": "En la rotonda siga {modifier} hacia {destination}"
+            },
+            "left": {
+                "default": "En la rotonda gira a la izquierda",
+                "name": "En la rotonda gira a la izquierda por {way_name}",
+                "destination": "En la rotonda gira a la izquierda hacia {destination}"
+            },
+            "right": {
+                "default": "En la rotonda gira a la derecha",
+                "name": "En la rotonda gira a la derecha por {way_name}",
+                "destination": "En la rotonda gira a la derecha hacia {destination}"
+            },
+            "straight": {
+                "default": "En la rotonda continúa recto",
+                "name": "En la rotonda continúa recto por {way_name}",
+                "destination": "En la rotonda continúa recto hacia {destination}"
+            }
+        },
+        "exit roundabout": {
+            "default": {
+                "default": "Siga {modifier}",
+                "name": "Siga {modifier} en {way_name}",
+                "destination": "Siga {modifier} hacia {destination}"
+            },
+            "left": {
+                "default": "Gire a la izquierda",
+                "name": "Gire a la izquierda en  {way_name}",
+                "destination": "Gire a la izquierda hacia {destination}"
+            },
+            "right": {
+                "default": "Gire a la derecha",
+                "name": "Gire a la derecha en  {way_name}",
+                "destination": "Gire a la derecha hacia {destination}"
+            },
+            "straight": {
+                "default": "Ve recto",
+                "name": "Ve recto en  {way_name}",
+                "destination": "Ve recto hacia {destination}"
+            }
+        },
+        "exit rotary": {
+            "default": {
+                "default": "Siga {modifier}",
+                "name": "Siga {modifier} en {way_name}",
+                "destination": "Siga {modifier} hacia {destination}"
+            },
+            "left": {
+                "default": "Gire a la izquierda",
+                "name": "Gire a la izquierda en  {way_name}",
+                "destination": "Gire a la izquierda hacia  {destination}"
+            },
+            "right": {
+                "default": "Gire a la derecha",
+                "name": "Gire a la derecha en  {way_name}",
+                "destination": "Gire a la derecha hacia  {destination}"
+            },
+            "straight": {
+                "default": "Ve recto",
+                "name": "Ve recto en  {way_name}",
+                "destination": "Ve recto hacia  {destination}"
+            }
+        },
+        "turn": {
+            "default": {
+                "default": "Gira {modifier}",
+                "name": "Gira {modifier} por {way_name}",
+                "destination": "Gira {modifier} hacia {destination}"
+            },
+            "left": {
+                "default": "Gira a la izquierda",
+                "name": "Gira a la izquierda por {way_name}",
+                "destination": "Gira a la izquierda hacia {destination}"
+            },
+            "right": {
+                "default": "Gira a la derecha",
+                "name": "Gira a la derecha por {way_name}",
+                "destination": "Gira a la derecha hacia {destination}"
+            },
+            "straight": {
+                "default": "Continúa recto",
+                "name": "Continúa recto por {way_name}",
+                "destination": "Continúa recto hacia  {destination}"
+            }
+        },
+        "use lane": {
+            "no_lanes": {
+                "default": "Continúa recto"
+            },
+            "default": {
+                "default": "{lane_instruction}"
+            }
+        }
+    }
+}

--- a/test/fixtures/v5/arrive/left.json
+++ b/test/fixtures/v5/arrive/left.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich links",
         "en": "You have arrived at your destination, on the left",
         "es": "Has llegado a tu destino, a la izquierda",
+        "es-ES": "Has llegado a tu destino, a la izquierda",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kiri",
         "it": "Sei arrivato alla tua destinazione, sulla sinistra",

--- a/test/fixtures/v5/arrive/no_modifier.json
+++ b/test/fixtures/v5/arrive/no_modifier.json
@@ -9,6 +9,7 @@
         "de": "Sie haben Ihr Ziel erreicht",
         "en": "You have arrived at your destination",
         "es": "Has llegado a tu destino",
+        "es-ES": "Has llegado a tu destino",
         "fr": "Vous êtes arrivés à votre destination",
         "id": "Anda telah tiba di tujuan ke-",
         "it": "Sei arrivato alla tua destinazione",

--- a/test/fixtures/v5/arrive/right.json
+++ b/test/fixtures/v5/arrive/right.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich rechts",
         "en": "You have arrived at your destination, on the right",
         "es": "Has llegado a tu destino, a la derecha",
+        "es-ES": "Has llegado a tu destino, a la derecha",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kanan",
         "it": "Sei arrivato alla tua destinazione, sulla destra",

--- a/test/fixtures/v5/arrive/sharp_left.json
+++ b/test/fixtures/v5/arrive/sharp_left.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich links",
         "en": "You have arrived at your destination, on the left",
         "es": "Has llegado a tu destino, a la izquierda",
+        "es-ES": "Has llegado a tu destino, a la izquierda",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kiri",
         "it": "Sei arrivato alla tua destinazione, sulla sinistra",

--- a/test/fixtures/v5/arrive/sharp_right.json
+++ b/test/fixtures/v5/arrive/sharp_right.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich rechts",
         "en": "You have arrived at your destination, on the right",
         "es": "Has llegado a tu destino, a la derecha",
+        "es-ES": "Has llegado a tu destino, a la derecha",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kanan",
         "it": "Sei arrivato alla tua destinazione, sulla destra",

--- a/test/fixtures/v5/arrive/slight_left.json
+++ b/test/fixtures/v5/arrive/slight_left.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich links",
         "en": "You have arrived at your destination, on the left",
         "es": "Has llegado a tu destino, a la izquierda",
+        "es-ES": "Has llegado a tu destino, a la izquierda",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kiri",
         "it": "Sei arrivato alla tua destinazione, sulla sinistra",

--- a/test/fixtures/v5/arrive/slight_right.json
+++ b/test/fixtures/v5/arrive/slight_right.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich rechts",
         "en": "You have arrived at your destination, on the right",
         "es": "Has llegado a tu destino, a la derecha",
+        "es-ES": "Has llegado a tu destino, a la derecha",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kanan",
         "it": "Sei arrivato alla tua destinazione, sulla destra",

--- a/test/fixtures/v5/arrive/straight.json
+++ b/test/fixtures/v5/arrive/straight.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich geradeaus",
         "en": "You have arrived at your destination, straight ahead",
         "es": "Has llegado a tu destino, en frente",
+        "es-ES": "Has llegado a tu destino, en frente",
         "fr": "Vous êtes arrivés à votre destination, droit devant",
         "id": "Anda telah tiba di tujuan ke-, lurus saja",
         "it": "Sei arrivato alla tua destinazione, si trova davanti a te",

--- a/test/fixtures/v5/arrive/uturn.json
+++ b/test/fixtures/v5/arrive/uturn.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr Ziel erreicht",
         "en": "You have arrived at your destination",
         "es": "Has llegado a tu destino",
+        "es-ES": "Has llegado a tu destino",
         "fr": "Vous êtes arrivés à votre destination",
         "id": "Anda telah tiba di tujuan ke-",
         "it": "Sei arrivato alla tua destinazione",

--- a/test/fixtures/v5/arrive_waypoint/left.json
+++ b/test/fixtures/v5/arrive_waypoint/left.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr erste Ziel erreicht, es befindet sich links",
         "en": "You have arrived at your 1st destination, on the left",
         "es": "Has llegado a tu 1ª destino, a la izquierda",
+        "es-ES": "Has llegado a tu 1ª destino, a la izquierda",
         "fr": "Vous êtes arrivés à votre première destination, sur la gauche",
         "id": "Anda telah tiba di tujuan ke-1, di sebelah kiri",
         "it": "Sei arrivato alla tua 1ª destinazione, sulla sinistra",

--- a/test/fixtures/v5/arrive_waypoint/no_modifier.json
+++ b/test/fixtures/v5/arrive_waypoint/no_modifier.json
@@ -9,6 +9,7 @@
         "de": "Sie haben Ihr erste Ziel erreicht",
         "en": "You have arrived at your 1st destination",
         "es": "Has llegado a tu 1ª destino",
+        "es-ES": "Has llegado a tu 1ª destino",
         "fr": "Vous êtes arrivés à votre première destination",
         "id": "Anda telah tiba di tujuan ke-1",
         "it": "Sei arrivato alla tua 1ª destinazione",

--- a/test/fixtures/v5/arrive_waypoint/right.json
+++ b/test/fixtures/v5/arrive_waypoint/right.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr erste Ziel erreicht, es befindet sich rechts",
         "en": "You have arrived at your 1st destination, on the right",
         "es": "Has llegado a tu 1ª destino, a la derecha",
+        "es-ES": "Has llegado a tu 1ª destino, a la derecha",
         "fr": "Vous êtes arrivés à votre première destination, sur la droite",
         "id": "Anda telah tiba di tujuan ke-1, di sebelah kanan",
         "it": "Sei arrivato alla tua 1ª destinazione, sulla destra",

--- a/test/fixtures/v5/arrive_waypoint/sharp_left.json
+++ b/test/fixtures/v5/arrive_waypoint/sharp_left.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr erste Ziel erreicht, es befindet sich links",
         "en": "You have arrived at your 1st destination, on the left",
         "es": "Has llegado a tu 1ª destino, a la izquierda",
+        "es-ES": "Has llegado a tu 1ª destino, a la izquierda",
         "fr": "Vous êtes arrivés à votre première destination, sur la gauche",
         "id": "Anda telah tiba di tujuan ke-1, di sebelah kiri",
         "it": "Sei arrivato alla tua 1ª destinazione, sulla sinistra",

--- a/test/fixtures/v5/arrive_waypoint/sharp_right.json
+++ b/test/fixtures/v5/arrive_waypoint/sharp_right.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr erste Ziel erreicht, es befindet sich rechts",
         "en": "You have arrived at your 1st destination, on the right",
         "es": "Has llegado a tu 1ª destino, a la derecha",
+        "es-ES": "Has llegado a tu 1ª destino, a la derecha",
         "fr": "Vous êtes arrivés à votre première destination, sur la droite",
         "id": "Anda telah tiba di tujuan ke-1, di sebelah kanan",
         "it": "Sei arrivato alla tua 1ª destinazione, sulla destra",

--- a/test/fixtures/v5/arrive_waypoint/slight_left.json
+++ b/test/fixtures/v5/arrive_waypoint/slight_left.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr erste Ziel erreicht, es befindet sich links",
         "en": "You have arrived at your 1st destination, on the left",
         "es": "Has llegado a tu 1ª destino, a la izquierda",
+        "es-ES": "Has llegado a tu 1ª destino, a la izquierda",
         "fr": "Vous êtes arrivés à votre première destination, sur la gauche",
         "id": "Anda telah tiba di tujuan ke-1, di sebelah kiri",
         "it": "Sei arrivato alla tua 1ª destinazione, sulla sinistra",

--- a/test/fixtures/v5/arrive_waypoint/slight_right.json
+++ b/test/fixtures/v5/arrive_waypoint/slight_right.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr erste Ziel erreicht, es befindet sich rechts",
         "en": "You have arrived at your 1st destination, on the right",
         "es": "Has llegado a tu 1ª destino, a la derecha",
+        "es-ES": "Has llegado a tu 1ª destino, a la derecha",
         "fr": "Vous êtes arrivés à votre première destination, sur la droite",
         "id": "Anda telah tiba di tujuan ke-1, di sebelah kanan",
         "it": "Sei arrivato alla tua 1ª destinazione, sulla destra",

--- a/test/fixtures/v5/arrive_waypoint/straight.json
+++ b/test/fixtures/v5/arrive_waypoint/straight.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr erste Ziel erreicht, es befindet sich geradeaus",
         "en": "You have arrived at your 1st destination, straight ahead",
         "es": "Has llegado a tu 1ª destino, en frente",
+        "es-ES": "Has llegado a tu 1ª destino, en frente",
         "fr": "Vous êtes arrivés à votre première destination, droit devant",
         "id": "Anda telah tiba di tujuan ke-1, lurus saja",
         "it": "Sei arrivato alla tua 1ª destinazione, si trova davanti a te",

--- a/test/fixtures/v5/arrive_waypoint/uturn.json
+++ b/test/fixtures/v5/arrive_waypoint/uturn.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr erste Ziel erreicht",
         "en": "You have arrived at your 1st destination",
         "es": "Has llegado a tu 1ª destino",
+        "es-ES": "Has llegado a tu 1ª destino",
         "fr": "Vous êtes arrivés à votre première destination",
         "id": "Anda telah tiba di tujuan ke-1",
         "it": "Sei arrivato alla tua 1ª destinazione",

--- a/test/fixtures/v5/arrive_waypoint_last/left.json
+++ b/test/fixtures/v5/arrive_waypoint_last/left.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich links",
         "en": "You have arrived at your destination, on the left",
         "es": "Has llegado a tu destino, a la izquierda",
+        "es-ES": "Has llegado a tu destino, a la izquierda",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kiri",
         "it": "Sei arrivato alla tua destinazione, sulla sinistra",

--- a/test/fixtures/v5/arrive_waypoint_last/no_modifier.json
+++ b/test/fixtures/v5/arrive_waypoint_last/no_modifier.json
@@ -9,6 +9,7 @@
         "de": "Sie haben Ihr Ziel erreicht",
         "en": "You have arrived at your destination",
         "es": "Has llegado a tu destino",
+        "es-ES": "Has llegado a tu destino",
         "fr": "Vous êtes arrivés à votre destination",
         "id": "Anda telah tiba di tujuan ke-",
         "it": "Sei arrivato alla tua destinazione",

--- a/test/fixtures/v5/arrive_waypoint_last/right.json
+++ b/test/fixtures/v5/arrive_waypoint_last/right.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich rechts",
         "en": "You have arrived at your destination, on the right",
         "es": "Has llegado a tu destino, a la derecha",
+        "es-ES": "Has llegado a tu destino, a la derecha",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kanan",
         "it": "Sei arrivato alla tua destinazione, sulla destra",

--- a/test/fixtures/v5/arrive_waypoint_last/sharp_left.json
+++ b/test/fixtures/v5/arrive_waypoint_last/sharp_left.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich links",
         "en": "You have arrived at your destination, on the left",
         "es": "Has llegado a tu destino, a la izquierda",
+        "es-ES": "Has llegado a tu destino, a la izquierda",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kiri",
         "it": "Sei arrivato alla tua destinazione, sulla sinistra",

--- a/test/fixtures/v5/arrive_waypoint_last/sharp_right.json
+++ b/test/fixtures/v5/arrive_waypoint_last/sharp_right.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich rechts",
         "en": "You have arrived at your destination, on the right",
         "es": "Has llegado a tu destino, a la derecha",
+        "es-ES": "Has llegado a tu destino, a la derecha",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kanan",
         "it": "Sei arrivato alla tua destinazione, sulla destra",

--- a/test/fixtures/v5/arrive_waypoint_last/slight_left.json
+++ b/test/fixtures/v5/arrive_waypoint_last/slight_left.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich links",
         "en": "You have arrived at your destination, on the left",
         "es": "Has llegado a tu destino, a la izquierda",
+        "es-ES": "Has llegado a tu destino, a la izquierda",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kiri",
         "it": "Sei arrivato alla tua destinazione, sulla sinistra",

--- a/test/fixtures/v5/arrive_waypoint_last/slight_right.json
+++ b/test/fixtures/v5/arrive_waypoint_last/slight_right.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich rechts",
         "en": "You have arrived at your destination, on the right",
         "es": "Has llegado a tu destino, a la derecha",
+        "es-ES": "Has llegado a tu destino, a la derecha",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kanan",
         "it": "Sei arrivato alla tua destinazione, sulla destra",

--- a/test/fixtures/v5/arrive_waypoint_last/straight.json
+++ b/test/fixtures/v5/arrive_waypoint_last/straight.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr Ziel erreicht, es befindet sich geradeaus",
         "en": "You have arrived at your destination, straight ahead",
         "es": "Has llegado a tu destino, en frente",
+        "es-ES": "Has llegado a tu destino, en frente",
         "fr": "Vous êtes arrivés à votre destination, droit devant",
         "id": "Anda telah tiba di tujuan ke-, lurus saja",
         "it": "Sei arrivato alla tua destinazione, si trova davanti a te",

--- a/test/fixtures/v5/arrive_waypoint_last/uturn.json
+++ b/test/fixtures/v5/arrive_waypoint_last/uturn.json
@@ -10,6 +10,7 @@
         "de": "Sie haben Ihr Ziel erreicht",
         "en": "You have arrived at your destination",
         "es": "Has llegado a tu destino",
+        "es-ES": "Has llegado a tu destino",
         "fr": "Vous êtes arrivés à votre destination",
         "id": "Anda telah tiba di tujuan ke-",
         "it": "Sei arrivato alla tua destinazione",

--- a/test/fixtures/v5/continue/left_default.json
+++ b/test/fixtures/v5/continue/left_default.json
@@ -10,6 +10,7 @@
         "de": "Links abbiegen",
         "en": "Turn left",
         "es": "Gire a izquierda",
+        "es-ES": "Gire a a la izquierda",
         "fr": "Tourner à gauche",
         "id": "Belok kiri",
         "it": "Gira a sinistra",

--- a/test/fixtures/v5/continue/left_destination.json
+++ b/test/fixtures/v5/continue/left_destination.json
@@ -11,6 +11,7 @@
         "de": "Links abbiegen Richtung Destination 1",
         "en": "Turn left towards Destination 1",
         "es": "Gire a izquierda hacia Destination 1",
+        "es-ES": "Gire a a la izquierda hacia Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "id": "Belok kiri menuju Destination 1",
         "it": "Gira a sinistra verso Destination 1",

--- a/test/fixtures/v5/continue/left_exit.json
+++ b/test/fixtures/v5/continue/left_exit.json
@@ -11,6 +11,7 @@
         "de": "Links abbiegen auf Way Name",
         "en": "Turn left onto Way Name",
         "es": "Gire a izquierda en Way Name",
+        "es-ES": "Gire a a la izquierda en Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "id": "Belok kiri ke Way Name",
         "it": "Gira a sinistra in Way Name",

--- a/test/fixtures/v5/continue/left_exit_destination.json
+++ b/test/fixtures/v5/continue/left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Links abbiegen Richtung Destination 1",
         "en": "Turn left towards Destination 1",
         "es": "Gire a izquierda hacia Destination 1",
+        "es-ES": "Gire a a la izquierda hacia Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "id": "Belok kiri menuju Destination 1",
         "it": "Gira a sinistra verso Destination 1",

--- a/test/fixtures/v5/continue/left_name.json
+++ b/test/fixtures/v5/continue/left_name.json
@@ -10,6 +10,7 @@
         "de": "Links weiterfahren auf Way Name",
         "en": "Turn left to stay on Way Name",
         "es": "Cruce a laizquierda en Way Name",
+        "es-ES": "Cruce a laa la izquierda en Way Name",
         "fr": "Continuer à gauche sur Way Name",
         "id": "Terus kiri ke Way Name",
         "it": "Continua a sinistra per stare su Way Name",

--- a/test/fixtures/v5/continue/right_default.json
+++ b/test/fixtures/v5/continue/right_default.json
@@ -10,6 +10,7 @@
         "de": "Rechts abbiegen",
         "en": "Turn right",
         "es": "Gire a derecha",
+        "es-ES": "Gire a a la derecha",
         "fr": "Tourner à droite",
         "id": "Belok kanan",
         "it": "Gira a destra",

--- a/test/fixtures/v5/continue/right_destination.json
+++ b/test/fixtures/v5/continue/right_destination.json
@@ -11,6 +11,7 @@
         "de": "Rechts abbiegen Richtung Destination 1",
         "en": "Turn right towards Destination 1",
         "es": "Gire a derecha hacia Destination 1",
+        "es-ES": "Gire a a la derecha hacia Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "id": "Belok kanan menuju Destination 1",
         "it": "Gira a destra verso Destination 1",

--- a/test/fixtures/v5/continue/right_exit.json
+++ b/test/fixtures/v5/continue/right_exit.json
@@ -11,6 +11,7 @@
         "de": "Rechts abbiegen auf Way Name",
         "en": "Turn right onto Way Name",
         "es": "Gire a derecha en Way Name",
+        "es-ES": "Gire a a la derecha en Way Name",
         "fr": "Tourner à droite sur Way Name",
         "id": "Belok kanan ke Way Name",
         "it": "Gira a destra in Way Name",

--- a/test/fixtures/v5/continue/right_exit_destination.json
+++ b/test/fixtures/v5/continue/right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Rechts abbiegen Richtung Destination 1",
         "en": "Turn right towards Destination 1",
         "es": "Gire a derecha hacia Destination 1",
+        "es-ES": "Gire a a la derecha hacia Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "id": "Belok kanan menuju Destination 1",
         "it": "Gira a destra verso Destination 1",

--- a/test/fixtures/v5/continue/right_name.json
+++ b/test/fixtures/v5/continue/right_name.json
@@ -10,6 +10,7 @@
         "de": "Rechts weiterfahren auf Way Name",
         "en": "Turn right to stay on Way Name",
         "es": "Cruce a laderecha en Way Name",
+        "es-ES": "Cruce a laa la derecha en Way Name",
         "fr": "Continuer à droite sur Way Name",
         "id": "Terus kanan ke Way Name",
         "it": "Continua a destra per stare su Way Name",

--- a/test/fixtures/v5/continue/sharp_left_default.json
+++ b/test/fixtures/v5/continue/sharp_left_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf links",
         "en": "Make a sharp left",
         "es": "Gire a la izquierda",
+        "es-ES": "Gire a la izquierda",
         "fr": "Prendre franchement à gauche",
         "id": "Belok kiri tajam",
         "it": "Svolta a sinistra",

--- a/test/fixtures/v5/continue/sharp_left_destination.json
+++ b/test/fixtures/v5/continue/sharp_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf links Richtung Destination 1",
         "en": "Make a sharp left towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Gire a la izquierda hacia Destination 1",
         "fr": "Prendre franchement à gauche en direction de Destination 1",
         "id": "Belok kiri tajam menuju Destination 1",
         "it": "Svolta a sinistra verso Destination 1",

--- a/test/fixtures/v5/continue/sharp_left_exit.json
+++ b/test/fixtures/v5/continue/sharp_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf links weiterfahren auf Way Name",
         "en": "Make a sharp left to stay on Way Name",
         "es": "Gire a la izquierda en Way Name",
+        "es-ES": "Gire a la izquierda en Way Name",
         "fr": "Make a sharp left to stay on Way Name",
         "id": "Make a sharp left to stay on Way Name",
         "it": "Make a sharp left to stay on Way Name",

--- a/test/fixtures/v5/continue/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/continue/sharp_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf links Richtung Destination 1",
         "en": "Make a sharp left towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Gire a la izquierda hacia Destination 1",
         "fr": "Prendre franchement à gauche en direction de Destination 1",
         "id": "Belok kiri tajam menuju Destination 1",
         "it": "Svolta a sinistra verso Destination 1",

--- a/test/fixtures/v5/continue/sharp_left_name.json
+++ b/test/fixtures/v5/continue/sharp_left_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf links weiterfahren auf Way Name",
         "en": "Make a sharp left to stay on Way Name",
         "es": "Gire a la izquierda en Way Name",
+        "es-ES": "Gire a la izquierda en Way Name",
         "fr": "Make a sharp left to stay on Way Name",
         "id": "Make a sharp left to stay on Way Name",
         "it": "Make a sharp left to stay on Way Name",

--- a/test/fixtures/v5/continue/sharp_right_default.json
+++ b/test/fixtures/v5/continue/sharp_right_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts",
         "en": "Make a sharp right",
         "es": "Gire a la derecha",
+        "es-ES": "Gire a la derecha",
         "fr": "Prendre franchement à droite",
         "id": "Belok kanan tajam",
         "it": "Svolta a destra",

--- a/test/fixtures/v5/continue/sharp_right_destination.json
+++ b/test/fixtures/v5/continue/sharp_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts Richtung Destination 1",
         "en": "Make a sharp right towards Destination 1",
         "es": "Gire a la derecha hacia Destination 1",
+        "es-ES": "Gire a la derecha hacia Destination 1",
         "fr": "Prendre franchement à droite en direction de Destination 1",
         "id": "Belok kanan tajam menuju Destination 1",
         "it": "Svolta a destra verso Destination 1",

--- a/test/fixtures/v5/continue/sharp_right_exit.json
+++ b/test/fixtures/v5/continue/sharp_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts weiterfahren auf Way Name",
         "en": "Make a sharp right to stay on Way Name",
         "es": "Gire a la derecha en Way Name",
+        "es-ES": "Gire a la derecha en Way Name",
         "fr": "Make a sharp right to stay on Way Name",
         "id": "Make a sharp right to stay on Way Name",
         "it": "Make a sharp right to stay on Way Name",

--- a/test/fixtures/v5/continue/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/continue/sharp_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf rechts Richtung Destination 1",
         "en": "Make a sharp right towards Destination 1",
         "es": "Gire a la derecha hacia Destination 1",
+        "es-ES": "Gire a la derecha hacia Destination 1",
         "fr": "Prendre franchement à droite en direction de Destination 1",
         "id": "Belok kanan tajam menuju Destination 1",
         "it": "Svolta a destra verso Destination 1",

--- a/test/fixtures/v5/continue/sharp_right_name.json
+++ b/test/fixtures/v5/continue/sharp_right_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts weiterfahren auf Way Name",
         "en": "Make a sharp right to stay on Way Name",
         "es": "Gire a la derecha en Way Name",
+        "es-ES": "Gire a la derecha en Way Name",
         "fr": "Make a sharp right to stay on Way Name",
         "id": "Make a sharp right to stay on Way Name",
         "it": "Make a sharp right to stay on Way Name",

--- a/test/fixtures/v5/continue/slight_left_default.json
+++ b/test/fixtures/v5/continue/slight_left_default.json
@@ -10,6 +10,7 @@
         "de": "Leicht links",
         "en": "Make a slight left",
         "es": "Gire a la izquierda",
+        "es-ES": "Gire a la izquierda",
         "fr": "Continuer légèrement à gauche",
         "id": "Tetap agak di kiri",
         "it": "Continua leggermente a sinistra",

--- a/test/fixtures/v5/continue/slight_left_destination.json
+++ b/test/fixtures/v5/continue/slight_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Leicht links weiter Richtung Destination 1",
         "en": "Make a slight left towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Gire a la izquierda hacia Destination 1",
         "fr": "Continuer légèrement à gauche en direction de Destination 1",
         "id": "Tetap agak di kiri menuju Destination 1",
         "it": "Continua leggermente a sinistra verso Destination 1",

--- a/test/fixtures/v5/continue/slight_left_exit.json
+++ b/test/fixtures/v5/continue/slight_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Leicht links weiter auf Way Name",
         "en": "Make a slight left to stay on Way Name",
         "es": "Doble levemente a la izquierda en Way Name",
+        "es-ES": "Doble levemente a la izquierda en Way Name",
         "fr": "Continuer légèrement à gauche sur Way Name",
         "id": "Tetap agak di kiri ke Way Name",
         "it": "Continua leggermente a sinistra per stare su Way Name",

--- a/test/fixtures/v5/continue/slight_left_exit_destination.json
+++ b/test/fixtures/v5/continue/slight_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Leicht links weiter Richtung Destination 1",
         "en": "Make a slight left towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Gire a la izquierda hacia Destination 1",
         "fr": "Continuer légèrement à gauche en direction de Destination 1",
         "id": "Tetap agak di kiri menuju Destination 1",
         "it": "Continua leggermente a sinistra verso Destination 1",

--- a/test/fixtures/v5/continue/slight_left_name.json
+++ b/test/fixtures/v5/continue/slight_left_name.json
@@ -10,6 +10,7 @@
         "de": "Leicht links weiter auf Way Name",
         "en": "Make a slight left to stay on Way Name",
         "es": "Doble levemente a la izquierda en Way Name",
+        "es-ES": "Doble levemente a la izquierda en Way Name",
         "fr": "Continuer légèrement à gauche sur Way Name",
         "id": "Tetap agak di kiri ke Way Name",
         "it": "Continua leggermente a sinistra per stare su Way Name",

--- a/test/fixtures/v5/continue/slight_right_default.json
+++ b/test/fixtures/v5/continue/slight_right_default.json
@@ -10,6 +10,7 @@
         "de": "Leicht rechts weiter",
         "en": "Make a slight right",
         "es": "Gire a la izquierda",
+        "es-ES": "Gire a la izquierda",
         "fr": "Continuer légèrement à droite",
         "id": "Tetap agak di kanan",
         "it": "Continua leggermente a destra",

--- a/test/fixtures/v5/continue/slight_right_destination.json
+++ b/test/fixtures/v5/continue/slight_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts weiter Richtung Destination 1",
         "en": "Make a slight right towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Gire a la izquierda hacia Destination 1",
         "fr": "Continuer légèrement à droite en direction de Destination 1",
         "id": "Tetap agak di kanan menuju Destination 1",
         "it": "Continua leggermente a destra verso Destination 1",

--- a/test/fixtures/v5/continue/slight_right_exit.json
+++ b/test/fixtures/v5/continue/slight_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts weiter auf Way Name",
         "en": "Make a slight right to stay on Way Name",
         "es": "Doble levemente a la derecha en Way Name",
+        "es-ES": "Doble levemente a la derecha en Way Name",
         "fr": "Continuer légèrement à droite sur Way Name",
         "id": "Tetap agak di kanan ke Way Name",
         "it": "Continua leggermente a destra per stare su Way Name",

--- a/test/fixtures/v5/continue/slight_right_exit_destination.json
+++ b/test/fixtures/v5/continue/slight_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Leicht rechts weiter Richtung Destination 1",
         "en": "Make a slight right towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Gire a la izquierda hacia Destination 1",
         "fr": "Continuer légèrement à droite en direction de Destination 1",
         "id": "Tetap agak di kanan menuju Destination 1",
         "it": "Continua leggermente a destra verso Destination 1",

--- a/test/fixtures/v5/continue/slight_right_name.json
+++ b/test/fixtures/v5/continue/slight_right_name.json
@@ -10,6 +10,7 @@
         "de": "Leicht rechts weiter auf Way Name",
         "en": "Make a slight right to stay on Way Name",
         "es": "Doble levemente a la derecha en Way Name",
+        "es-ES": "Doble levemente a la derecha en Way Name",
         "fr": "Continuer légèrement à droite sur Way Name",
         "id": "Tetap agak di kanan ke Way Name",
         "it": "Continua leggermente a destra per stare su Way Name",

--- a/test/fixtures/v5/continue/straight_default.json
+++ b/test/fixtures/v5/continue/straight_default.json
@@ -10,6 +10,7 @@
         "de": "Geradeaus weiterfahren",
         "en": "Continue straight",
         "es": "Continúe recto",
+        "es-ES": "Continúe recto",
         "fr": "Continuer tout droit",
         "id": "Lurus terus",
         "it": "Continua dritto",

--- a/test/fixtures/v5/continue/straight_destination.json
+++ b/test/fixtures/v5/continue/straight_destination.json
@@ -11,6 +11,7 @@
         "de": "Weiterfahren in Richtung Destination 1",
         "en": "Continue towards Destination 1",
         "es": "Continúe hacia Destination 1",
+        "es-ES": "Continúe hacia Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "id": "Terus menuju Destination 1",
         "it": "Continua verso Destination 1",

--- a/test/fixtures/v5/continue/straight_exit.json
+++ b/test/fixtures/v5/continue/straight_exit.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus weiterfahren auf Way Name",
         "en": "Continue straight to stay on Way Name",
         "es": "Continúe en Way Name",
+        "es-ES": "Continúe en Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "id": "Terus ke Way Name",
         "it": "Continua dritto per stare su Way Name",

--- a/test/fixtures/v5/continue/straight_exit_destination.json
+++ b/test/fixtures/v5/continue/straight_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Weiterfahren in Richtung Destination 1",
         "en": "Continue towards Destination 1",
         "es": "Continúe hacia Destination 1",
+        "es-ES": "Continúe hacia Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "id": "Terus menuju Destination 1",
         "it": "Continua verso Destination 1",

--- a/test/fixtures/v5/continue/straight_name.json
+++ b/test/fixtures/v5/continue/straight_name.json
@@ -10,6 +10,7 @@
         "de": "Geradeaus weiterfahren auf Way Name",
         "en": "Continue straight to stay on Way Name",
         "es": "Continúe en Way Name",
+        "es-ES": "Continúe en Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "id": "Terus ke Way Name",
         "it": "Continua dritto per stare su Way Name",

--- a/test/fixtures/v5/continue/uturn_default.json
+++ b/test/fixtures/v5/continue/uturn_default.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung",
         "en": "Make a U-turn",
         "es": "Haz un cambio de sentido",
+        "es-ES": "Haz un cambio de sentido",
         "fr": "Faire demi-tour",
         "id": "Putar balik",
         "it": "Fai un'inversione a U",

--- a/test/fixtures/v5/continue/uturn_destination.json
+++ b/test/fixtures/v5/continue/uturn_destination.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
+        "es-ES": "Haz un cambio de sentido hacia Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "id": "Putar balik menuju Destination 1",
         "it": "Fai un'inversione a U verso Destination 1",

--- a/test/fixtures/v5/continue/uturn_exit.json
+++ b/test/fixtures/v5/continue/uturn_exit.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung auf Way Name",
         "en": "Make a U-turn and continue on Way Name",
         "es": "Haz un cambio de sentido y continúe en Way Name",
+        "es-ES": "Haz un cambio de sentido y continúe en Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "id": "Putar balik ke arah Way Name",
         "it": "Fai un'inversione ad U poi continua su Way Name",

--- a/test/fixtures/v5/continue/uturn_exit_destination.json
+++ b/test/fixtures/v5/continue/uturn_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "180°-Wendung Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
+        "es-ES": "Haz un cambio de sentido hacia Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "id": "Putar balik menuju Destination 1",
         "it": "Fai un'inversione a U verso Destination 1",

--- a/test/fixtures/v5/continue/uturn_name.json
+++ b/test/fixtures/v5/continue/uturn_name.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung auf Way Name",
         "en": "Make a U-turn and continue on Way Name",
         "es": "Haz un cambio de sentido y continúe en Way Name",
+        "es-ES": "Haz un cambio de sentido y continúe en Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "id": "Putar balik ke arah Way Name",
         "it": "Fai un'inversione ad U poi continua su Way Name",

--- a/test/fixtures/v5/depart/east_110.json
+++ b/test/fixtures/v5/depart/east_110.json
@@ -10,6 +10,7 @@
         "de": "Fahren Sie Richtung Osten",
         "en": "Head east",
         "es": "Ve a este",
+        "es-ES": "Dirígete al este",
         "fr": "Rouler vers l'est",
         "id": "Arah timur",
         "it": "Continua verso est",

--- a/test/fixtures/v5/depart/east_70.json
+++ b/test/fixtures/v5/depart/east_70.json
@@ -10,6 +10,7 @@
         "de": "Fahren Sie Richtung Osten",
         "en": "Head east",
         "es": "Ve a este",
+        "es-ES": "Dirígete al este",
         "fr": "Rouler vers l'est",
         "id": "Arah timur",
         "it": "Continua verso est",

--- a/test/fixtures/v5/depart/modifier_default.json
+++ b/test/fixtures/v5/depart/modifier_default.json
@@ -11,6 +11,7 @@
         "de": "Fahren Sie Richtung Norden",
         "en": "Head north",
         "es": "Ve a norte",
+        "es-ES": "Dirígete al norte",
         "fr": "Rouler vers le nord",
         "id": "Arah utara",
         "it": "Continua verso nord",

--- a/test/fixtures/v5/depart/modifier_destination.json
+++ b/test/fixtures/v5/depart/modifier_destination.json
@@ -12,6 +12,7 @@
         "de": "Fahren Sie Richtung Norden auf Way Name",
         "en": "Head north on Way Name",
         "es": "Ve a norte en Way Name",
+        "es-ES": "Dirígete al norte por Way Name",
         "fr": "Rouler vers le nord sur Way Name",
         "id": "Arah utara di Way Name",
         "it": "Continua verso nord in Way Name",

--- a/test/fixtures/v5/depart/modifier_exit.json
+++ b/test/fixtures/v5/depart/modifier_exit.json
@@ -12,6 +12,7 @@
         "de": "Fahren Sie Richtung Norden auf Way Name",
         "en": "Head north on Way Name",
         "es": "Ve a norte en Way Name",
+        "es-ES": "Dirígete al norte por Way Name",
         "fr": "Rouler vers le nord sur Way Name",
         "id": "Arah utara di Way Name",
         "it": "Continua verso nord in Way Name",

--- a/test/fixtures/v5/depart/modifier_exit_destination.json
+++ b/test/fixtures/v5/depart/modifier_exit_destination.json
@@ -13,6 +13,7 @@
         "de": "Fahren Sie Richtung Norden auf Way Name",
         "en": "Head north on Way Name",
         "es": "Ve a norte en Way Name",
+        "es-ES": "Dirígete al norte por Way Name",
         "fr": "Rouler vers le nord sur Way Name",
         "id": "Arah utara di Way Name",
         "it": "Continua verso nord in Way Name",

--- a/test/fixtures/v5/depart/modifier_name.json
+++ b/test/fixtures/v5/depart/modifier_name.json
@@ -11,6 +11,7 @@
         "de": "Fahren Sie Richtung Norden auf Way Name",
         "en": "Head north on Way Name",
         "es": "Ve a norte en Way Name",
+        "es-ES": "Dirígete al norte por Way Name",
         "fr": "Rouler vers le nord sur Way Name",
         "id": "Arah utara di Way Name",
         "it": "Continua verso nord in Way Name",

--- a/test/fixtures/v5/depart/north_20.json
+++ b/test/fixtures/v5/depart/north_20.json
@@ -10,6 +10,7 @@
         "de": "Fahren Sie Richtung Norden",
         "en": "Head north",
         "es": "Ve a norte",
+        "es-ES": "Dirígete al norte",
         "fr": "Rouler vers le nord",
         "id": "Arah utara",
         "it": "Continua verso nord",

--- a/test/fixtures/v5/depart/north_340.json
+++ b/test/fixtures/v5/depart/north_340.json
@@ -10,6 +10,7 @@
         "de": "Fahren Sie Richtung Norden",
         "en": "Head north",
         "es": "Ve a norte",
+        "es-ES": "Dirígete al norte",
         "fr": "Rouler vers le nord",
         "id": "Arah utara",
         "it": "Continua verso nord",

--- a/test/fixtures/v5/depart/northeast_21.json
+++ b/test/fixtures/v5/depart/northeast_21.json
@@ -10,6 +10,7 @@
         "de": "Fahren Sie Richtung Nordosten",
         "en": "Head northeast",
         "es": "Ve a noreste",
+        "es-ES": "Dirígete al noreste",
         "fr": "Rouler vers le nord-est",
         "id": "Arah timur laut",
         "it": "Continua verso nord-est",

--- a/test/fixtures/v5/depart/northeast_69.json
+++ b/test/fixtures/v5/depart/northeast_69.json
@@ -10,6 +10,7 @@
         "de": "Fahren Sie Richtung Nordosten",
         "en": "Head northeast",
         "es": "Ve a noreste",
+        "es-ES": "Dirígete al noreste",
         "fr": "Rouler vers le nord-est",
         "id": "Arah timur laut",
         "it": "Continua verso nord-est",

--- a/test/fixtures/v5/depart/northwest_291.json
+++ b/test/fixtures/v5/depart/northwest_291.json
@@ -10,6 +10,7 @@
         "de": "Fahren Sie Richtung Nordwesten",
         "en": "Head northwest",
         "es": "Ve a noroeste",
+        "es-ES": "Dirígete al noroeste",
         "fr": "Rouler vers le nord-ouest",
         "id": "Arah barat laut",
         "it": "Continua verso nord-ovest",

--- a/test/fixtures/v5/depart/northwest_339.json
+++ b/test/fixtures/v5/depart/northwest_339.json
@@ -10,6 +10,7 @@
         "de": "Fahren Sie Richtung Nordwesten",
         "en": "Head northwest",
         "es": "Ve a noroeste",
+        "es-ES": "Dirígete al noroeste",
         "fr": "Rouler vers le nord-ouest",
         "id": "Arah barat laut",
         "it": "Continua verso nord-ovest",

--- a/test/fixtures/v5/depart/south_160.json
+++ b/test/fixtures/v5/depart/south_160.json
@@ -10,6 +10,7 @@
         "de": "Fahren Sie Richtung Süden",
         "en": "Head south",
         "es": "Ve a sur",
+        "es-ES": "Dirígete al sur",
         "fr": "Rouler vers le sud",
         "id": "Arah selatan",
         "it": "Continua verso sud",

--- a/test/fixtures/v5/depart/south_200.json
+++ b/test/fixtures/v5/depart/south_200.json
@@ -10,6 +10,7 @@
         "de": "Fahren Sie Richtung Süden",
         "en": "Head south",
         "es": "Ve a sur",
+        "es-ES": "Dirígete al sur",
         "fr": "Rouler vers le sud",
         "id": "Arah selatan",
         "it": "Continua verso sud",

--- a/test/fixtures/v5/depart/southeast_111.json
+++ b/test/fixtures/v5/depart/southeast_111.json
@@ -10,6 +10,7 @@
         "de": "Fahren Sie Richtung Südosten",
         "en": "Head southeast",
         "es": "Ve a sureste",
+        "es-ES": "Dirígete al sureste",
         "fr": "Rouler vers le sud-est",
         "id": "Arah tenggara",
         "it": "Continua verso sud-est",

--- a/test/fixtures/v5/depart/southeast_159.json
+++ b/test/fixtures/v5/depart/southeast_159.json
@@ -10,6 +10,7 @@
         "de": "Fahren Sie Richtung Südosten",
         "en": "Head southeast",
         "es": "Ve a sureste",
+        "es-ES": "Dirígete al sureste",
         "fr": "Rouler vers le sud-est",
         "id": "Arah tenggara",
         "it": "Continua verso sud-est",

--- a/test/fixtures/v5/depart/southwest_201.json
+++ b/test/fixtures/v5/depart/southwest_201.json
@@ -10,6 +10,7 @@
         "de": "Fahren Sie Richtung Südwesten",
         "en": "Head southwest",
         "es": "Ve a suroeste",
+        "es-ES": "Dirígete al suroeste",
         "fr": "Rouler vers le sud-ouest",
         "id": "Arah barat daya",
         "it": "Continua verso sud-ovest",

--- a/test/fixtures/v5/depart/southwest_249.json
+++ b/test/fixtures/v5/depart/southwest_249.json
@@ -10,6 +10,7 @@
         "de": "Fahren Sie Richtung Südwesten",
         "en": "Head southwest",
         "es": "Ve a suroeste",
+        "es-ES": "Dirígete al suroeste",
         "fr": "Rouler vers le sud-ouest",
         "id": "Arah barat daya",
         "it": "Continua verso sud-ovest",

--- a/test/fixtures/v5/depart/west_250.json
+++ b/test/fixtures/v5/depart/west_250.json
@@ -10,6 +10,7 @@
         "de": "Fahren Sie Richtung Westen",
         "en": "Head west",
         "es": "Ve a oeste",
+        "es-ES": "Dirígete al oeste",
         "fr": "Rouler vers l'ouest",
         "id": "Arah barat",
         "it": "Continua verso ovest",

--- a/test/fixtures/v5/depart/west_290.json
+++ b/test/fixtures/v5/depart/west_290.json
@@ -10,6 +10,7 @@
         "de": "Fahren Sie Richtung Westen",
         "en": "Head west",
         "es": "Ve a oeste",
+        "es-ES": "Dirígete al oeste",
         "fr": "Rouler vers l'ouest",
         "id": "Arah barat",
         "it": "Continua verso ovest",

--- a/test/fixtures/v5/end_of_road/left_default.json
+++ b/test/fixtures/v5/end_of_road/left_default.json
@@ -10,6 +10,7 @@
         "de": "Links abbiegen",
         "en": "Turn left",
         "es": "Gire a izquierda",
+        "es-ES": "Al final de la calle gira a la izquierda",
         "fr": "Tourner à gauche",
         "id": "Belok kiri",
         "it": "Gira a sinistra",

--- a/test/fixtures/v5/end_of_road/left_destination.json
+++ b/test/fixtures/v5/end_of_road/left_destination.json
@@ -11,6 +11,7 @@
         "de": "Links abbiegen Richtung Destination 1",
         "en": "Turn left towards Destination 1",
         "es": "Gire a izquierda hacia Destination 1",
+        "es-ES": "Al final de la calle gira a la izquierda hacia Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "id": "Belok kiri menuju Destination 1",
         "it": "Gira a sinistra verso Destination 1",

--- a/test/fixtures/v5/end_of_road/left_exit.json
+++ b/test/fixtures/v5/end_of_road/left_exit.json
@@ -11,6 +11,7 @@
         "de": "Links abbiegen auf Way Name",
         "en": "Turn left onto Way Name",
         "es": "Gire a izquierda en Way Name",
+        "es-ES": "Al final de la calle gira a la izquierda por Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "id": "Belok kiri ke Way Name",
         "it": "Gira a sinistra in Way Name",

--- a/test/fixtures/v5/end_of_road/left_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Links abbiegen Richtung Destination 1",
         "en": "Turn left towards Destination 1",
         "es": "Gire a izquierda hacia Destination 1",
+        "es-ES": "Al final de la calle gira a la izquierda hacia Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "id": "Belok kiri menuju Destination 1",
         "it": "Gira a sinistra verso Destination 1",

--- a/test/fixtures/v5/end_of_road/left_name.json
+++ b/test/fixtures/v5/end_of_road/left_name.json
@@ -10,6 +10,7 @@
         "de": "Links abbiegen auf Way Name",
         "en": "Turn left onto Way Name",
         "es": "Gire a izquierda en Way Name",
+        "es-ES": "Al final de la calle gira a la izquierda por Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "id": "Belok kiri ke Way Name",
         "it": "Gira a sinistra in Way Name",

--- a/test/fixtures/v5/end_of_road/right_default.json
+++ b/test/fixtures/v5/end_of_road/right_default.json
@@ -10,6 +10,7 @@
         "de": "Rechts abbiegen",
         "en": "Turn right",
         "es": "Gire a derecha",
+        "es-ES": "Al final de la calle gira a la derecha",
         "fr": "Tourner à droite",
         "id": "Belok kanan",
         "it": "Gira a destra",

--- a/test/fixtures/v5/end_of_road/right_destination.json
+++ b/test/fixtures/v5/end_of_road/right_destination.json
@@ -11,6 +11,7 @@
         "de": "Rechts abbiegen Richtung Destination 1",
         "en": "Turn right towards Destination 1",
         "es": "Gire a derecha hacia Destination 1",
+        "es-ES": "Al final de la calle gira a la derecha hacia Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "id": "Belok kanan menuju Destination 1",
         "it": "Gira a destra verso Destination 1",

--- a/test/fixtures/v5/end_of_road/right_exit.json
+++ b/test/fixtures/v5/end_of_road/right_exit.json
@@ -11,6 +11,7 @@
         "de": "Rechts abbiegen auf Way Name",
         "en": "Turn right onto Way Name",
         "es": "Gire a derecha en Way Name",
+        "es-ES": "Al final de la calle gira a la derecha por Way Name",
         "fr": "Tourner à droite sur Way Name",
         "id": "Belok kanan ke Way Name",
         "it": "Gira a destra in Way Name",

--- a/test/fixtures/v5/end_of_road/right_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Rechts abbiegen Richtung Destination 1",
         "en": "Turn right towards Destination 1",
         "es": "Gire a derecha hacia Destination 1",
+        "es-ES": "Al final de la calle gira a la derecha hacia Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "id": "Belok kanan menuju Destination 1",
         "it": "Gira a destra verso Destination 1",

--- a/test/fixtures/v5/end_of_road/right_name.json
+++ b/test/fixtures/v5/end_of_road/right_name.json
@@ -10,6 +10,7 @@
         "de": "Rechts abbiegen auf Way Name",
         "en": "Turn right onto Way Name",
         "es": "Gire a derecha en Way Name",
+        "es-ES": "Al final de la calle gira a la derecha por Way Name",
         "fr": "Tourner à droite sur Way Name",
         "id": "Belok kanan ke Way Name",
         "it": "Gira a destra in Way Name",

--- a/test/fixtures/v5/end_of_road/sharp_left_default.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf links abbiegen",
         "en": "Turn sharp left",
         "es": "Gire a cerrada a la izquierda",
+        "es-ES": "Al final de la calle gira cerrada a la izquierda",
         "fr": "Tourner franchement à gauche",
         "id": "Belok tajam kiri",
         "it": "Gira a sinistra",

--- a/test/fixtures/v5/end_of_road/sharp_left_destination.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf links abbiegen Richtung Destination 1",
         "en": "Turn sharp left towards Destination 1",
         "es": "Gire a cerrada a la izquierda hacia Destination 1",
+        "es-ES": "Al final de la calle gira cerrada a la izquierda hacia Destination 1",
         "fr": "Tourner franchement à gauche en direction de Destination 1",
         "id": "Belok tajam kiri menuju Destination 1",
         "it": "Gira a sinistra verso Destination 1",

--- a/test/fixtures/v5/end_of_road/sharp_left_exit.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf links abbiegen auf Way Name",
         "en": "Turn sharp left onto Way Name",
         "es": "Gire a cerrada a la izquierda en Way Name",
+        "es-ES": "Al final de la calle gira cerrada a la izquierda por Way Name",
         "fr": "Tourner franchement à gauche sur Way Name",
         "id": "Belok tajam kiri ke Way Name",
         "it": "Gira a sinistra in Way Name",

--- a/test/fixtures/v5/end_of_road/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf links abbiegen Richtung Destination 1",
         "en": "Turn sharp left towards Destination 1",
         "es": "Gire a cerrada a la izquierda hacia Destination 1",
+        "es-ES": "Al final de la calle gira cerrada a la izquierda hacia Destination 1",
         "fr": "Tourner franchement à gauche en direction de Destination 1",
         "id": "Belok tajam kiri menuju Destination 1",
         "it": "Gira a sinistra verso Destination 1",

--- a/test/fixtures/v5/end_of_road/sharp_left_name.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf links abbiegen auf Way Name",
         "en": "Turn sharp left onto Way Name",
         "es": "Gire a cerrada a la izquierda en Way Name",
+        "es-ES": "Al final de la calle gira cerrada a la izquierda por Way Name",
         "fr": "Tourner franchement à gauche sur Way Name",
         "id": "Belok tajam kiri ke Way Name",
         "it": "Gira a sinistra in Way Name",

--- a/test/fixtures/v5/end_of_road/sharp_right_default.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts abbiegen",
         "en": "Turn sharp right",
         "es": "Gire a cerrada a la derecha",
+        "es-ES": "Al final de la calle gira cerrada a la derecha",
         "fr": "Tourner franchement à droite",
         "id": "Belok tajam kanan",
         "it": "Gira a destra",

--- a/test/fixtures/v5/end_of_road/sharp_right_destination.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts abbiegen Richtung Destination 1",
         "en": "Turn sharp right towards Destination 1",
         "es": "Gire a cerrada a la derecha hacia Destination 1",
+        "es-ES": "Al final de la calle gira cerrada a la derecha hacia Destination 1",
         "fr": "Tourner franchement à droite en direction de Destination 1",
         "id": "Belok tajam kanan menuju Destination 1",
         "it": "Gira a destra verso Destination 1",

--- a/test/fixtures/v5/end_of_road/sharp_right_exit.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts abbiegen auf Way Name",
         "en": "Turn sharp right onto Way Name",
         "es": "Gire a cerrada a la derecha en Way Name",
+        "es-ES": "Al final de la calle gira cerrada a la derecha por Way Name",
         "fr": "Tourner franchement à droite sur Way Name",
         "id": "Belok tajam kanan ke Way Name",
         "it": "Gira a destra in Way Name",

--- a/test/fixtures/v5/end_of_road/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf rechts abbiegen Richtung Destination 1",
         "en": "Turn sharp right towards Destination 1",
         "es": "Gire a cerrada a la derecha hacia Destination 1",
+        "es-ES": "Al final de la calle gira cerrada a la derecha hacia Destination 1",
         "fr": "Tourner franchement à droite en direction de Destination 1",
         "id": "Belok tajam kanan menuju Destination 1",
         "it": "Gira a destra verso Destination 1",

--- a/test/fixtures/v5/end_of_road/sharp_right_name.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts abbiegen auf Way Name",
         "en": "Turn sharp right onto Way Name",
         "es": "Gire a cerrada a la derecha en Way Name",
+        "es-ES": "Al final de la calle gira cerrada a la derecha por Way Name",
         "fr": "Tourner franchement à droite sur Way Name",
         "id": "Belok tajam kanan ke Way Name",
         "it": "Gira a destra in Way Name",

--- a/test/fixtures/v5/end_of_road/slight_left_default.json
+++ b/test/fixtures/v5/end_of_road/slight_left_default.json
@@ -10,6 +10,7 @@
         "de": "Leicht links abbiegen",
         "en": "Turn slight left",
         "es": "Gire a ligeramente a la izquierda",
+        "es-ES": "Al final de la calle gira ligeramente a la izquierda",
         "fr": "Tourner légèrement à gauche",
         "id": "Belok agak ke kiri",
         "it": "Gira a sinistra leggermente",

--- a/test/fixtures/v5/end_of_road/slight_left_destination.json
+++ b/test/fixtures/v5/end_of_road/slight_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Leicht links abbiegen Richtung Destination 1",
         "en": "Turn slight left towards Destination 1",
         "es": "Gire a ligeramente a la izquierda hacia Destination 1",
+        "es-ES": "Al final de la calle gira ligeramente a la izquierda hacia Destination 1",
         "fr": "Tourner légèrement à gauche en direction de Destination 1",
         "id": "Belok agak ke kiri menuju Destination 1",
         "it": "Gira a sinistra leggermente verso Destination 1",

--- a/test/fixtures/v5/end_of_road/slight_left_exit.json
+++ b/test/fixtures/v5/end_of_road/slight_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Leicht links abbiegen auf Way Name",
         "en": "Turn slight left onto Way Name",
         "es": "Gire a ligeramente a la izquierda en Way Name",
+        "es-ES": "Al final de la calle gira ligeramente a la izquierda por Way Name",
         "fr": "Tourner légèrement à gauche sur Way Name",
         "id": "Belok agak ke kiri ke Way Name",
         "it": "Gira a sinistra leggermente in Way Name",

--- a/test/fixtures/v5/end_of_road/slight_left_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/slight_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Leicht links abbiegen Richtung Destination 1",
         "en": "Turn slight left towards Destination 1",
         "es": "Gire a ligeramente a la izquierda hacia Destination 1",
+        "es-ES": "Al final de la calle gira ligeramente a la izquierda hacia Destination 1",
         "fr": "Tourner légèrement à gauche en direction de Destination 1",
         "id": "Belok agak ke kiri menuju Destination 1",
         "it": "Gira a sinistra leggermente verso Destination 1",

--- a/test/fixtures/v5/end_of_road/slight_left_name.json
+++ b/test/fixtures/v5/end_of_road/slight_left_name.json
@@ -10,6 +10,7 @@
         "de": "Leicht links abbiegen auf Way Name",
         "en": "Turn slight left onto Way Name",
         "es": "Gire a ligeramente a la izquierda en Way Name",
+        "es-ES": "Al final de la calle gira ligeramente a la izquierda por Way Name",
         "fr": "Tourner légèrement à gauche sur Way Name",
         "id": "Belok agak ke kiri ke Way Name",
         "it": "Gira a sinistra leggermente in Way Name",

--- a/test/fixtures/v5/end_of_road/slight_right_default.json
+++ b/test/fixtures/v5/end_of_road/slight_right_default.json
@@ -10,6 +10,7 @@
         "de": "Leicht rechts abbiegen",
         "en": "Turn slight right",
         "es": "Gire a ligeramente a la derecha",
+        "es-ES": "Al final de la calle gira ligeramente a la derecha",
         "fr": "Tourner légèrement à droite",
         "id": "Belok agak ke kanan",
         "it": "Gira a destra leggermente",

--- a/test/fixtures/v5/end_of_road/slight_right_destination.json
+++ b/test/fixtures/v5/end_of_road/slight_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts abbiegen Richtung Destination 1",
         "en": "Turn slight right towards Destination 1",
         "es": "Gire a ligeramente a la derecha hacia Destination 1",
+        "es-ES": "Al final de la calle gira ligeramente a la derecha hacia Destination 1",
         "fr": "Tourner légèrement à droite en direction de Destination 1",
         "id": "Belok agak ke kanan menuju Destination 1",
         "it": "Gira a destra leggermente verso Destination 1",

--- a/test/fixtures/v5/end_of_road/slight_right_exit.json
+++ b/test/fixtures/v5/end_of_road/slight_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts abbiegen auf Way Name",
         "en": "Turn slight right onto Way Name",
         "es": "Gire a ligeramente a la derecha en Way Name",
+        "es-ES": "Al final de la calle gira ligeramente a la derecha por Way Name",
         "fr": "Tourner légèrement à droite sur Way Name",
         "id": "Belok agak ke kanan ke Way Name",
         "it": "Gira a destra leggermente in Way Name",

--- a/test/fixtures/v5/end_of_road/slight_right_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/slight_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Leicht rechts abbiegen Richtung Destination 1",
         "en": "Turn slight right towards Destination 1",
         "es": "Gire a ligeramente a la derecha hacia Destination 1",
+        "es-ES": "Al final de la calle gira ligeramente a la derecha hacia Destination 1",
         "fr": "Tourner légèrement à droite en direction de Destination 1",
         "id": "Belok agak ke kanan menuju Destination 1",
         "it": "Gira a destra leggermente verso Destination 1",

--- a/test/fixtures/v5/end_of_road/slight_right_name.json
+++ b/test/fixtures/v5/end_of_road/slight_right_name.json
@@ -10,6 +10,7 @@
         "de": "Leicht rechts abbiegen auf Way Name",
         "en": "Turn slight right onto Way Name",
         "es": "Gire a ligeramente a la derecha en Way Name",
+        "es-ES": "Al final de la calle gira ligeramente a la derecha por Way Name",
         "fr": "Tourner légèrement à droite sur Way Name",
         "id": "Belok agak ke kanan ke Way Name",
         "it": "Gira a destra leggermente in Way Name",

--- a/test/fixtures/v5/end_of_road/straight_default.json
+++ b/test/fixtures/v5/end_of_road/straight_default.json
@@ -10,6 +10,7 @@
         "de": "Geradeaus weiterfahren",
         "en": "Continue straight",
         "es": "Continúe recto",
+        "es-ES": "Al final de la calle continúa recto",
         "fr": "Continuer tout droit",
         "id": "Lurus terus",
         "it": "Continua dritto",

--- a/test/fixtures/v5/end_of_road/straight_destination.json
+++ b/test/fixtures/v5/end_of_road/straight_destination.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus weiterfahren Richtung Destination 1",
         "en": "Continue straight towards Destination 1",
         "es": "Continúe recto hacia Destination 1",
+        "es-ES": "Al final de la calle continúa recto hacia Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "id": "Tetap lurus menuju Destination 1",
         "it": "Continua dritto verso Destination 1",

--- a/test/fixtures/v5/end_of_road/straight_exit.json
+++ b/test/fixtures/v5/end_of_road/straight_exit.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus weiterfahren auf Way Name",
         "en": "Continue straight onto Way Name",
         "es": "Continúe recto en Way Name",
+        "es-ES": "Al final de la calle continúa recto por Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "id": "Tetap lurus ke Way Name ",
         "it": "Continua dritto in Way Name",

--- a/test/fixtures/v5/end_of_road/straight_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/straight_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Geradeaus weiterfahren Richtung Destination 1",
         "en": "Continue straight towards Destination 1",
         "es": "Continúe recto hacia Destination 1",
+        "es-ES": "Al final de la calle continúa recto hacia Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "id": "Tetap lurus menuju Destination 1",
         "it": "Continua dritto verso Destination 1",

--- a/test/fixtures/v5/end_of_road/straight_name.json
+++ b/test/fixtures/v5/end_of_road/straight_name.json
@@ -10,6 +10,7 @@
         "de": "Geradeaus weiterfahren auf Way Name",
         "en": "Continue straight onto Way Name",
         "es": "Continúe recto en Way Name",
+        "es-ES": "Al final de la calle continúa recto por Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "id": "Tetap lurus ke Way Name ",
         "it": "Continua dritto in Way Name",

--- a/test/fixtures/v5/end_of_road/uturn_default.json
+++ b/test/fixtures/v5/end_of_road/uturn_default.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung am Ende der Straße",
         "en": "Make a U-turn at the end of the road",
         "es": "Haz un cambio de sentido al final de la via",
+        "es-ES": "Al final de la calle haz un cambio de sentido",
         "fr": "Faire demi-tour à la fin de la route",
         "id": "Putar balik di akhir jalan",
         "it": "Fai un'inversione a U alla fine della strada",

--- a/test/fixtures/v5/end_of_road/uturn_destination.json
+++ b/test/fixtures/v5/end_of_road/uturn_destination.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung Richtung Destination 1 am Ende der Straße",
         "en": "Make a U-turn towards Destination 1 at the end of the road",
         "es": "Haz un cambio de sentido hacia Destination 1 al final de la via",
+        "es-ES": "Al final de la calle haz un cambio de sentido hacia Destination 1",
         "fr": "Faire demi-tour à la fin de la route en direction de Destination 1",
         "id": "Putar balik menuju Destination 1 di akhir jalan",
         "it": "Fai un'inversione a U verso Destination 1 alla fine della strada",

--- a/test/fixtures/v5/end_of_road/uturn_exit.json
+++ b/test/fixtures/v5/end_of_road/uturn_exit.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung auf Way Name am Ende der Straße",
         "en": "Make a U-turn onto Way Name at the end of the road",
         "es": "Haz un cambio de sentido en Way Name al final de la via",
+        "es-ES": "Al final de la calle haz un cambio de sentido en Way Name",
         "fr": "Faire demi-tour à la fin de la route Way Name",
         "id": "Putar balik di Way Name di akhir jalan",
         "it": "Fai un'inversione a U in Way Name alla fine della strada",

--- a/test/fixtures/v5/end_of_road/uturn_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/uturn_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "180°-Wendung Richtung Destination 1 am Ende der Straße",
         "en": "Make a U-turn towards Destination 1 at the end of the road",
         "es": "Haz un cambio de sentido hacia Destination 1 al final de la via",
+        "es-ES": "Al final de la calle haz un cambio de sentido hacia Destination 1",
         "fr": "Faire demi-tour à la fin de la route en direction de Destination 1",
         "id": "Putar balik menuju Destination 1 di akhir jalan",
         "it": "Fai un'inversione a U verso Destination 1 alla fine della strada",

--- a/test/fixtures/v5/end_of_road/uturn_name.json
+++ b/test/fixtures/v5/end_of_road/uturn_name.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung auf Way Name am Ende der Straße",
         "en": "Make a U-turn onto Way Name at the end of the road",
         "es": "Haz un cambio de sentido en Way Name al final de la via",
+        "es-ES": "Al final de la calle haz un cambio de sentido en Way Name",
         "fr": "Faire demi-tour à la fin de la route Way Name",
         "id": "Putar balik di Way Name di akhir jalan",
         "it": "Fai un'inversione a U in Way Name alla fine della strada",

--- a/test/fixtures/v5/exit_rotary/left_default.json
+++ b/test/fixtures/v5/exit_rotary/left_default.json
@@ -10,6 +10,7 @@
         "de": "Links abbiegen",
         "en": "Turn left",
         "es": "Gire a la izquierda",
+        "es-ES": "Gire a la izquierda",
         "fr": "Tourner à gauche",
         "id": "Belok kiri",
         "it": "Svolta a sinistra",

--- a/test/fixtures/v5/exit_rotary/left_destination.json
+++ b/test/fixtures/v5/exit_rotary/left_destination.json
@@ -11,6 +11,7 @@
         "de": "Links abbiegen Richtung Destination 1",
         "en": "Turn left towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Gire a la izquierda hacia Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "id": "Belok kiri menuju Destination 1",
         "it": "Svolta a sinistra verso Destination 1",

--- a/test/fixtures/v5/exit_rotary/left_exit.json
+++ b/test/fixtures/v5/exit_rotary/left_exit.json
@@ -11,6 +11,7 @@
         "de": "Links abbiegen auf Way Name",
         "en": "Turn left onto Way Name",
         "es": "Gire a la izquierda en Way Name",
+        "es-ES": "Gire a la izquierda en Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "id": "Belok kiri ke Way Name",
         "it": "Svolta a sinistra in Way Name",

--- a/test/fixtures/v5/exit_rotary/left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Links abbiegen Richtung Destination 1",
         "en": "Turn left towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Gire a la izquierda hacia Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "id": "Belok kiri menuju Destination 1",
         "it": "Svolta a sinistra verso Destination 1",

--- a/test/fixtures/v5/exit_rotary/left_name.json
+++ b/test/fixtures/v5/exit_rotary/left_name.json
@@ -10,6 +10,7 @@
         "de": "Links abbiegen auf Way Name",
         "en": "Turn left onto Way Name",
         "es": "Gire a la izquierda en Way Name",
+        "es-ES": "Gire a la izquierda en Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "id": "Belok kiri ke Way Name",
         "it": "Svolta a sinistra in Way Name",

--- a/test/fixtures/v5/exit_rotary/right_default.json
+++ b/test/fixtures/v5/exit_rotary/right_default.json
@@ -10,6 +10,7 @@
         "de": "Rechts abbiegen",
         "en": "Turn right",
         "es": "Gire a la derecha",
+        "es-ES": "Gire a la derecha",
         "fr": "Tourner à droite",
         "id": "Belok kanan",
         "it": "Gira a destra",

--- a/test/fixtures/v5/exit_rotary/right_destination.json
+++ b/test/fixtures/v5/exit_rotary/right_destination.json
@@ -11,6 +11,7 @@
         "de": "Rechts abbiegen Richtung Destination 1",
         "en": "Turn right towards Destination 1",
         "es": "Gire a la derecha hacia Destination 1",
+        "es-ES": "Gire a la derecha hacia Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "id": "Belok kanan menuju Destination 1",
         "it": "Svolta a destra verso Destination 1",

--- a/test/fixtures/v5/exit_rotary/right_exit.json
+++ b/test/fixtures/v5/exit_rotary/right_exit.json
@@ -11,6 +11,7 @@
         "de": "Rechts abbiegen auf Way Name",
         "en": "Turn right onto Way Name",
         "es": "Gire a la derecha en Way Name",
+        "es-ES": "Gire a la derecha en Way Name",
         "fr": "Tourner à droite sur Way Name",
         "id": "Belok kanan ke Way Name",
         "it": "Svolta a destra in Way Name",

--- a/test/fixtures/v5/exit_rotary/right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Rechts abbiegen Richtung Destination 1",
         "en": "Turn right towards Destination 1",
         "es": "Gire a la derecha hacia Destination 1",
+        "es-ES": "Gire a la derecha hacia Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "id": "Belok kanan menuju Destination 1",
         "it": "Svolta a destra verso Destination 1",

--- a/test/fixtures/v5/exit_rotary/right_name.json
+++ b/test/fixtures/v5/exit_rotary/right_name.json
@@ -10,6 +10,7 @@
         "de": "Rechts abbiegen auf Way Name",
         "en": "Turn right onto Way Name",
         "es": "Gire a la derecha en Way Name",
+        "es-ES": "Gire a la derecha en Way Name",
         "fr": "Tourner à droite sur Way Name",
         "id": "Belok kanan ke Way Name",
         "it": "Svolta a destra in Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_left_default.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf links abbiegen",
         "en": "Make a sharp left",
         "es": "Siga cerrada a la izquierda",
+        "es-ES": "Siga cerrada a la izquierda",
         "fr": "Tourner franchement à gauche",
         "id": "Lakukan tajam kiri",
         "it": "Fai una sinistra",

--- a/test/fixtures/v5/exit_rotary/sharp_left_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf links abbiegen Richtung Destination 1",
         "en": "Make a sharp left towards Destination 1",
         "es": "Siga cerrada a la izquierda hacia Destination 1",
+        "es-ES": "Siga cerrada a la izquierda hacia Destination 1",
         "fr": "Tourner franchement à gauche en direction de Destination 1",
         "id": "Lakukan tajam kiri menuju Destination 1",
         "it": "Fai una sinistra verso Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_left_exit.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf links abbiegen auf Way Name",
         "en": "Make a sharp left onto Way Name",
         "es": "Siga cerrada a la izquierda en Way Name",
+        "es-ES": "Siga cerrada a la izquierda en Way Name",
         "fr": "Tourner franchement à gauche sur Way Name",
         "id": "Lakukan tajam kiri ke arah Way Name",
         "it": "Fai una sinistra in Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf links abbiegen Richtung Destination 1",
         "en": "Make a sharp left towards Destination 1",
         "es": "Siga cerrada a la izquierda hacia Destination 1",
+        "es-ES": "Siga cerrada a la izquierda hacia Destination 1",
         "fr": "Tourner franchement à gauche en direction de Destination 1",
         "id": "Lakukan tajam kiri menuju Destination 1",
         "it": "Fai una sinistra verso Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_left_name.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf links abbiegen auf Way Name",
         "en": "Make a sharp left onto Way Name",
         "es": "Siga cerrada a la izquierda en Way Name",
+        "es-ES": "Siga cerrada a la izquierda en Way Name",
         "fr": "Tourner franchement à gauche sur Way Name",
         "id": "Lakukan tajam kiri ke arah Way Name",
         "it": "Fai una sinistra in Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_right_default.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts abbiegen",
         "en": "Make a sharp right",
         "es": "Siga cerrada a la derecha",
+        "es-ES": "Siga cerrada a la derecha",
         "fr": "Tourner franchement à droite",
         "id": "Lakukan tajam kanan",
         "it": "Fai una destra",

--- a/test/fixtures/v5/exit_rotary/sharp_right_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts abbiegen Richtung Destination 1",
         "en": "Make a sharp right towards Destination 1",
         "es": "Siga cerrada a la derecha hacia Destination 1",
+        "es-ES": "Siga cerrada a la derecha hacia Destination 1",
         "fr": "Tourner franchement à droite en direction de Destination 1",
         "id": "Lakukan tajam kanan menuju Destination 1",
         "it": "Fai una destra verso Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_right_exit.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts abbiegen auf Way Name",
         "en": "Make a sharp right onto Way Name",
         "es": "Siga cerrada a la derecha en Way Name",
+        "es-ES": "Siga cerrada a la derecha en Way Name",
         "fr": "Tourner franchement à droite sur Way Name",
         "id": "Lakukan tajam kanan ke arah Way Name",
         "it": "Fai una destra in Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf rechts abbiegen Richtung Destination 1",
         "en": "Make a sharp right towards Destination 1",
         "es": "Siga cerrada a la derecha hacia Destination 1",
+        "es-ES": "Siga cerrada a la derecha hacia Destination 1",
         "fr": "Tourner franchement à droite en direction de Destination 1",
         "id": "Lakukan tajam kanan menuju Destination 1",
         "it": "Fai una destra verso Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_right_name.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts abbiegen auf Way Name",
         "en": "Make a sharp right onto Way Name",
         "es": "Siga cerrada a la derecha en Way Name",
+        "es-ES": "Siga cerrada a la derecha en Way Name",
         "fr": "Tourner franchement à droite sur Way Name",
         "id": "Lakukan tajam kanan ke arah Way Name",
         "it": "Fai una destra in Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_left_default.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_default.json
@@ -10,6 +10,7 @@
         "de": "Leicht links abbiegen",
         "en": "Make a slight left",
         "es": "Siga ligeramente a la izquierda",
+        "es-ES": "Siga ligeramente a la izquierda",
         "fr": "Tourner légèrement à gauche",
         "id": "Lakukan agak ke kiri",
         "it": "Fai una sinistra leggermente",

--- a/test/fixtures/v5/exit_rotary/slight_left_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Leicht links abbiegen Richtung Destination 1",
         "en": "Make a slight left towards Destination 1",
         "es": "Siga ligeramente a la izquierda hacia Destination 1",
+        "es-ES": "Siga ligeramente a la izquierda hacia Destination 1",
         "fr": "Tourner légèrement à gauche en direction de Destination 1",
         "id": "Lakukan agak ke kiri menuju Destination 1",
         "it": "Fai una sinistra leggermente verso Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_left_exit.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Leicht links abbiegen auf Way Name",
         "en": "Make a slight left onto Way Name",
         "es": "Siga ligeramente a la izquierda en Way Name",
+        "es-ES": "Siga ligeramente a la izquierda en Way Name",
         "fr": "Tourner légèrement à gauche sur Way Name",
         "id": "Lakukan agak ke kiri ke arah Way Name",
         "it": "Fai una sinistra leggermente in Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Leicht links abbiegen Richtung Destination 1",
         "en": "Make a slight left towards Destination 1",
         "es": "Siga ligeramente a la izquierda hacia Destination 1",
+        "es-ES": "Siga ligeramente a la izquierda hacia Destination 1",
         "fr": "Tourner légèrement à gauche en direction de Destination 1",
         "id": "Lakukan agak ke kiri menuju Destination 1",
         "it": "Fai una sinistra leggermente verso Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_left_name.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_name.json
@@ -10,6 +10,7 @@
         "de": "Leicht links abbiegen auf Way Name",
         "en": "Make a slight left onto Way Name",
         "es": "Siga ligeramente a la izquierda en Way Name",
+        "es-ES": "Siga ligeramente a la izquierda en Way Name",
         "fr": "Tourner légèrement à gauche sur Way Name",
         "id": "Lakukan agak ke kiri ke arah Way Name",
         "it": "Fai una sinistra leggermente in Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_right_default.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_default.json
@@ -10,6 +10,7 @@
         "de": "Leicht rechts abbiegen",
         "en": "Make a slight right",
         "es": "Siga ligeramente a la derecha",
+        "es-ES": "Siga ligeramente a la derecha",
         "fr": "Tourner légèrement à droite",
         "id": "Lakukan agak ke kanan",
         "it": "Fai una destra leggermente",

--- a/test/fixtures/v5/exit_rotary/slight_right_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts abbiegen Richtung Destination 1",
         "en": "Make a slight right towards Destination 1",
         "es": "Siga ligeramente a la derecha hacia Destination 1",
+        "es-ES": "Siga ligeramente a la derecha hacia Destination 1",
         "fr": "Tourner légèrement à droite en direction de Destination 1",
         "id": "Lakukan agak ke kanan menuju Destination 1",
         "it": "Fai una destra leggermente verso Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_right_exit.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts abbiegen auf Way Name",
         "en": "Make a slight right onto Way Name",
         "es": "Siga ligeramente a la derecha en Way Name",
+        "es-ES": "Siga ligeramente a la derecha en Way Name",
         "fr": "Tourner légèrement à droite sur Way Name",
         "id": "Lakukan agak ke kanan ke arah Way Name",
         "it": "Fai una destra leggermente in Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Leicht rechts abbiegen Richtung Destination 1",
         "en": "Make a slight right towards Destination 1",
         "es": "Siga ligeramente a la derecha hacia Destination 1",
+        "es-ES": "Siga ligeramente a la derecha hacia Destination 1",
         "fr": "Tourner légèrement à droite en direction de Destination 1",
         "id": "Lakukan agak ke kanan menuju Destination 1",
         "it": "Fai una destra leggermente verso Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_right_name.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_name.json
@@ -10,6 +10,7 @@
         "de": "Leicht rechts abbiegen auf Way Name",
         "en": "Make a slight right onto Way Name",
         "es": "Siga ligeramente a la derecha en Way Name",
+        "es-ES": "Siga ligeramente a la derecha en Way Name",
         "fr": "Tourner légèrement à droite sur Way Name",
         "id": "Lakukan agak ke kanan ke arah Way Name",
         "it": "Fai una destra leggermente in Way Name",

--- a/test/fixtures/v5/exit_rotary/straight_default.json
+++ b/test/fixtures/v5/exit_rotary/straight_default.json
@@ -10,6 +10,7 @@
         "de": "Geradeaus weiterfahren",
         "en": "Go straight",
         "es": "Ve recto",
+        "es-ES": "Ve recto",
         "fr": "Aller tout droit",
         "id": "Lurus",
         "it": "Prosegui dritto",

--- a/test/fixtures/v5/exit_rotary/straight_destination.json
+++ b/test/fixtures/v5/exit_rotary/straight_destination.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus weiterfahren Richtung Destination 1",
         "en": "Go straight towards Destination 1",
         "es": "Ve recto hacia Destination 1",
+        "es-ES": "Ve recto hacia Destination 1",
         "fr": "Aller tout droit en direction de Destination 1",
         "id": "Lurus menuju Destination 1",
         "it": "Continua verso Destination 1",

--- a/test/fixtures/v5/exit_rotary/straight_exit.json
+++ b/test/fixtures/v5/exit_rotary/straight_exit.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus weiterfahren auf Way Name",
         "en": "Go straight onto Way Name",
         "es": "Ve recto en Way Name",
+        "es-ES": "Ve recto en Way Name",
         "fr": "Aller tout droit sur Way Name",
         "id": "Lurus arah Way Name",
         "it": "Continua su Way Name",

--- a/test/fixtures/v5/exit_rotary/straight_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/straight_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Geradeaus weiterfahren Richtung Destination 1",
         "en": "Go straight towards Destination 1",
         "es": "Ve recto hacia Destination 1",
+        "es-ES": "Ve recto hacia Destination 1",
         "fr": "Aller tout droit en direction de Destination 1",
         "id": "Lurus menuju Destination 1",
         "it": "Continua verso Destination 1",

--- a/test/fixtures/v5/exit_rotary/straight_name.json
+++ b/test/fixtures/v5/exit_rotary/straight_name.json
@@ -10,6 +10,7 @@
         "de": "Geradeaus weiterfahren auf Way Name",
         "en": "Go straight onto Way Name",
         "es": "Ve recto en Way Name",
+        "es-ES": "Ve recto en Way Name",
         "fr": "Aller tout droit sur Way Name",
         "id": "Lurus arah Way Name",
         "it": "Continua su Way Name",

--- a/test/fixtures/v5/exit_rotary/uturn_default.json
+++ b/test/fixtures/v5/exit_rotary/uturn_default.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung abbiegen",
         "en": "Make a U-turn",
         "es": "Siga cambio de sentido",
+        "es-ES": "Siga cambio de sentido",
         "fr": "Tourner demi-tour",
         "id": "Lakukan putar balik",
         "it": "Fai una inversione a U",

--- a/test/fixtures/v5/exit_rotary/uturn_destination.json
+++ b/test/fixtures/v5/exit_rotary/uturn_destination.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung abbiegen Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
         "es": "Siga cambio de sentido hacia Destination 1",
+        "es-ES": "Siga cambio de sentido hacia Destination 1",
         "fr": "Tourner demi-tour en direction de Destination 1",
         "id": "Lakukan putar balik menuju Destination 1",
         "it": "Fai una inversione a U verso Destination 1",

--- a/test/fixtures/v5/exit_rotary/uturn_exit.json
+++ b/test/fixtures/v5/exit_rotary/uturn_exit.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung abbiegen auf Way Name",
         "en": "Make a U-turn onto Way Name",
         "es": "Siga cambio de sentido en Way Name",
+        "es-ES": "Siga cambio de sentido en Way Name",
         "fr": "Tourner demi-tour sur Way Name",
         "id": "Lakukan putar balik ke arah Way Name",
         "it": "Fai una inversione a U in Way Name",

--- a/test/fixtures/v5/exit_rotary/uturn_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/uturn_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "180°-Wendung abbiegen Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
         "es": "Siga cambio de sentido hacia Destination 1",
+        "es-ES": "Siga cambio de sentido hacia Destination 1",
         "fr": "Tourner demi-tour en direction de Destination 1",
         "id": "Lakukan putar balik menuju Destination 1",
         "it": "Fai una inversione a U verso Destination 1",

--- a/test/fixtures/v5/exit_rotary/uturn_name.json
+++ b/test/fixtures/v5/exit_rotary/uturn_name.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung abbiegen auf Way Name",
         "en": "Make a U-turn onto Way Name",
         "es": "Siga cambio de sentido en Way Name",
+        "es-ES": "Siga cambio de sentido en Way Name",
         "fr": "Tourner demi-tour sur Way Name",
         "id": "Lakukan putar balik ke arah Way Name",
         "it": "Fai una inversione a U in Way Name",

--- a/test/fixtures/v5/exit_roundabout/left_default.json
+++ b/test/fixtures/v5/exit_roundabout/left_default.json
@@ -10,6 +10,7 @@
         "de": "Links abbiegen",
         "en": "Turn left",
         "es": "Gire a la izquierda",
+        "es-ES": "Gire a la izquierda",
         "fr": "Tourner à gauche",
         "id": "Belok kiri",
         "it": "Svolta a sinistra",

--- a/test/fixtures/v5/exit_roundabout/left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/left_destination.json
@@ -11,6 +11,7 @@
         "de": "Links abbiegen Richtung Destination 1",
         "en": "Turn left towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Gire a la izquierda hacia Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "id": "Belok kiri menuju Destination 1",
         "it": "Svolta a sinistra verso Destination 1",

--- a/test/fixtures/v5/exit_roundabout/left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/left_exit.json
@@ -11,6 +11,7 @@
         "de": "Links abbiegen auf Way Name",
         "en": "Turn left onto Way Name",
         "es": "Gire a la izquierda en Way Name",
+        "es-ES": "Gire a la izquierda en Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "id": "Belok kiri ke Way Name",
         "it": "Svolta a sinistra in Way Name",

--- a/test/fixtures/v5/exit_roundabout/left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Links abbiegen Richtung Destination 1",
         "en": "Turn left towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Gire a la izquierda hacia Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "id": "Belok kiri menuju Destination 1",
         "it": "Svolta a sinistra verso Destination 1",

--- a/test/fixtures/v5/exit_roundabout/left_name.json
+++ b/test/fixtures/v5/exit_roundabout/left_name.json
@@ -10,6 +10,7 @@
         "de": "Links abbiegen auf Way Name",
         "en": "Turn left onto Way Name",
         "es": "Gire a la izquierda en Way Name",
+        "es-ES": "Gire a la izquierda en Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "id": "Belok kiri ke Way Name",
         "it": "Svolta a sinistra in Way Name",

--- a/test/fixtures/v5/exit_roundabout/right_default.json
+++ b/test/fixtures/v5/exit_roundabout/right_default.json
@@ -10,6 +10,7 @@
         "de": "Rechts abbiegen",
         "en": "Turn right",
         "es": "Gire a la derecha",
+        "es-ES": "Gire a la derecha",
         "fr": "Tourner à droite",
         "id": "Belok kanan",
         "it": "Gira a destra",

--- a/test/fixtures/v5/exit_roundabout/right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/right_destination.json
@@ -11,6 +11,7 @@
         "de": "Rechts abbiegen Richtung Destination 1",
         "en": "Turn right towards Destination 1",
         "es": "Gire a la derecha hacia Destination 1",
+        "es-ES": "Gire a la derecha hacia Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "id": "Belok kanan menuju Destination 1",
         "it": "Svolta a destra verso Destination 1",

--- a/test/fixtures/v5/exit_roundabout/right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/right_exit.json
@@ -11,6 +11,7 @@
         "de": "Rechts abbiegen auf Way Name",
         "en": "Turn right onto Way Name",
         "es": "Gire a la derecha en Way Name",
+        "es-ES": "Gire a la derecha en Way Name",
         "fr": "Tourner à droite sur Way Name",
         "id": "Belok kanan ke Way Name",
         "it": "Svolta a destra in Way Name",

--- a/test/fixtures/v5/exit_roundabout/right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Rechts abbiegen Richtung Destination 1",
         "en": "Turn right towards Destination 1",
         "es": "Gire a la derecha hacia Destination 1",
+        "es-ES": "Gire a la derecha hacia Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "id": "Belok kanan menuju Destination 1",
         "it": "Svolta a destra verso Destination 1",

--- a/test/fixtures/v5/exit_roundabout/right_name.json
+++ b/test/fixtures/v5/exit_roundabout/right_name.json
@@ -10,6 +10,7 @@
         "de": "Rechts abbiegen auf Way Name",
         "en": "Turn right onto Way Name",
         "es": "Gire a la derecha en Way Name",
+        "es-ES": "Gire a la derecha en Way Name",
         "fr": "Tourner à droite sur Way Name",
         "id": "Belok kanan ke Way Name",
         "it": "Svolta a destra in Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_default.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf links abbiegen",
         "en": "Make a sharp left",
         "es": "Siga cerrada a la izquierda",
+        "es-ES": "Siga cerrada a la izquierda",
         "fr": "Tourner franchement à gauche",
         "id": "Lakukan tajam kiri",
         "it": "Fai una sinistra",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf links abbiegen Richtung Destination 1",
         "en": "Make a sharp left towards Destination 1",
         "es": "Siga cerrada a la izquierda hacia Destination 1",
+        "es-ES": "Siga cerrada a la izquierda hacia Destination 1",
         "fr": "Tourner franchement à gauche en direction de Destination 1",
         "id": "Lakukan tajam kiri menuju Destination 1",
         "it": "Fai una sinistra verso Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf links abbiegen auf Way Name",
         "en": "Make a sharp left onto Way Name",
         "es": "Siga cerrada a la izquierda en Way Name",
+        "es-ES": "Siga cerrada a la izquierda en Way Name",
         "fr": "Tourner franchement à gauche sur Way Name",
         "id": "Lakukan tajam kiri ke arah Way Name",
         "it": "Fai una sinistra in Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf links abbiegen Richtung Destination 1",
         "en": "Make a sharp left towards Destination 1",
         "es": "Siga cerrada a la izquierda hacia Destination 1",
+        "es-ES": "Siga cerrada a la izquierda hacia Destination 1",
         "fr": "Tourner franchement à gauche en direction de Destination 1",
         "id": "Lakukan tajam kiri menuju Destination 1",
         "it": "Fai una sinistra verso Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_name.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf links abbiegen auf Way Name",
         "en": "Make a sharp left onto Way Name",
         "es": "Siga cerrada a la izquierda en Way Name",
+        "es-ES": "Siga cerrada a la izquierda en Way Name",
         "fr": "Tourner franchement à gauche sur Way Name",
         "id": "Lakukan tajam kiri ke arah Way Name",
         "it": "Fai una sinistra in Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_default.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts abbiegen",
         "en": "Make a sharp right",
         "es": "Siga cerrada a la derecha",
+        "es-ES": "Siga cerrada a la derecha",
         "fr": "Tourner franchement à droite",
         "id": "Lakukan tajam kanan",
         "it": "Fai una destra",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts abbiegen Richtung Destination 1",
         "en": "Make a sharp right towards Destination 1",
         "es": "Siga cerrada a la derecha hacia Destination 1",
+        "es-ES": "Siga cerrada a la derecha hacia Destination 1",
         "fr": "Tourner franchement à droite en direction de Destination 1",
         "id": "Lakukan tajam kanan menuju Destination 1",
         "it": "Fai una destra verso Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts abbiegen auf Way Name",
         "en": "Make a sharp right onto Way Name",
         "es": "Siga cerrada a la derecha en Way Name",
+        "es-ES": "Siga cerrada a la derecha en Way Name",
         "fr": "Tourner franchement à droite sur Way Name",
         "id": "Lakukan tajam kanan ke arah Way Name",
         "it": "Fai una destra in Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf rechts abbiegen Richtung Destination 1",
         "en": "Make a sharp right towards Destination 1",
         "es": "Siga cerrada a la derecha hacia Destination 1",
+        "es-ES": "Siga cerrada a la derecha hacia Destination 1",
         "fr": "Tourner franchement à droite en direction de Destination 1",
         "id": "Lakukan tajam kanan menuju Destination 1",
         "it": "Fai una destra verso Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_name.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts abbiegen auf Way Name",
         "en": "Make a sharp right onto Way Name",
         "es": "Siga cerrada a la derecha en Way Name",
+        "es-ES": "Siga cerrada a la derecha en Way Name",
         "fr": "Tourner franchement à droite sur Way Name",
         "id": "Lakukan tajam kanan ke arah Way Name",
         "it": "Fai una destra in Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_left_default.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_default.json
@@ -10,6 +10,7 @@
         "de": "Leicht links abbiegen",
         "en": "Make a slight left",
         "es": "Siga ligeramente a la izquierda",
+        "es-ES": "Siga ligeramente a la izquierda",
         "fr": "Tourner légèrement à gauche",
         "id": "Lakukan agak ke kiri",
         "it": "Fai una sinistra leggermente",

--- a/test/fixtures/v5/exit_roundabout/slight_left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Leicht links abbiegen Richtung Destination 1",
         "en": "Make a slight left towards Destination 1",
         "es": "Siga ligeramente a la izquierda hacia Destination 1",
+        "es-ES": "Siga ligeramente a la izquierda hacia Destination 1",
         "fr": "Tourner légèrement à gauche en direction de Destination 1",
         "id": "Lakukan agak ke kiri menuju Destination 1",
         "it": "Fai una sinistra leggermente verso Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Leicht links abbiegen auf Way Name",
         "en": "Make a slight left onto Way Name",
         "es": "Siga ligeramente a la izquierda en Way Name",
+        "es-ES": "Siga ligeramente a la izquierda en Way Name",
         "fr": "Tourner légèrement à gauche sur Way Name",
         "id": "Lakukan agak ke kiri ke arah Way Name",
         "it": "Fai una sinistra leggermente in Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Leicht links abbiegen Richtung Destination 1",
         "en": "Make a slight left towards Destination 1",
         "es": "Siga ligeramente a la izquierda hacia Destination 1",
+        "es-ES": "Siga ligeramente a la izquierda hacia Destination 1",
         "fr": "Tourner légèrement à gauche en direction de Destination 1",
         "id": "Lakukan agak ke kiri menuju Destination 1",
         "it": "Fai una sinistra leggermente verso Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_left_name.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_name.json
@@ -10,6 +10,7 @@
         "de": "Leicht links abbiegen auf Way Name",
         "en": "Make a slight left onto Way Name",
         "es": "Siga ligeramente a la izquierda en Way Name",
+        "es-ES": "Siga ligeramente a la izquierda en Way Name",
         "fr": "Tourner légèrement à gauche sur Way Name",
         "id": "Lakukan agak ke kiri ke arah Way Name",
         "it": "Fai una sinistra leggermente in Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_right_default.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_default.json
@@ -10,6 +10,7 @@
         "de": "Leicht rechts abbiegen",
         "en": "Make a slight right",
         "es": "Siga ligeramente a la derecha",
+        "es-ES": "Siga ligeramente a la derecha",
         "fr": "Tourner légèrement à droite",
         "id": "Lakukan agak ke kanan",
         "it": "Fai una destra leggermente",

--- a/test/fixtures/v5/exit_roundabout/slight_right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts abbiegen Richtung Destination 1",
         "en": "Make a slight right towards Destination 1",
         "es": "Siga ligeramente a la derecha hacia Destination 1",
+        "es-ES": "Siga ligeramente a la derecha hacia Destination 1",
         "fr": "Tourner légèrement à droite en direction de Destination 1",
         "id": "Lakukan agak ke kanan menuju Destination 1",
         "it": "Fai una destra leggermente verso Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts abbiegen auf Way Name",
         "en": "Make a slight right onto Way Name",
         "es": "Siga ligeramente a la derecha en Way Name",
+        "es-ES": "Siga ligeramente a la derecha en Way Name",
         "fr": "Tourner légèrement à droite sur Way Name",
         "id": "Lakukan agak ke kanan ke arah Way Name",
         "it": "Fai una destra leggermente in Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Leicht rechts abbiegen Richtung Destination 1",
         "en": "Make a slight right towards Destination 1",
         "es": "Siga ligeramente a la derecha hacia Destination 1",
+        "es-ES": "Siga ligeramente a la derecha hacia Destination 1",
         "fr": "Tourner légèrement à droite en direction de Destination 1",
         "id": "Lakukan agak ke kanan menuju Destination 1",
         "it": "Fai una destra leggermente verso Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_right_name.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_name.json
@@ -10,6 +10,7 @@
         "de": "Leicht rechts abbiegen auf Way Name",
         "en": "Make a slight right onto Way Name",
         "es": "Siga ligeramente a la derecha en Way Name",
+        "es-ES": "Siga ligeramente a la derecha en Way Name",
         "fr": "Tourner légèrement à droite sur Way Name",
         "id": "Lakukan agak ke kanan ke arah Way Name",
         "it": "Fai una destra leggermente in Way Name",

--- a/test/fixtures/v5/exit_roundabout/straight_default.json
+++ b/test/fixtures/v5/exit_roundabout/straight_default.json
@@ -10,6 +10,7 @@
         "de": "Geradeaus weiterfahren",
         "en": "Go straight",
         "es": "Ve recto",
+        "es-ES": "Ve recto",
         "fr": "Aller tout droit",
         "id": "Lurus",
         "it": "Prosegui dritto",

--- a/test/fixtures/v5/exit_roundabout/straight_destination.json
+++ b/test/fixtures/v5/exit_roundabout/straight_destination.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus weiterfahren Richtung Destination 1",
         "en": "Go straight towards Destination 1",
         "es": "Ve recto hacia Destination 1",
+        "es-ES": "Ve recto hacia Destination 1",
         "fr": "Aller tout droit en direction de Destination 1",
         "id": "Lurus menuju Destination 1",
         "it": "Continua verso Destination 1",

--- a/test/fixtures/v5/exit_roundabout/straight_exit.json
+++ b/test/fixtures/v5/exit_roundabout/straight_exit.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus weiterfahren auf Way Name",
         "en": "Go straight onto Way Name",
         "es": "Ve recto en Way Name",
+        "es-ES": "Ve recto en Way Name",
         "fr": "Aller tout droit sur Way Name",
         "id": "Lurus arah Way Name",
         "it": "Continua su Way Name",

--- a/test/fixtures/v5/exit_roundabout/straight_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/straight_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Geradeaus weiterfahren Richtung Destination 1",
         "en": "Go straight towards Destination 1",
         "es": "Ve recto hacia Destination 1",
+        "es-ES": "Ve recto hacia Destination 1",
         "fr": "Aller tout droit en direction de Destination 1",
         "id": "Lurus menuju Destination 1",
         "it": "Continua verso Destination 1",

--- a/test/fixtures/v5/exit_roundabout/straight_name.json
+++ b/test/fixtures/v5/exit_roundabout/straight_name.json
@@ -10,6 +10,7 @@
         "de": "Geradeaus weiterfahren auf Way Name",
         "en": "Go straight onto Way Name",
         "es": "Ve recto en Way Name",
+        "es-ES": "Ve recto en Way Name",
         "fr": "Aller tout droit sur Way Name",
         "id": "Lurus arah Way Name",
         "it": "Continua su Way Name",

--- a/test/fixtures/v5/exit_roundabout/uturn_default.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_default.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung abbiegen",
         "en": "Make a U-turn",
         "es": "Siga cambio de sentido",
+        "es-ES": "Siga cambio de sentido",
         "fr": "Tourner demi-tour",
         "id": "Lakukan putar balik",
         "it": "Fai una inversione a U",

--- a/test/fixtures/v5/exit_roundabout/uturn_destination.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_destination.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung abbiegen Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
         "es": "Siga cambio de sentido hacia Destination 1",
+        "es-ES": "Siga cambio de sentido hacia Destination 1",
         "fr": "Tourner demi-tour en direction de Destination 1",
         "id": "Lakukan putar balik menuju Destination 1",
         "it": "Fai una inversione a U verso Destination 1",

--- a/test/fixtures/v5/exit_roundabout/uturn_exit.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_exit.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung abbiegen auf Way Name",
         "en": "Make a U-turn onto Way Name",
         "es": "Siga cambio de sentido en Way Name",
+        "es-ES": "Siga cambio de sentido en Way Name",
         "fr": "Tourner demi-tour sur Way Name",
         "id": "Lakukan putar balik ke arah Way Name",
         "it": "Fai una inversione a U in Way Name",

--- a/test/fixtures/v5/exit_roundabout/uturn_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "180°-Wendung abbiegen Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
         "es": "Siga cambio de sentido hacia Destination 1",
+        "es-ES": "Siga cambio de sentido hacia Destination 1",
         "fr": "Tourner demi-tour en direction de Destination 1",
         "id": "Lakukan putar balik menuju Destination 1",
         "it": "Fai una inversione a U verso Destination 1",

--- a/test/fixtures/v5/exit_roundabout/uturn_name.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_name.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung abbiegen auf Way Name",
         "en": "Make a U-turn onto Way Name",
         "es": "Siga cambio de sentido en Way Name",
+        "es-ES": "Siga cambio de sentido en Way Name",
         "fr": "Tourner demi-tour sur Way Name",
         "id": "Lakukan putar balik ke arah Way Name",
         "it": "Fai una inversione a U in Way Name",

--- a/test/fixtures/v5/fork/left_default.json
+++ b/test/fixtures/v5/fork/left_default.json
@@ -10,6 +10,7 @@
         "de": "Links halten an der Gabelung",
         "en": "Keep left at the fork",
         "es": "Mantengase izquierda en el cruce",
+        "es-ES": "Mantente a la izquierda en el cruce",
         "fr": "Rester à gauche à l'embranchement",
         "id": "Tetap kiri di pertigaan",
         "it": "Mantieni la sinistra al bivio",

--- a/test/fixtures/v5/fork/left_destination.json
+++ b/test/fixtures/v5/fork/left_destination.json
@@ -11,6 +11,7 @@
         "de": "Links halten an der Gabelung Richtung Destination 1",
         "en": "Keep left at the fork towards Destination 1",
         "es": "Mantengase izquierda en el cruce hacia Destination 1",
+        "es-ES": "Mantente a la izquierda en el cruce hacia Destination 1",
         "fr": "Rester à gauche à l'embranchement en direction de Destination 1",
         "id": "Tetap kiri di pertigaan menuju Destination 1",
         "it": "Mantieni la sinistra al bivio verso Destination 1",

--- a/test/fixtures/v5/fork/left_exit.json
+++ b/test/fixtures/v5/fork/left_exit.json
@@ -11,6 +11,7 @@
         "de": "Links halten an der Gabelung auf Way Name",
         "en": "Keep left at the fork onto Way Name",
         "es": "Mantengase izquierda en el cruce en Way Name",
+        "es-ES": "Mantente a la izquierda en el cruce por Way Name",
         "fr": "Rester à gauche à l'embranchement sur Way Name",
         "id": "Tetap kiri di pertigaan ke Way Name",
         "it": "Mantieni la sinistra al bivio in Way Name",

--- a/test/fixtures/v5/fork/left_exit_destination.json
+++ b/test/fixtures/v5/fork/left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Links halten an der Gabelung Richtung Destination 1",
         "en": "Keep left at the fork towards Destination 1",
         "es": "Mantengase izquierda en el cruce hacia Destination 1",
+        "es-ES": "Mantente a la izquierda en el cruce hacia Destination 1",
         "fr": "Rester à gauche à l'embranchement en direction de Destination 1",
         "id": "Tetap kiri di pertigaan menuju Destination 1",
         "it": "Mantieni la sinistra al bivio verso Destination 1",

--- a/test/fixtures/v5/fork/left_name.json
+++ b/test/fixtures/v5/fork/left_name.json
@@ -10,6 +10,7 @@
         "de": "Links halten an der Gabelung auf Way Name",
         "en": "Keep left at the fork onto Way Name",
         "es": "Mantengase izquierda en el cruce en Way Name",
+        "es-ES": "Mantente a la izquierda en el cruce por Way Name",
         "fr": "Rester à gauche à l'embranchement sur Way Name",
         "id": "Tetap kiri di pertigaan ke Way Name",
         "it": "Mantieni la sinistra al bivio in Way Name",

--- a/test/fixtures/v5/fork/right_default.json
+++ b/test/fixtures/v5/fork/right_default.json
@@ -10,6 +10,7 @@
         "de": "Rechts halten an der Gabelung",
         "en": "Keep right at the fork",
         "es": "Mantengase derecha en el cruce",
+        "es-ES": "Mantente a la derecha en el cruce",
         "fr": "Rester à droite à l'embranchement",
         "id": "Tetap kanan di pertigaan",
         "it": "Mantieni la destra al bivio",

--- a/test/fixtures/v5/fork/right_destination.json
+++ b/test/fixtures/v5/fork/right_destination.json
@@ -11,6 +11,7 @@
         "de": "Rechts halten an der Gabelung Richtung Destination 1",
         "en": "Keep right at the fork towards Destination 1",
         "es": "Mantengase derecha en el cruce hacia Destination 1",
+        "es-ES": "Mantente a la derecha en el cruce hacia Destination 1",
         "fr": "Rester à droite à l'embranchement en direction de Destination 1",
         "id": "Tetap kanan di pertigaan menuju Destination 1",
         "it": "Mantieni la destra al bivio verso Destination 1",

--- a/test/fixtures/v5/fork/right_exit.json
+++ b/test/fixtures/v5/fork/right_exit.json
@@ -11,6 +11,7 @@
         "de": "Rechts halten an der Gabelung auf Way Name",
         "en": "Keep right at the fork onto Way Name",
         "es": "Mantengase derecha en el cruce en Way Name",
+        "es-ES": "Mantente a la derecha en el cruce por Way Name",
         "fr": "Rester à droite à l'embranchement sur Way Name",
         "id": "Tetap kanan di pertigaan ke Way Name",
         "it": "Mantieni la destra al bivio in Way Name",

--- a/test/fixtures/v5/fork/right_exit_destination.json
+++ b/test/fixtures/v5/fork/right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Rechts halten an der Gabelung Richtung Destination 1",
         "en": "Keep right at the fork towards Destination 1",
         "es": "Mantengase derecha en el cruce hacia Destination 1",
+        "es-ES": "Mantente a la derecha en el cruce hacia Destination 1",
         "fr": "Rester à droite à l'embranchement en direction de Destination 1",
         "id": "Tetap kanan di pertigaan menuju Destination 1",
         "it": "Mantieni la destra al bivio verso Destination 1",

--- a/test/fixtures/v5/fork/right_name.json
+++ b/test/fixtures/v5/fork/right_name.json
@@ -10,6 +10,7 @@
         "de": "Rechts halten an der Gabelung auf Way Name",
         "en": "Keep right at the fork onto Way Name",
         "es": "Mantengase derecha en el cruce en Way Name",
+        "es-ES": "Mantente a la derecha en el cruce por Way Name",
         "fr": "Rester à droite à l'embranchement sur Way Name",
         "id": "Tetap kanan di pertigaan ke Way Name",
         "it": "Mantieni la destra al bivio in Way Name",

--- a/test/fixtures/v5/fork/sharp_left_default.json
+++ b/test/fixtures/v5/fork/sharp_left_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf links abbiegen an der Gabelung",
         "en": "Take a sharp left at the fork",
         "es": "Gire a la izquierda en el cruce",
+        "es-ES": "Gira la izquierda en el cruce",
         "fr": "Prendre franchement à gauche à l'embranchement",
         "id": "Belok kiri pada pertigaan",
         "it": "Svolta a sinistra al bivio",

--- a/test/fixtures/v5/fork/sharp_left_destination.json
+++ b/test/fixtures/v5/fork/sharp_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf links abbiegen an der Gabelung Richtung Destination 1",
         "en": "Take a sharp left at the fork towards Destination 1",
         "es": "Gire a la izquierda en el cruce hacia Destination 1",
+        "es-ES": "Gira a la izquierda en el cruce hacia Destination 1",
         "fr": "Prendre franchement à gauche à l'embranchement en direction de Destination 1",
         "id": "Belok kiri pada pertigaan menuju Destination 1",
         "it": "Svolta a sinistra al bivio verso Destination 1",

--- a/test/fixtures/v5/fork/sharp_left_exit.json
+++ b/test/fixtures/v5/fork/sharp_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf links abbiegen an der Gabelung auf Way Name",
         "en": "Take a sharp left at the fork onto Way Name",
         "es": "Gire a la izquierda en el cruce en Way Name",
+        "es-ES": "Gira a la izquierda en el cruce por Way Name",
         "fr": "Prendre franchement à gauche à l'embranchement sur Way Name",
         "id": "Belok kiri pada pertigaan ke arah Way Name",
         "it": "Svolta a sinistra al bivio in Way Name",

--- a/test/fixtures/v5/fork/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/fork/sharp_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf links abbiegen an der Gabelung Richtung Destination 1",
         "en": "Take a sharp left at the fork towards Destination 1",
         "es": "Gire a la izquierda en el cruce hacia Destination 1",
+        "es-ES": "Gira a la izquierda en el cruce hacia Destination 1",
         "fr": "Prendre franchement à gauche à l'embranchement en direction de Destination 1",
         "id": "Belok kiri pada pertigaan menuju Destination 1",
         "it": "Svolta a sinistra al bivio verso Destination 1",

--- a/test/fixtures/v5/fork/sharp_left_name.json
+++ b/test/fixtures/v5/fork/sharp_left_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf links abbiegen an der Gabelung auf Way Name",
         "en": "Take a sharp left at the fork onto Way Name",
         "es": "Gire a la izquierda en el cruce en Way Name",
+        "es-ES": "Gira a la izquierda en el cruce por Way Name",
         "fr": "Prendre franchement à gauche à l'embranchement sur Way Name",
         "id": "Belok kiri pada pertigaan ke arah Way Name",
         "it": "Svolta a sinistra al bivio in Way Name",

--- a/test/fixtures/v5/fork/sharp_right_default.json
+++ b/test/fixtures/v5/fork/sharp_right_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts abbiegen an der Gabelung",
         "en": "Take a sharp right at the fork",
         "es": "Gire a la derecha en el cruce",
+        "es-ES": "Gira a la derecha en el cruce",
         "fr": "Prendre franchement à droite à l'embranchement",
         "id": "Belok kanan pada pertigaan",
         "it": "Svolta a destra al bivio",

--- a/test/fixtures/v5/fork/sharp_right_destination.json
+++ b/test/fixtures/v5/fork/sharp_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts abbiegen an der Gabelung Richtung Destination 1",
         "en": "Take a sharp right at the fork towards Destination 1",
         "es": "Gire a la derecha en el cruce hacia Destination 1",
+        "es-ES": "Gira a la derecha en el cruce hacia Destination 1",
         "fr": "Prendre franchement à droite à l'embranchement en direction de Destination 1",
         "id": "Belok kanan pada pertigaan menuju Destination 1",
         "it": "Svolta a destra al bivio verso Destination 1",

--- a/test/fixtures/v5/fork/sharp_right_exit.json
+++ b/test/fixtures/v5/fork/sharp_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts abbiegen an der Gabelung auf Way Name",
         "en": "Take a sharp right at the fork onto Way Name",
         "es": "Gire a la derecha en el cruce en Way Name",
+        "es-ES": "Gira a la derecha en el cruce por Way Name",
         "fr": "Prendre franchement à droite à l'embranchement sur Way Name",
         "id": "Belok kanan pada pertigaan ke arah Way Name",
         "it": "Svolta a destra al bivio in Way Name",

--- a/test/fixtures/v5/fork/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/fork/sharp_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf rechts abbiegen an der Gabelung Richtung Destination 1",
         "en": "Take a sharp right at the fork towards Destination 1",
         "es": "Gire a la derecha en el cruce hacia Destination 1",
+        "es-ES": "Gira a la derecha en el cruce hacia Destination 1",
         "fr": "Prendre franchement à droite à l'embranchement en direction de Destination 1",
         "id": "Belok kanan pada pertigaan menuju Destination 1",
         "it": "Svolta a destra al bivio verso Destination 1",

--- a/test/fixtures/v5/fork/sharp_right_name.json
+++ b/test/fixtures/v5/fork/sharp_right_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts abbiegen an der Gabelung auf Way Name",
         "en": "Take a sharp right at the fork onto Way Name",
         "es": "Gire a la derecha en el cruce en Way Name",
+        "es-ES": "Gira a la derecha en el cruce por Way Name",
         "fr": "Prendre franchement à droite à l'embranchement sur Way Name",
         "id": "Belok kanan pada pertigaan ke arah Way Name",
         "it": "Svolta a destra al bivio in Way Name",

--- a/test/fixtures/v5/fork/slight_left_default.json
+++ b/test/fixtures/v5/fork/slight_left_default.json
@@ -10,6 +10,7 @@
         "de": "Links halten an der Gabelung",
         "en": "Keep left at the fork",
         "es": "Mantengase a la izquierda en el cruce",
+        "es-ES": "Mantente a la izquierda en el cruce",
         "fr": "Rester à gauche à l'embranchement",
         "id": "Tetap di kiri pada pertigaan",
         "it": "Mantieni la sinistra al bivio",

--- a/test/fixtures/v5/fork/slight_left_destination.json
+++ b/test/fixtures/v5/fork/slight_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Links halten an der Gabelung Richtung Destination 1",
         "en": "Keep left at the fork towards Destination 1",
         "es": "Mantengase a la izquierda en el cruce hacia Destination 1",
+        "es-ES": "Mantente a la izquierda en el cruce hacia Destination 1",
         "fr": "Rester à gauche à l'embranchement en direction de Destination 1",
         "id": "Tetap di kiri pada pertigaan menuju Destination 1",
         "it": "Mantieni la sinistra al bivio verso Destination 1",

--- a/test/fixtures/v5/fork/slight_left_exit.json
+++ b/test/fixtures/v5/fork/slight_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Links halten an der Gabelung auf Way Name",
         "en": "Keep left at the fork onto Way Name",
         "es": "Mantengase a la izquierda en el cruce en Way Name",
+        "es-ES": "Mantente a la izquierda en el cruce por Way Name",
         "fr": "Rester à gauche à l'embranchement sur Way Name",
         "id": "Tetap di kiri pada pertigaan ke arah Way Name",
         "it": "Mantieni la sinistra al bivio in Way Name",

--- a/test/fixtures/v5/fork/slight_left_exit_destination.json
+++ b/test/fixtures/v5/fork/slight_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Links halten an der Gabelung Richtung Destination 1",
         "en": "Keep left at the fork towards Destination 1",
         "es": "Mantengase a la izquierda en el cruce hacia Destination 1",
+        "es-ES": "Mantente a la izquierda en el cruce hacia Destination 1",
         "fr": "Rester à gauche à l'embranchement en direction de Destination 1",
         "id": "Tetap di kiri pada pertigaan menuju Destination 1",
         "it": "Mantieni la sinistra al bivio verso Destination 1",

--- a/test/fixtures/v5/fork/slight_left_name.json
+++ b/test/fixtures/v5/fork/slight_left_name.json
@@ -10,6 +10,7 @@
         "de": "Links halten an der Gabelung auf Way Name",
         "en": "Keep left at the fork onto Way Name",
         "es": "Mantengase a la izquierda en el cruce en Way Name",
+        "es-ES": "Mantente a la izquierda en el cruce por Way Name",
         "fr": "Rester à gauche à l'embranchement sur Way Name",
         "id": "Tetap di kiri pada pertigaan ke arah Way Name",
         "it": "Mantieni la sinistra al bivio in Way Name",

--- a/test/fixtures/v5/fork/slight_right_default.json
+++ b/test/fixtures/v5/fork/slight_right_default.json
@@ -10,6 +10,7 @@
         "de": "Rechts halten an der Gabelung",
         "en": "Keep right at the fork",
         "es": "Mantengase a la derecha en el cruce",
+        "es-ES": "Mantente a la derecha en el cruce",
         "fr": "Rester à droite à l'embranchement",
         "id": "Tetap di kanan pada pertigaan",
         "it": "Mantieni la destra al bivio",

--- a/test/fixtures/v5/fork/slight_right_destination.json
+++ b/test/fixtures/v5/fork/slight_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Rechts halten an der Gabelung Richtung Destination 1",
         "en": "Keep right at the fork towards Destination 1",
         "es": "Mantengase a la derecha en el cruce hacia Destination 1",
+        "es-ES": "Mantente a la derecha en el cruce hacia Destination 1",
         "fr": "Rester à droite à l'embranchement en direction de Destination 1",
         "id": "Tetap di kanan pada pertigaan menuju Destination 1",
         "it": "Mantieni la destra al bivio verso Destination 1",

--- a/test/fixtures/v5/fork/slight_right_exit.json
+++ b/test/fixtures/v5/fork/slight_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Rechts halten an der Gabelung auf Way Name",
         "en": "Keep right at the fork onto Way Name",
         "es": "Mantengase a la derecha en el cruce en Way Name",
+        "es-ES": "Mantente a la derecha en el cruce por Way Name",
         "fr": "Rester à droite à l'embranchement sur Way Name",
         "id": "Tetap di kanan pada pertigaan ke arah Way Name",
         "it": "Mantieni la destra al bivio in Way Name",

--- a/test/fixtures/v5/fork/slight_right_exit_destination.json
+++ b/test/fixtures/v5/fork/slight_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Rechts halten an der Gabelung Richtung Destination 1",
         "en": "Keep right at the fork towards Destination 1",
         "es": "Mantengase a la derecha en el cruce hacia Destination 1",
+        "es-ES": "Mantente a la derecha en el cruce hacia Destination 1",
         "fr": "Rester à droite à l'embranchement en direction de Destination 1",
         "id": "Tetap di kanan pada pertigaan menuju Destination 1",
         "it": "Mantieni la destra al bivio verso Destination 1",

--- a/test/fixtures/v5/fork/slight_right_name.json
+++ b/test/fixtures/v5/fork/slight_right_name.json
@@ -10,6 +10,7 @@
         "de": "Rechts halten an der Gabelung auf Way Name",
         "en": "Keep right at the fork onto Way Name",
         "es": "Mantengase a la derecha en el cruce en Way Name",
+        "es-ES": "Mantente a la derecha en el cruce por Way Name",
         "fr": "Rester à droite à l'embranchement sur Way Name",
         "id": "Tetap di kanan pada pertigaan ke arah Way Name",
         "it": "Mantieni la destra al bivio in Way Name",

--- a/test/fixtures/v5/fork/straight_default.json
+++ b/test/fixtures/v5/fork/straight_default.json
@@ -10,6 +10,7 @@
         "de": "Geradeaus halten an der Gabelung",
         "en": "Keep straight at the fork",
         "es": "Mantengase recto en el cruce",
+        "es-ES": "Mantente recto en el cruce",
         "fr": "Rester tout droit à l'embranchement",
         "id": "Tetap lurus di pertigaan",
         "it": "Mantieni la dritto al bivio",

--- a/test/fixtures/v5/fork/straight_destination.json
+++ b/test/fixtures/v5/fork/straight_destination.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus halten an der Gabelung Richtung Destination 1",
         "en": "Keep straight at the fork towards Destination 1",
         "es": "Mantengase recto en el cruce hacia Destination 1",
+        "es-ES": "Mantente recto en el cruce hacia Destination 1",
         "fr": "Rester tout droit à l'embranchement en direction de Destination 1",
         "id": "Tetap lurus di pertigaan menuju Destination 1",
         "it": "Mantieni la dritto al bivio verso Destination 1",

--- a/test/fixtures/v5/fork/straight_exit.json
+++ b/test/fixtures/v5/fork/straight_exit.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus halten an der Gabelung auf Way Name",
         "en": "Keep straight at the fork onto Way Name",
         "es": "Mantengase recto en el cruce en Way Name",
+        "es-ES": "Mantente recto en el cruce por Way Name",
         "fr": "Rester tout droit à l'embranchement sur Way Name",
         "id": "Tetap lurus di pertigaan ke Way Name",
         "it": "Mantieni la dritto al bivio in Way Name",

--- a/test/fixtures/v5/fork/straight_exit_destination.json
+++ b/test/fixtures/v5/fork/straight_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Geradeaus halten an der Gabelung Richtung Destination 1",
         "en": "Keep straight at the fork towards Destination 1",
         "es": "Mantengase recto en el cruce hacia Destination 1",
+        "es-ES": "Mantente recto en el cruce hacia Destination 1",
         "fr": "Rester tout droit à l'embranchement en direction de Destination 1",
         "id": "Tetap lurus di pertigaan menuju Destination 1",
         "it": "Mantieni la dritto al bivio verso Destination 1",

--- a/test/fixtures/v5/fork/straight_name.json
+++ b/test/fixtures/v5/fork/straight_name.json
@@ -10,6 +10,7 @@
         "de": "Geradeaus halten an der Gabelung auf Way Name",
         "en": "Keep straight at the fork onto Way Name",
         "es": "Mantengase recto en el cruce en Way Name",
+        "es-ES": "Mantente recto en el cruce por Way Name",
         "fr": "Rester tout droit à l'embranchement sur Way Name",
         "id": "Tetap lurus di pertigaan ke Way Name",
         "it": "Mantieni la dritto al bivio in Way Name",

--- a/test/fixtures/v5/fork/uturn_default.json
+++ b/test/fixtures/v5/fork/uturn_default.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung",
         "en": "Make a U-turn",
         "es": "Haz un cambio de sentido",
+        "es-ES": "Haz un cambio de sentido",
         "fr": "Faire demi-tour",
         "id": "Putar balik",
         "it": "Fai un'inversione a U",

--- a/test/fixtures/v5/fork/uturn_destination.json
+++ b/test/fixtures/v5/fork/uturn_destination.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
+        "es-ES": "Haz un cambio de sentido hacia Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "id": "Putar balik menuju Destination 1",
         "it": "Fai un'inversione a U verso Destination 1",

--- a/test/fixtures/v5/fork/uturn_exit.json
+++ b/test/fixtures/v5/fork/uturn_exit.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung auf Way Name",
         "en": "Make a U-turn onto Way Name",
         "es": "Haz un cambio de sentido en Way Name",
+        "es-ES": "Haz un cambio de sentido en Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "id": "Putar balik ke arah Way Name",
         "it": "Fai un'inversione a U in Way Name",

--- a/test/fixtures/v5/fork/uturn_exit_destination.json
+++ b/test/fixtures/v5/fork/uturn_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "180°-Wendung Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
+        "es-ES": "Haz un cambio de sentido hacia Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "id": "Putar balik menuju Destination 1",
         "it": "Fai un'inversione a U verso Destination 1",

--- a/test/fixtures/v5/fork/uturn_name.json
+++ b/test/fixtures/v5/fork/uturn_name.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung auf Way Name",
         "en": "Make a U-turn onto Way Name",
         "es": "Haz un cambio de sentido en Way Name",
+        "es-ES": "Haz un cambio de sentido en Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "id": "Putar balik ke arah Way Name",
         "it": "Fai un'inversione a U in Way Name",

--- a/test/fixtures/v5/merge/left_default.json
+++ b/test/fixtures/v5/merge/left_default.json
@@ -10,6 +10,7 @@
         "de": "Links auffahren",
         "en": "Merge left",
         "es": "Gire a izquierda",
+        "es-ES": "Incorpórate a la izquierda",
         "fr": "Rejoindre à gauche",
         "id": "Bergabung kiri",
         "it": "Immettiti a sinistra",

--- a/test/fixtures/v5/merge/left_destination.json
+++ b/test/fixtures/v5/merge/left_destination.json
@@ -11,6 +11,7 @@
         "de": "Links auffahren Richtung Destination 1",
         "en": "Merge left towards Destination 1",
         "es": "Gire a izquierda hacia Destination 1",
+        "es-ES": "Incorpórate a la izquierda hacia Destination 1",
         "fr": "Rejoindre à gauche en direction de Destination 1",
         "id": "Bergabung kiri menuju Destination 1",
         "it": "Immettiti sinistra verso Destination 1",

--- a/test/fixtures/v5/merge/left_exit.json
+++ b/test/fixtures/v5/merge/left_exit.json
@@ -11,6 +11,7 @@
         "de": "Links auffahren auf Way Name",
         "en": "Merge left onto Way Name",
         "es": "Gire a izquierda en Way Name",
+        "es-ES": "Incorpórate a la izquierda por Way Name",
         "fr": "Rejoindre à gauche sur Way Name",
         "id": "Bergabung kiri ke arah Way Name",
         "it": "Immettiti sinistra in Way Name",

--- a/test/fixtures/v5/merge/left_exit_destination.json
+++ b/test/fixtures/v5/merge/left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Links auffahren Richtung Destination 1",
         "en": "Merge left towards Destination 1",
         "es": "Gire a izquierda hacia Destination 1",
+        "es-ES": "Incorpórate a la izquierda hacia Destination 1",
         "fr": "Rejoindre à gauche en direction de Destination 1",
         "id": "Bergabung kiri menuju Destination 1",
         "it": "Immettiti sinistra verso Destination 1",

--- a/test/fixtures/v5/merge/left_name.json
+++ b/test/fixtures/v5/merge/left_name.json
@@ -10,6 +10,7 @@
         "de": "Links auffahren auf Way Name",
         "en": "Merge left onto Way Name",
         "es": "Gire a izquierda en Way Name",
+        "es-ES": "Incorpórate a la izquierda por Way Name",
         "fr": "Rejoindre à gauche sur Way Name",
         "id": "Bergabung kiri ke arah Way Name",
         "it": "Immettiti sinistra in Way Name",

--- a/test/fixtures/v5/merge/right_default.json
+++ b/test/fixtures/v5/merge/right_default.json
@@ -10,6 +10,7 @@
         "de": "Rechts auffahren",
         "en": "Merge right",
         "es": "Gire a derecha",
+        "es-ES": "Incorpórate a la derecha",
         "fr": "Rejoindre à droite",
         "id": "Bergabung kanan",
         "it": "Immettiti a destra",

--- a/test/fixtures/v5/merge/right_destination.json
+++ b/test/fixtures/v5/merge/right_destination.json
@@ -11,6 +11,7 @@
         "de": "Rechts auffahren Richtung Destination 1",
         "en": "Merge right towards Destination 1",
         "es": "Gire a derecha hacia Destination 1",
+        "es-ES": "Incorpórate a la derecha hacia Destination 1",
         "fr": "Rejoindre à droite en direction de Destination 1",
         "id": "Bergabung kanan menuju Destination 1",
         "it": "Immettiti destra verso Destination 1",

--- a/test/fixtures/v5/merge/right_exit.json
+++ b/test/fixtures/v5/merge/right_exit.json
@@ -11,6 +11,7 @@
         "de": "Rechts auffahren auf Way Name",
         "en": "Merge right onto Way Name",
         "es": "Gire a derecha en Way Name",
+        "es-ES": "Incorpórate a la derecha por Way Name",
         "fr": "Rejoindre à droite sur Way Name",
         "id": "Bergabung kanan ke arah Way Name",
         "it": "Immettiti destra in Way Name",

--- a/test/fixtures/v5/merge/right_exit_destination.json
+++ b/test/fixtures/v5/merge/right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Rechts auffahren Richtung Destination 1",
         "en": "Merge right towards Destination 1",
         "es": "Gire a derecha hacia Destination 1",
+        "es-ES": "Incorpórate a la derecha hacia Destination 1",
         "fr": "Rejoindre à droite en direction de Destination 1",
         "id": "Bergabung kanan menuju Destination 1",
         "it": "Immettiti destra verso Destination 1",

--- a/test/fixtures/v5/merge/right_name.json
+++ b/test/fixtures/v5/merge/right_name.json
@@ -10,6 +10,7 @@
         "de": "Rechts auffahren auf Way Name",
         "en": "Merge right onto Way Name",
         "es": "Gire a derecha en Way Name",
+        "es-ES": "Incorpórate a la derecha por Way Name",
         "fr": "Rejoindre à droite sur Way Name",
         "id": "Bergabung kanan ke arah Way Name",
         "it": "Immettiti destra in Way Name",

--- a/test/fixtures/v5/merge/sharp_left_default.json
+++ b/test/fixtures/v5/merge/sharp_left_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf links auffahren",
         "en": "Merge left",
         "es": "Gire a la izquierda",
+        "es-ES": "Incorpórate a la izquierda",
         "fr": "Rejoindre par la gauche",
         "id": "Bergabung di kiri",
         "it": "Immettiti a sinistra",

--- a/test/fixtures/v5/merge/sharp_left_destination.json
+++ b/test/fixtures/v5/merge/sharp_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf links auffahren Richtung Destination 1",
         "en": "Merge left towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Incorpórate a la izquierda hacia Destination 1",
         "fr": "Rejoindre par la gauche la route en direction de Destination 1",
         "id": "Bergabung di kiri menuju Destination 1",
         "it": "Immettiti a sinistra verso Destination 1",

--- a/test/fixtures/v5/merge/sharp_left_exit.json
+++ b/test/fixtures/v5/merge/sharp_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf links auffahren auf Way Name",
         "en": "Merge left onto Way Name",
         "es": "Gire a la izquierda en Way Name",
+        "es-ES": "Incorpórate a la izquierda por Way Name",
         "fr": "Rejoindre Way Name par la gauche",
         "id": "Bergabung di kiri ke arah Way Name",
         "it": "Immettiti a sinistra in Way Name",

--- a/test/fixtures/v5/merge/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/merge/sharp_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf links auffahren Richtung Destination 1",
         "en": "Merge left towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Incorpórate a la izquierda hacia Destination 1",
         "fr": "Rejoindre par la gauche la route en direction de Destination 1",
         "id": "Bergabung di kiri menuju Destination 1",
         "it": "Immettiti a sinistra verso Destination 1",

--- a/test/fixtures/v5/merge/sharp_left_name.json
+++ b/test/fixtures/v5/merge/sharp_left_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf links auffahren auf Way Name",
         "en": "Merge left onto Way Name",
         "es": "Gire a la izquierda en Way Name",
+        "es-ES": "Incorpórate a la izquierda por Way Name",
         "fr": "Rejoindre Way Name par la gauche",
         "id": "Bergabung di kiri ke arah Way Name",
         "it": "Immettiti a sinistra in Way Name",

--- a/test/fixtures/v5/merge/sharp_right_default.json
+++ b/test/fixtures/v5/merge/sharp_right_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts auffahren",
         "en": "Merge right",
         "es": "Gire a la derecha",
+        "es-ES": "Incorpórate a la derecha",
         "fr": "Rejoindre par la droite",
         "id": "Bergabung di kanan",
         "it": "Immettiti a destra",

--- a/test/fixtures/v5/merge/sharp_right_destination.json
+++ b/test/fixtures/v5/merge/sharp_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts auffahren Richtung Destination 1",
         "en": "Merge right towards Destination 1",
         "es": "Gire a la derecha hacia Destination 1",
+        "es-ES": "Incorpórate a la derecha hacia Destination 1",
         "fr": "Rejoindre par la droite la route en direction de Destination 1",
         "id": "Bergabung di kanan menuju Destination 1",
         "it": "Immettiti a destra verso Destination 1",

--- a/test/fixtures/v5/merge/sharp_right_exit.json
+++ b/test/fixtures/v5/merge/sharp_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts auffahren auf Way Name",
         "en": "Merge right onto Way Name",
         "es": "Gire a la derecha en Way Name",
+        "es-ES": "Incorpórate a la derecha por Way Name",
         "fr": "Rejoindre Way Name par la droite",
         "id": "Bergabung di kanan ke arah Way Name",
         "it": "Immettiti a destra in Way Name",

--- a/test/fixtures/v5/merge/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/merge/sharp_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf rechts auffahren Richtung Destination 1",
         "en": "Merge right towards Destination 1",
         "es": "Gire a la derecha hacia Destination 1",
+        "es-ES": "Incorpórate a la derecha hacia Destination 1",
         "fr": "Rejoindre par la droite la route en direction de Destination 1",
         "id": "Bergabung di kanan menuju Destination 1",
         "it": "Immettiti a destra verso Destination 1",

--- a/test/fixtures/v5/merge/sharp_right_name.json
+++ b/test/fixtures/v5/merge/sharp_right_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts auffahren auf Way Name",
         "en": "Merge right onto Way Name",
         "es": "Gire a la derecha en Way Name",
+        "es-ES": "Incorpórate a la derecha por Way Name",
         "fr": "Rejoindre Way Name par la droite",
         "id": "Bergabung di kanan ke arah Way Name",
         "it": "Immettiti a destra in Way Name",

--- a/test/fixtures/v5/merge/slight_left_default.json
+++ b/test/fixtures/v5/merge/slight_left_default.json
@@ -10,6 +10,7 @@
         "de": "Leicht links auffahren",
         "en": "Merge left",
         "es": "Gire a la izquierda",
+        "es-ES": "Incorpórate a la izquierda",
         "fr": "Rejoindre par la gauche",
         "id": "Bergabung di kiri",
         "it": "Immettiti a sinistra",

--- a/test/fixtures/v5/merge/slight_left_destination.json
+++ b/test/fixtures/v5/merge/slight_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Leicht links auffahren Richtung Destination 1",
         "en": "Merge left towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Incorpórate a la izquierda hacia Destination 1",
         "fr": "Rejoindre par la gauche la route en direction de Destination 1",
         "id": "Bergabung di kiri menuju Destination 1",
         "it": "Immettiti a sinistra verso Destination 1",

--- a/test/fixtures/v5/merge/slight_left_exit.json
+++ b/test/fixtures/v5/merge/slight_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Leicht links auffahren auf Way Name",
         "en": "Merge left onto Way Name",
         "es": "Gire a la izquierda en Way Name",
+        "es-ES": "Incorpórate a la izquierda por Way Name",
         "fr": "Rejoindre Way Name par la gauche",
         "id": "Bergabung di kiri ke arah Way Name",
         "it": "Immettiti a sinistra in Way Name",

--- a/test/fixtures/v5/merge/slight_left_exit_destination.json
+++ b/test/fixtures/v5/merge/slight_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Leicht links auffahren Richtung Destination 1",
         "en": "Merge left towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Incorpórate a la izquierda hacia Destination 1",
         "fr": "Rejoindre par la gauche la route en direction de Destination 1",
         "id": "Bergabung di kiri menuju Destination 1",
         "it": "Immettiti a sinistra verso Destination 1",

--- a/test/fixtures/v5/merge/slight_left_name.json
+++ b/test/fixtures/v5/merge/slight_left_name.json
@@ -10,6 +10,7 @@
         "de": "Leicht links auffahren auf Way Name",
         "en": "Merge left onto Way Name",
         "es": "Gire a la izquierda en Way Name",
+        "es-ES": "Incorpórate a la izquierda por Way Name",
         "fr": "Rejoindre Way Name par la gauche",
         "id": "Bergabung di kiri ke arah Way Name",
         "it": "Immettiti a sinistra in Way Name",

--- a/test/fixtures/v5/merge/slight_right_default.json
+++ b/test/fixtures/v5/merge/slight_right_default.json
@@ -10,6 +10,7 @@
         "de": "Leicht rechts auffahren",
         "en": "Merge right",
         "es": "Gire a la derecha",
+        "es-ES": "Incorpórate a la derecha",
         "fr": "Rejoindre par la droite",
         "id": "Bergabung di kanan",
         "it": "Immettiti a destra",

--- a/test/fixtures/v5/merge/slight_right_destination.json
+++ b/test/fixtures/v5/merge/slight_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts auffahren Richtung Destination 1",
         "en": "Merge right towards Destination 1",
         "es": "Gire a la derecha hacia Destination 1",
+        "es-ES": "Incorpórate a la derecha hacia Destination 1",
         "fr": "Rejoindre par la droite la route en direction de Destination 1",
         "id": "Bergabung di kanan menuju Destination 1",
         "it": "Immettiti a destra verso Destination 1",

--- a/test/fixtures/v5/merge/slight_right_exit.json
+++ b/test/fixtures/v5/merge/slight_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts auffahren auf Way Name",
         "en": "Merge right onto Way Name",
         "es": "Gire a la derecha en Way Name",
+        "es-ES": "Incorpórate a la derecha por Way Name",
         "fr": "Rejoindre Way Name par la droite",
         "id": "Bergabung di kanan ke arah Way Name",
         "it": "Immettiti a destra in Way Name",

--- a/test/fixtures/v5/merge/slight_right_exit_destination.json
+++ b/test/fixtures/v5/merge/slight_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Leicht rechts auffahren Richtung Destination 1",
         "en": "Merge right towards Destination 1",
         "es": "Gire a la derecha hacia Destination 1",
+        "es-ES": "Incorpórate a la derecha hacia Destination 1",
         "fr": "Rejoindre par la droite la route en direction de Destination 1",
         "id": "Bergabung di kanan menuju Destination 1",
         "it": "Immettiti a destra verso Destination 1",

--- a/test/fixtures/v5/merge/slight_right_name.json
+++ b/test/fixtures/v5/merge/slight_right_name.json
@@ -10,6 +10,7 @@
         "de": "Leicht rechts auffahren auf Way Name",
         "en": "Merge right onto Way Name",
         "es": "Gire a la derecha en Way Name",
+        "es-ES": "Incorpórate a la derecha por Way Name",
         "fr": "Rejoindre Way Name par la droite",
         "id": "Bergabung di kanan ke arah Way Name",
         "it": "Immettiti a destra in Way Name",

--- a/test/fixtures/v5/merge/straight_default.json
+++ b/test/fixtures/v5/merge/straight_default.json
@@ -10,6 +10,7 @@
         "de": "Geradeaus auffahren",
         "en": "Merge straight",
         "es": "Gire a recto",
+        "es-ES": "Incorpórate recto",
         "fr": "Rejoindre tout droit",
         "id": "Bergabung lurus",
         "it": "Immettiti a dritto",

--- a/test/fixtures/v5/merge/straight_destination.json
+++ b/test/fixtures/v5/merge/straight_destination.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus auffahren Richtung Destination 1",
         "en": "Merge straight towards Destination 1",
         "es": "Gire a recto hacia Destination 1",
+        "es-ES": "Incorpórate recto hacia Destination 1",
         "fr": "Rejoindre tout droit en direction de Destination 1",
         "id": "Bergabung lurus menuju Destination 1",
         "it": "Immettiti dritto verso Destination 1",

--- a/test/fixtures/v5/merge/straight_exit.json
+++ b/test/fixtures/v5/merge/straight_exit.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus auffahren auf Way Name",
         "en": "Merge straight onto Way Name",
         "es": "Gire a recto en Way Name",
+        "es-ES": "Incorpórate recto por Way Name",
         "fr": "Rejoindre tout droit sur Way Name",
         "id": "Bergabung lurus ke arah Way Name",
         "it": "Immettiti dritto in Way Name",

--- a/test/fixtures/v5/merge/straight_exit_destination.json
+++ b/test/fixtures/v5/merge/straight_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Geradeaus auffahren Richtung Destination 1",
         "en": "Merge straight towards Destination 1",
         "es": "Gire a recto hacia Destination 1",
+        "es-ES": "Incorpórate recto hacia Destination 1",
         "fr": "Rejoindre tout droit en direction de Destination 1",
         "id": "Bergabung lurus menuju Destination 1",
         "it": "Immettiti dritto verso Destination 1",

--- a/test/fixtures/v5/merge/straight_name.json
+++ b/test/fixtures/v5/merge/straight_name.json
@@ -10,6 +10,7 @@
         "de": "Geradeaus auffahren auf Way Name",
         "en": "Merge straight onto Way Name",
         "es": "Gire a recto en Way Name",
+        "es-ES": "Incorpórate recto por Way Name",
         "fr": "Rejoindre tout droit sur Way Name",
         "id": "Bergabung lurus ke arah Way Name",
         "it": "Immettiti dritto in Way Name",

--- a/test/fixtures/v5/merge/uturn_default.json
+++ b/test/fixtures/v5/merge/uturn_default.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung",
         "en": "Make a U-turn",
         "es": "Haz un cambio de sentido",
+        "es-ES": "Haz un cambio de sentido",
         "fr": "Faire demi-tour",
         "id": "Putar balik",
         "it": "Fai un'inversione a U",

--- a/test/fixtures/v5/merge/uturn_destination.json
+++ b/test/fixtures/v5/merge/uturn_destination.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
+        "es-ES": "Haz un cambio de sentido hacia Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "id": "Putar balik menuju Destination 1",
         "it": "Fai un'inversione a U verso Destination 1",

--- a/test/fixtures/v5/merge/uturn_exit.json
+++ b/test/fixtures/v5/merge/uturn_exit.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung auf Way Name",
         "en": "Make a U-turn onto Way Name",
         "es": "Haz un cambio de sentido en Way Name",
+        "es-ES": "Haz un cambio de sentido en Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "id": "Putar balik ke arah Way Name",
         "it": "Fai un'inversione a U in Way Name",

--- a/test/fixtures/v5/merge/uturn_exit_destination.json
+++ b/test/fixtures/v5/merge/uturn_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "180°-Wendung Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
+        "es-ES": "Haz un cambio de sentido hacia Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "id": "Putar balik menuju Destination 1",
         "it": "Fai un'inversione a U verso Destination 1",

--- a/test/fixtures/v5/merge/uturn_name.json
+++ b/test/fixtures/v5/merge/uturn_name.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung auf Way Name",
         "en": "Make a U-turn onto Way Name",
         "es": "Haz un cambio de sentido en Way Name",
+        "es-ES": "Haz un cambio de sentido en Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "id": "Putar balik ke arah Way Name",
         "it": "Fai un'inversione a U in Way Name",

--- a/test/fixtures/v5/modes/driving_turn_left.json
+++ b/test/fixtures/v5/modes/driving_turn_left.json
@@ -11,6 +11,7 @@
         "de": "Links abbiegen auf Way Name",
         "en": "Turn left onto Way Name",
         "es": "Gire a la izquierda en Way Name",
+        "es-ES": "Gira a la izquierda por Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "id": "Belok kiri ke Way Name",
         "it": "Svolta a sinistra in Way Name",

--- a/test/fixtures/v5/modes/ferry_fork_left_default.json
+++ b/test/fixtures/v5/modes/ferry_fork_left_default.json
@@ -11,6 +11,7 @@
         "de": "Fähre nehmen",
         "en": "Take the ferry",
         "es": "Coge el ferry",
+        "es-ES": "Coge el ferry",
         "fr": "Prendre le ferry",
         "id": "Naik ferry",
         "it": "Prendi il traghetto",

--- a/test/fixtures/v5/modes/ferry_fork_left_destination.json
+++ b/test/fixtures/v5/modes/ferry_fork_left_destination.json
@@ -12,6 +12,7 @@
         "de": "Fähre nehmen Richtung Destination 1",
         "en": "Take the ferry towards Destination 1",
         "es": "Coge el ferry a Destination 1",
+        "es-ES": "Coge el ferry hacia Destination 1",
         "fr": "Prendre le ferry en direction de Destination 1",
         "id": "Naik ferry menuju Destination 1",
         "it": "Prendi il traghetto verso Destination 1",

--- a/test/fixtures/v5/modes/ferry_fork_left_exit.json
+++ b/test/fixtures/v5/modes/ferry_fork_left_exit.json
@@ -12,6 +12,7 @@
         "de": "Fähre nehmen Way Name",
         "en": "Take the ferry Way Name",
         "es": "Coge el ferry Way Name",
+        "es-ES": "Coge el ferry Way Name",
         "fr": "Prendre le ferry Way Name",
         "id": "Naik ferry di Way Name",
         "it": "Prendi il traghetto Way Name",

--- a/test/fixtures/v5/modes/ferry_fork_left_exit_destination.json
+++ b/test/fixtures/v5/modes/ferry_fork_left_exit_destination.json
@@ -13,6 +13,7 @@
         "de": "Fähre nehmen Richtung Destination 1",
         "en": "Take the ferry towards Destination 1",
         "es": "Coge el ferry a Destination 1",
+        "es-ES": "Coge el ferry hacia Destination 1",
         "fr": "Prendre le ferry en direction de Destination 1",
         "id": "Naik ferry menuju Destination 1",
         "it": "Prendi il traghetto verso Destination 1",

--- a/test/fixtures/v5/modes/ferry_fork_left_name.json
+++ b/test/fixtures/v5/modes/ferry_fork_left_name.json
@@ -11,6 +11,7 @@
         "de": "Fähre nehmen Way Name",
         "en": "Take the ferry Way Name",
         "es": "Coge el ferry Way Name",
+        "es-ES": "Coge el ferry Way Name",
         "fr": "Prendre le ferry Way Name",
         "id": "Naik ferry di Way Name",
         "it": "Prendi il traghetto Way Name",

--- a/test/fixtures/v5/modes/ferry_turn_left_default.json
+++ b/test/fixtures/v5/modes/ferry_turn_left_default.json
@@ -11,6 +11,7 @@
         "de": "Fähre nehmen",
         "en": "Take the ferry",
         "es": "Coge el ferry",
+        "es-ES": "Coge el ferry",
         "fr": "Prendre le ferry",
         "id": "Naik ferry",
         "it": "Prendi il traghetto",

--- a/test/fixtures/v5/modes/ferry_turn_left_destination.json
+++ b/test/fixtures/v5/modes/ferry_turn_left_destination.json
@@ -12,6 +12,7 @@
         "de": "Fähre nehmen Richtung Destination 1",
         "en": "Take the ferry towards Destination 1",
         "es": "Coge el ferry a Destination 1",
+        "es-ES": "Coge el ferry hacia Destination 1",
         "fr": "Prendre le ferry en direction de Destination 1",
         "id": "Naik ferry menuju Destination 1",
         "it": "Prendi il traghetto verso Destination 1",

--- a/test/fixtures/v5/modes/ferry_turn_left_exit.json
+++ b/test/fixtures/v5/modes/ferry_turn_left_exit.json
@@ -12,6 +12,7 @@
         "de": "Fähre nehmen Way Name",
         "en": "Take the ferry Way Name",
         "es": "Coge el ferry Way Name",
+        "es-ES": "Coge el ferry Way Name",
         "fr": "Prendre le ferry Way Name",
         "id": "Naik ferry di Way Name",
         "it": "Prendi il traghetto Way Name",

--- a/test/fixtures/v5/modes/ferry_turn_left_exit_destination.json
+++ b/test/fixtures/v5/modes/ferry_turn_left_exit_destination.json
@@ -13,6 +13,7 @@
         "de": "Fähre nehmen Richtung Destination 1",
         "en": "Take the ferry towards Destination 1",
         "es": "Coge el ferry a Destination 1",
+        "es-ES": "Coge el ferry hacia Destination 1",
         "fr": "Prendre le ferry en direction de Destination 1",
         "id": "Naik ferry menuju Destination 1",
         "it": "Prendi il traghetto verso Destination 1",

--- a/test/fixtures/v5/modes/ferry_turn_left_name.json
+++ b/test/fixtures/v5/modes/ferry_turn_left_name.json
@@ -11,6 +11,7 @@
         "de": "Fähre nehmen Way Name",
         "en": "Take the ferry Way Name",
         "es": "Coge el ferry Way Name",
+        "es-ES": "Coge el ferry Way Name",
         "fr": "Prendre le ferry Way Name",
         "id": "Naik ferry di Way Name",
         "it": "Prendi il traghetto Way Name",

--- a/test/fixtures/v5/new_name/left_default.json
+++ b/test/fixtures/v5/new_name/left_default.json
@@ -10,6 +10,7 @@
         "de": "Links weiterfahren",
         "en": "Continue left",
         "es": "Continúe izquierda",
+        "es-ES": "Continúa a la izquierda",
         "fr": "Continuer à gauche",
         "id": "Lanjutkan kiri",
         "it": "Continua a sinistra",

--- a/test/fixtures/v5/new_name/left_destination.json
+++ b/test/fixtures/v5/new_name/left_destination.json
@@ -11,6 +11,7 @@
         "de": "Links weiterfahren Richtung Destination 1",
         "en": "Continue left towards Destination 1",
         "es": "Continúe izquierda hacia Destination 1",
+        "es-ES": "Continúa a la izquierda hacia Destination 1",
         "fr": "Continuer à gauche en direction de Destination 1",
         "id": "Lanjutkan kiri menuju Destination 1",
         "it": "Continua a sinistra verso Destination 1",

--- a/test/fixtures/v5/new_name/left_exit.json
+++ b/test/fixtures/v5/new_name/left_exit.json
@@ -11,6 +11,7 @@
         "de": "Links weiterfahren auf Way Name",
         "en": "Continue left onto Way Name",
         "es": "Continúe izquierda en Way Name",
+        "es-ES": "Continúa a la izquierda por Way Name",
         "fr": "Continuer à gauche sur Way Name",
         "id": "Lanjutkan kiri menuju Way Name",
         "it": "Continua a sinistra in Way Name",

--- a/test/fixtures/v5/new_name/left_exit_destination.json
+++ b/test/fixtures/v5/new_name/left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Links weiterfahren Richtung Destination 1",
         "en": "Continue left towards Destination 1",
         "es": "Continúe izquierda hacia Destination 1",
+        "es-ES": "Continúa a la izquierda hacia Destination 1",
         "fr": "Continuer à gauche en direction de Destination 1",
         "id": "Lanjutkan kiri menuju Destination 1",
         "it": "Continua a sinistra verso Destination 1",

--- a/test/fixtures/v5/new_name/left_name.json
+++ b/test/fixtures/v5/new_name/left_name.json
@@ -10,6 +10,7 @@
         "de": "Links weiterfahren auf Way Name",
         "en": "Continue left onto Way Name",
         "es": "Continúe izquierda en Way Name",
+        "es-ES": "Continúa a la izquierda por Way Name",
         "fr": "Continuer à gauche sur Way Name",
         "id": "Lanjutkan kiri menuju Way Name",
         "it": "Continua a sinistra in Way Name",

--- a/test/fixtures/v5/new_name/right_default.json
+++ b/test/fixtures/v5/new_name/right_default.json
@@ -10,6 +10,7 @@
         "de": "Rechts weiterfahren",
         "en": "Continue right",
         "es": "Continúe derecha",
+        "es-ES": "Continúa a la derecha",
         "fr": "Continuer à droite",
         "id": "Lanjutkan kanan",
         "it": "Continua a destra",

--- a/test/fixtures/v5/new_name/right_destination.json
+++ b/test/fixtures/v5/new_name/right_destination.json
@@ -11,6 +11,7 @@
         "de": "Rechts weiterfahren Richtung Destination 1",
         "en": "Continue right towards Destination 1",
         "es": "Continúe derecha hacia Destination 1",
+        "es-ES": "Continúa a la derecha hacia Destination 1",
         "fr": "Continuer à droite en direction de Destination 1",
         "id": "Lanjutkan kanan menuju Destination 1",
         "it": "Continua a destra verso Destination 1",

--- a/test/fixtures/v5/new_name/right_exit.json
+++ b/test/fixtures/v5/new_name/right_exit.json
@@ -11,6 +11,7 @@
         "de": "Rechts weiterfahren auf Way Name",
         "en": "Continue right onto Way Name",
         "es": "Continúe derecha en Way Name",
+        "es-ES": "Continúa a la derecha por Way Name",
         "fr": "Continuer à droite sur Way Name",
         "id": "Lanjutkan kanan menuju Way Name",
         "it": "Continua a destra in Way Name",

--- a/test/fixtures/v5/new_name/right_exit_destination.json
+++ b/test/fixtures/v5/new_name/right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Rechts weiterfahren Richtung Destination 1",
         "en": "Continue right towards Destination 1",
         "es": "Continúe derecha hacia Destination 1",
+        "es-ES": "Continúa a la derecha hacia Destination 1",
         "fr": "Continuer à droite en direction de Destination 1",
         "id": "Lanjutkan kanan menuju Destination 1",
         "it": "Continua a destra verso Destination 1",

--- a/test/fixtures/v5/new_name/right_name.json
+++ b/test/fixtures/v5/new_name/right_name.json
@@ -10,6 +10,7 @@
         "de": "Rechts weiterfahren auf Way Name",
         "en": "Continue right onto Way Name",
         "es": "Continúe derecha en Way Name",
+        "es-ES": "Continúa a la derecha por Way Name",
         "fr": "Continuer à droite sur Way Name",
         "id": "Lanjutkan kanan menuju Way Name",
         "it": "Continua a destra in Way Name",

--- a/test/fixtures/v5/new_name/sharp_left_default.json
+++ b/test/fixtures/v5/new_name/sharp_left_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf links",
         "en": "Take a sharp left",
         "es": "Gire a la izquierda",
+        "es-ES": "Gira a la izquierda",
         "fr": "Prendre franchement à gauche",
         "id": "Belok kiri tajam",
         "it": "Svolta a sinistra",

--- a/test/fixtures/v5/new_name/sharp_left_destination.json
+++ b/test/fixtures/v5/new_name/sharp_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf links Richtung Destination 1",
         "en": "Take a sharp left towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Gira a la izquierda hacia Destination 1",
         "fr": "Prendre franchement à gauche en direction de Destination 1",
         "id": "Belok kiri tajam menuju Destination 1",
         "it": "Svolta a sinistra verso Destination 1",

--- a/test/fixtures/v5/new_name/sharp_left_exit.json
+++ b/test/fixtures/v5/new_name/sharp_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf links auf Way Name",
         "en": "Take a sharp left onto Way Name",
         "es": "Gire a la izquierda en Way Name",
+        "es-ES": "Gira a la izquierda por Way Name",
         "fr": "Prendre franchement à gauche sur Way Name",
         "id": "Belok kiri tajam ke arah Way Name",
         "it": "Svolta a sinistra in Way Name",

--- a/test/fixtures/v5/new_name/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/new_name/sharp_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf links Richtung Destination 1",
         "en": "Take a sharp left towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Gira a la izquierda hacia Destination 1",
         "fr": "Prendre franchement à gauche en direction de Destination 1",
         "id": "Belok kiri tajam menuju Destination 1",
         "it": "Svolta a sinistra verso Destination 1",

--- a/test/fixtures/v5/new_name/sharp_left_name.json
+++ b/test/fixtures/v5/new_name/sharp_left_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf links auf Way Name",
         "en": "Take a sharp left onto Way Name",
         "es": "Gire a la izquierda en Way Name",
+        "es-ES": "Gira a la izquierda por Way Name",
         "fr": "Prendre franchement à gauche sur Way Name",
         "id": "Belok kiri tajam ke arah Way Name",
         "it": "Svolta a sinistra in Way Name",

--- a/test/fixtures/v5/new_name/sharp_right_default.json
+++ b/test/fixtures/v5/new_name/sharp_right_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts",
         "en": "Take a sharp right",
         "es": "Gire a la derecha",
+        "es-ES": "Gira a la derecha",
         "fr": "Prendre franchement à droite",
         "id": "Belok kanan tajam",
         "it": "Svolta a destra",

--- a/test/fixtures/v5/new_name/sharp_right_destination.json
+++ b/test/fixtures/v5/new_name/sharp_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts Richtung Destination 1",
         "en": "Take a sharp right towards Destination 1",
         "es": "Gire a la derecha hacia Destination 1",
+        "es-ES": "Gira a la derecha hacia Destination 1",
         "fr": "Prendre franchement à droite en direction de Destination 1",
         "id": "Belok kanan tajam menuju Destination 1",
         "it": "Svolta a destra verso Destination 1",

--- a/test/fixtures/v5/new_name/sharp_right_exit.json
+++ b/test/fixtures/v5/new_name/sharp_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts auf Way Name",
         "en": "Take a sharp right onto Way Name",
         "es": "Gire a la derecha en Way Name",
+        "es-ES": "Gira a la derecha por Way Name",
         "fr": "Prendre franchement à droite sur Way Name",
         "id": "Belok kanan tajam ke arah Way Name",
         "it": "Svolta a destra in Way Name",

--- a/test/fixtures/v5/new_name/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/new_name/sharp_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf rechts Richtung Destination 1",
         "en": "Take a sharp right towards Destination 1",
         "es": "Gire a la derecha hacia Destination 1",
+        "es-ES": "Gira a la derecha hacia Destination 1",
         "fr": "Prendre franchement à droite en direction de Destination 1",
         "id": "Belok kanan tajam menuju Destination 1",
         "it": "Svolta a destra verso Destination 1",

--- a/test/fixtures/v5/new_name/sharp_right_name.json
+++ b/test/fixtures/v5/new_name/sharp_right_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts auf Way Name",
         "en": "Take a sharp right onto Way Name",
         "es": "Gire a la derecha en Way Name",
+        "es-ES": "Gira a la derecha por Way Name",
         "fr": "Prendre franchement à droite sur Way Name",
         "id": "Belok kanan tajam ke arah Way Name",
         "it": "Svolta a destra in Way Name",

--- a/test/fixtures/v5/new_name/slight_left_default.json
+++ b/test/fixtures/v5/new_name/slight_left_default.json
@@ -10,6 +10,7 @@
         "de": "Leicht links weiter",
         "en": "Continue slightly left",
         "es": "Continúe ligeramente a la izquierda",
+        "es-ES": "Continúa ligeramente por la izquierda",
         "fr": "Continuer légèrement à gauche",
         "id": "Lanjut dengan agak ke kiri",
         "it": "Continua leggermente a sinistra",

--- a/test/fixtures/v5/new_name/slight_left_destination.json
+++ b/test/fixtures/v5/new_name/slight_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Leicht links weiter Richtung Destination 1",
         "en": "Continue slightly left towards Destination 1",
         "es": "Continúe ligeramente a la izquierda hacia Destination 1",
+        "es-ES": "Continúa ligeramente por la izquierda hacia Destination 1",
         "fr": "Continuer légèrement à gauche en direction de Destination 1",
         "id": "Tetap agak di kiri menuju Destination 1",
         "it": "Continua leggermente a sinistra verso Destination 1",

--- a/test/fixtures/v5/new_name/slight_left_exit.json
+++ b/test/fixtures/v5/new_name/slight_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Leicht links weiter auf Way Name",
         "en": "Continue slightly left onto Way Name",
         "es": "Continúe ligeramente a la izquierda en Way Name",
+        "es-ES": "Continúa ligeramente por la izquierda por Way Name",
         "fr": "Continuer légèrement à gauche sur Way Name",
         "id": "Lanjut dengan agak di kiri ke Way Name",
         "it": "Continua leggermente a sinistra in Way Name",

--- a/test/fixtures/v5/new_name/slight_left_exit_destination.json
+++ b/test/fixtures/v5/new_name/slight_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Leicht links weiter Richtung Destination 1",
         "en": "Continue slightly left towards Destination 1",
         "es": "Continúe ligeramente a la izquierda hacia Destination 1",
+        "es-ES": "Continúa ligeramente por la izquierda hacia Destination 1",
         "fr": "Continuer légèrement à gauche en direction de Destination 1",
         "id": "Tetap agak di kiri menuju Destination 1",
         "it": "Continua leggermente a sinistra verso Destination 1",

--- a/test/fixtures/v5/new_name/slight_left_name.json
+++ b/test/fixtures/v5/new_name/slight_left_name.json
@@ -10,6 +10,7 @@
         "de": "Leicht links weiter auf Way Name",
         "en": "Continue slightly left onto Way Name",
         "es": "Continúe ligeramente a la izquierda en Way Name",
+        "es-ES": "Continúa ligeramente por la izquierda por Way Name",
         "fr": "Continuer légèrement à gauche sur Way Name",
         "id": "Lanjut dengan agak di kiri ke Way Name",
         "it": "Continua leggermente a sinistra in Way Name",

--- a/test/fixtures/v5/new_name/slight_right_default.json
+++ b/test/fixtures/v5/new_name/slight_right_default.json
@@ -10,6 +10,7 @@
         "de": "Leicht rechts weiter",
         "en": "Continue slightly right",
         "es": "Continúe ligeramente a la derecha",
+        "es-ES": "Continúa ligeramente por la derecha",
         "fr": "Continuer légèrement à droite",
         "id": "Tetap agak di kanan",
         "it": "Continua leggermente a destra",

--- a/test/fixtures/v5/new_name/slight_right_destination.json
+++ b/test/fixtures/v5/new_name/slight_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts weiter Richtung Destination 1",
         "en": "Continue slightly right towards Destination 1",
         "es": "Continúe ligeramente a la derecha hacia Destination 1",
+        "es-ES": "Continúa ligeramente por la derecha hacia Destination 1",
         "fr": "Continuer légèrement à droite en direction de Destination 1",
         "id": "Tetap agak di kanan menuju Destination 1",
         "it": "Continua leggermente a destra verso Destination 1",

--- a/test/fixtures/v5/new_name/slight_right_exit.json
+++ b/test/fixtures/v5/new_name/slight_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts weiter auf Way Name",
         "en": "Continue slightly right onto Way Name",
         "es": "Continúe ligeramente a la derecha en Way Name",
+        "es-ES": "Continúa ligeramente por la derecha por Way Name",
         "fr": "Continuer légèrement à droite sur Way Name",
         "id": "Tetap agak di kanan ke Way Name",
         "it": "Continua leggermente a destra in Way Name ",

--- a/test/fixtures/v5/new_name/slight_right_exit_destination.json
+++ b/test/fixtures/v5/new_name/slight_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Leicht rechts weiter Richtung Destination 1",
         "en": "Continue slightly right towards Destination 1",
         "es": "Continúe ligeramente a la derecha hacia Destination 1",
+        "es-ES": "Continúa ligeramente por la derecha hacia Destination 1",
         "fr": "Continuer légèrement à droite en direction de Destination 1",
         "id": "Tetap agak di kanan menuju Destination 1",
         "it": "Continua leggermente a destra verso Destination 1",

--- a/test/fixtures/v5/new_name/slight_right_name.json
+++ b/test/fixtures/v5/new_name/slight_right_name.json
@@ -10,6 +10,7 @@
         "de": "Leicht rechts weiter auf Way Name",
         "en": "Continue slightly right onto Way Name",
         "es": "Continúe ligeramente a la derecha en Way Name",
+        "es-ES": "Continúa ligeramente por la derecha por Way Name",
         "fr": "Continuer légèrement à droite sur Way Name",
         "id": "Tetap agak di kanan ke Way Name",
         "it": "Continua leggermente a destra in Way Name ",

--- a/test/fixtures/v5/new_name/straight_default.json
+++ b/test/fixtures/v5/new_name/straight_default.json
@@ -10,6 +10,7 @@
         "de": "Geradeaus weiterfahren",
         "en": "Continue straight",
         "es": "Continúe recto",
+        "es-ES": "Continúa recto",
         "fr": "Continuer tout droit",
         "id": "Lurus terus",
         "it": "Continua dritto",

--- a/test/fixtures/v5/new_name/straight_destination.json
+++ b/test/fixtures/v5/new_name/straight_destination.json
@@ -11,6 +11,7 @@
         "de": "Weiterfahren in Richtung Destination 1",
         "en": "Continue towards Destination 1",
         "es": "Continúe hacia Destination 1",
+        "es-ES": "Continúa hacia Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "id": "Terus menuju Destination 1",
         "it": "Continua verso Destination 1",

--- a/test/fixtures/v5/new_name/straight_exit.json
+++ b/test/fixtures/v5/new_name/straight_exit.json
@@ -11,6 +11,7 @@
         "de": "Weiterfahren auf Way Name",
         "en": "Continue onto Way Name",
         "es": "Continúe en Way Name",
+        "es-ES": "Continúa por Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "id": "Terus ke Way Name",
         "it": "Continua in Way Name",

--- a/test/fixtures/v5/new_name/straight_exit_destination.json
+++ b/test/fixtures/v5/new_name/straight_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Weiterfahren in Richtung Destination 1",
         "en": "Continue towards Destination 1",
         "es": "Continúe hacia Destination 1",
+        "es-ES": "Continúa hacia Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "id": "Terus menuju Destination 1",
         "it": "Continua verso Destination 1",

--- a/test/fixtures/v5/new_name/straight_name.json
+++ b/test/fixtures/v5/new_name/straight_name.json
@@ -10,6 +10,7 @@
         "de": "Weiterfahren auf Way Name",
         "en": "Continue onto Way Name",
         "es": "Continúe en Way Name",
+        "es-ES": "Continúa por Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "id": "Terus ke Way Name",
         "it": "Continua in Way Name",

--- a/test/fixtures/v5/new_name/uturn_default.json
+++ b/test/fixtures/v5/new_name/uturn_default.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung",
         "en": "Make a U-turn",
         "es": "Haz un cambio de sentido",
+        "es-ES": "Haz un cambio de sentido",
         "fr": "Faire demi-tour",
         "id": "Putar balik",
         "it": "Fai un'inversione a U",

--- a/test/fixtures/v5/new_name/uturn_destination.json
+++ b/test/fixtures/v5/new_name/uturn_destination.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
+        "es-ES": "Haz un cambio de sentido hacia Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "id": "Putar balik menuju Destination 1",
         "it": "Fai un'inversione a U verso Destination 1",

--- a/test/fixtures/v5/new_name/uturn_exit.json
+++ b/test/fixtures/v5/new_name/uturn_exit.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung auf Way Name",
         "en": "Make a U-turn onto Way Name",
         "es": "Haz un cambio de sentido en Way Name",
+        "es-ES": "Haz un cambio de sentido en Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "id": "Putar balik ke arah Way Name",
         "it": "Fai un'inversione a U in Way Name",

--- a/test/fixtures/v5/new_name/uturn_exit_destination.json
+++ b/test/fixtures/v5/new_name/uturn_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "180°-Wendung Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
+        "es-ES": "Haz un cambio de sentido hacia Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "id": "Putar balik menuju Destination 1",
         "it": "Fai un'inversione a U verso Destination 1",

--- a/test/fixtures/v5/new_name/uturn_name.json
+++ b/test/fixtures/v5/new_name/uturn_name.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung auf Way Name",
         "en": "Make a U-turn onto Way Name",
         "es": "Haz un cambio de sentido en Way Name",
+        "es-ES": "Haz un cambio de sentido en Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "id": "Putar balik ke arah Way Name",
         "it": "Fai un'inversione a U in Way Name",

--- a/test/fixtures/v5/notification/left_default.json
+++ b/test/fixtures/v5/notification/left_default.json
@@ -10,6 +10,7 @@
         "de": "Links weiterfahren",
         "en": "Continue left",
         "es": "Continúe izquierda",
+        "es-ES": "Continúa a la izquierda",
         "fr": "Continuer à gauche",
         "id": "Lanjutkan kiri",
         "it": "Continua a sinistra",

--- a/test/fixtures/v5/notification/left_destination.json
+++ b/test/fixtures/v5/notification/left_destination.json
@@ -11,6 +11,7 @@
         "de": "Links weiterfahren Richtung Destination 1",
         "en": "Continue left towards Destination 1",
         "es": "Continúe izquierda hacia Destination 1",
+        "es-ES": "Continúa a la izquierda hacia Destination 1",
         "fr": "Continuer à gauche en direction de Destination 1",
         "id": "Lanjutkan kiri menuju Destination 1",
         "it": "Continua a sinistra verso Destination 1",

--- a/test/fixtures/v5/notification/left_exit.json
+++ b/test/fixtures/v5/notification/left_exit.json
@@ -11,6 +11,7 @@
         "de": "Links weiterfahren auf Way Name",
         "en": "Continue left onto Way Name",
         "es": "Continúe izquierda en Way Name",
+        "es-ES": "Continúa a la izquierda por Way Name",
         "fr": "Continuer à gauche sur Way Name",
         "id": "Lanjutkan kiri menuju Way Name",
         "it": "Continua a sinistra in Way Name",

--- a/test/fixtures/v5/notification/left_exit_destination.json
+++ b/test/fixtures/v5/notification/left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Links weiterfahren Richtung Destination 1",
         "en": "Continue left towards Destination 1",
         "es": "Continúe izquierda hacia Destination 1",
+        "es-ES": "Continúa a la izquierda hacia Destination 1",
         "fr": "Continuer à gauche en direction de Destination 1",
         "id": "Lanjutkan kiri menuju Destination 1",
         "it": "Continua a sinistra verso Destination 1",

--- a/test/fixtures/v5/notification/left_name.json
+++ b/test/fixtures/v5/notification/left_name.json
@@ -10,6 +10,7 @@
         "de": "Links weiterfahren auf Way Name",
         "en": "Continue left onto Way Name",
         "es": "Continúe izquierda en Way Name",
+        "es-ES": "Continúa a la izquierda por Way Name",
         "fr": "Continuer à gauche sur Way Name",
         "id": "Lanjutkan kiri menuju Way Name",
         "it": "Continua a sinistra in Way Name",

--- a/test/fixtures/v5/notification/right_default.json
+++ b/test/fixtures/v5/notification/right_default.json
@@ -10,6 +10,7 @@
         "de": "Rechts weiterfahren",
         "en": "Continue right",
         "es": "Continúe derecha",
+        "es-ES": "Continúa a la derecha",
         "fr": "Continuer à droite",
         "id": "Lanjutkan kanan",
         "it": "Continua a destra",

--- a/test/fixtures/v5/notification/right_destination.json
+++ b/test/fixtures/v5/notification/right_destination.json
@@ -11,6 +11,7 @@
         "de": "Rechts weiterfahren Richtung Destination 1",
         "en": "Continue right towards Destination 1",
         "es": "Continúe derecha hacia Destination 1",
+        "es-ES": "Continúa a la derecha hacia Destination 1",
         "fr": "Continuer à droite en direction de Destination 1",
         "id": "Lanjutkan kanan menuju Destination 1",
         "it": "Continua a destra verso Destination 1",

--- a/test/fixtures/v5/notification/right_exit.json
+++ b/test/fixtures/v5/notification/right_exit.json
@@ -11,6 +11,7 @@
         "de": "Rechts weiterfahren auf Way Name",
         "en": "Continue right onto Way Name",
         "es": "Continúe derecha en Way Name",
+        "es-ES": "Continúa a la derecha por Way Name",
         "fr": "Continuer à droite sur Way Name",
         "id": "Lanjutkan kanan menuju Way Name",
         "it": "Continua a destra in Way Name",

--- a/test/fixtures/v5/notification/right_exit_destination.json
+++ b/test/fixtures/v5/notification/right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Rechts weiterfahren Richtung Destination 1",
         "en": "Continue right towards Destination 1",
         "es": "Continúe derecha hacia Destination 1",
+        "es-ES": "Continúa a la derecha hacia Destination 1",
         "fr": "Continuer à droite en direction de Destination 1",
         "id": "Lanjutkan kanan menuju Destination 1",
         "it": "Continua a destra verso Destination 1",

--- a/test/fixtures/v5/notification/right_name.json
+++ b/test/fixtures/v5/notification/right_name.json
@@ -10,6 +10,7 @@
         "de": "Rechts weiterfahren auf Way Name",
         "en": "Continue right onto Way Name",
         "es": "Continúe derecha en Way Name",
+        "es-ES": "Continúa a la derecha por Way Name",
         "fr": "Continuer à droite sur Way Name",
         "id": "Lanjutkan kanan menuju Way Name",
         "it": "Continua a destra in Way Name",

--- a/test/fixtures/v5/notification/sharp_left_default.json
+++ b/test/fixtures/v5/notification/sharp_left_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf links weiterfahren",
         "en": "Continue sharp left",
         "es": "Continúe cerrada a la izquierda",
+        "es-ES": "Continúa cerrada a la izquierda",
         "fr": "Continuer franchement à gauche",
         "id": "Lanjutkan tajam kiri",
         "it": "Continua a sinistra",

--- a/test/fixtures/v5/notification/sharp_left_destination.json
+++ b/test/fixtures/v5/notification/sharp_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf links weiterfahren Richtung Destination 1",
         "en": "Continue sharp left towards Destination 1",
         "es": "Continúe cerrada a la izquierda hacia Destination 1",
+        "es-ES": "Continúa cerrada a la izquierda hacia Destination 1",
         "fr": "Continuer franchement à gauche en direction de Destination 1",
         "id": "Lanjutkan tajam kiri menuju Destination 1",
         "it": "Continua a sinistra verso Destination 1",

--- a/test/fixtures/v5/notification/sharp_left_exit.json
+++ b/test/fixtures/v5/notification/sharp_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf links weiterfahren auf Way Name",
         "en": "Continue sharp left onto Way Name",
         "es": "Continúe cerrada a la izquierda en Way Name",
+        "es-ES": "Continúa cerrada a la izquierda por Way Name",
         "fr": "Continuer franchement à gauche sur Way Name",
         "id": "Lanjutkan tajam kiri menuju Way Name",
         "it": "Continua a sinistra in Way Name",

--- a/test/fixtures/v5/notification/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/notification/sharp_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf links weiterfahren Richtung Destination 1",
         "en": "Continue sharp left towards Destination 1",
         "es": "Continúe cerrada a la izquierda hacia Destination 1",
+        "es-ES": "Continúa cerrada a la izquierda hacia Destination 1",
         "fr": "Continuer franchement à gauche en direction de Destination 1",
         "id": "Lanjutkan tajam kiri menuju Destination 1",
         "it": "Continua a sinistra verso Destination 1",

--- a/test/fixtures/v5/notification/sharp_left_name.json
+++ b/test/fixtures/v5/notification/sharp_left_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf links weiterfahren auf Way Name",
         "en": "Continue sharp left onto Way Name",
         "es": "Continúe cerrada a la izquierda en Way Name",
+        "es-ES": "Continúa cerrada a la izquierda por Way Name",
         "fr": "Continuer franchement à gauche sur Way Name",
         "id": "Lanjutkan tajam kiri menuju Way Name",
         "it": "Continua a sinistra in Way Name",

--- a/test/fixtures/v5/notification/sharp_right_default.json
+++ b/test/fixtures/v5/notification/sharp_right_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts weiterfahren",
         "en": "Continue sharp right",
         "es": "Continúe cerrada a la derecha",
+        "es-ES": "Continúa cerrada a la derecha",
         "fr": "Continuer franchement à droite",
         "id": "Lanjutkan tajam kanan",
         "it": "Continua a destra",

--- a/test/fixtures/v5/notification/sharp_right_destination.json
+++ b/test/fixtures/v5/notification/sharp_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts weiterfahren Richtung Destination 1",
         "en": "Continue sharp right towards Destination 1",
         "es": "Continúe cerrada a la derecha hacia Destination 1",
+        "es-ES": "Continúa cerrada a la derecha hacia Destination 1",
         "fr": "Continuer franchement à droite en direction de Destination 1",
         "id": "Lanjutkan tajam kanan menuju Destination 1",
         "it": "Continua a destra verso Destination 1",

--- a/test/fixtures/v5/notification/sharp_right_exit.json
+++ b/test/fixtures/v5/notification/sharp_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts weiterfahren auf Way Name",
         "en": "Continue sharp right onto Way Name",
         "es": "Continúe cerrada a la derecha en Way Name",
+        "es-ES": "Continúa cerrada a la derecha por Way Name",
         "fr": "Continuer franchement à droite sur Way Name",
         "id": "Lanjutkan tajam kanan menuju Way Name",
         "it": "Continua a destra in Way Name",

--- a/test/fixtures/v5/notification/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/notification/sharp_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf rechts weiterfahren Richtung Destination 1",
         "en": "Continue sharp right towards Destination 1",
         "es": "Continúe cerrada a la derecha hacia Destination 1",
+        "es-ES": "Continúa cerrada a la derecha hacia Destination 1",
         "fr": "Continuer franchement à droite en direction de Destination 1",
         "id": "Lanjutkan tajam kanan menuju Destination 1",
         "it": "Continua a destra verso Destination 1",

--- a/test/fixtures/v5/notification/sharp_right_name.json
+++ b/test/fixtures/v5/notification/sharp_right_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts weiterfahren auf Way Name",
         "en": "Continue sharp right onto Way Name",
         "es": "Continúe cerrada a la derecha en Way Name",
+        "es-ES": "Continúa cerrada a la derecha por Way Name",
         "fr": "Continuer franchement à droite sur Way Name",
         "id": "Lanjutkan tajam kanan menuju Way Name",
         "it": "Continua a destra in Way Name",

--- a/test/fixtures/v5/notification/slight_left_default.json
+++ b/test/fixtures/v5/notification/slight_left_default.json
@@ -10,6 +10,7 @@
         "de": "Leicht links weiterfahren",
         "en": "Continue slight left",
         "es": "Continúe ligeramente a la izquierda",
+        "es-ES": "Continúa ligeramente a la izquierda",
         "fr": "Continuer légèrement à gauche",
         "id": "Lanjutkan agak ke kiri",
         "it": "Continua a sinistra leggermente",

--- a/test/fixtures/v5/notification/slight_left_destination.json
+++ b/test/fixtures/v5/notification/slight_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Leicht links weiterfahren Richtung Destination 1",
         "en": "Continue slight left towards Destination 1",
         "es": "Continúe ligeramente a la izquierda hacia Destination 1",
+        "es-ES": "Continúa ligeramente a la izquierda hacia Destination 1",
         "fr": "Continuer légèrement à gauche en direction de Destination 1",
         "id": "Lanjutkan agak ke kiri menuju Destination 1",
         "it": "Continua a sinistra leggermente verso Destination 1",

--- a/test/fixtures/v5/notification/slight_left_exit.json
+++ b/test/fixtures/v5/notification/slight_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Leicht links weiterfahren auf Way Name",
         "en": "Continue slight left onto Way Name",
         "es": "Continúe ligeramente a la izquierda en Way Name",
+        "es-ES": "Continúa ligeramente a la izquierda por Way Name",
         "fr": "Continuer légèrement à gauche sur Way Name",
         "id": "Lanjutkan agak ke kiri menuju Way Name",
         "it": "Continua a sinistra leggermente in Way Name",

--- a/test/fixtures/v5/notification/slight_left_exit_destination.json
+++ b/test/fixtures/v5/notification/slight_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Leicht links weiterfahren Richtung Destination 1",
         "en": "Continue slight left towards Destination 1",
         "es": "Continúe ligeramente a la izquierda hacia Destination 1",
+        "es-ES": "Continúa ligeramente a la izquierda hacia Destination 1",
         "fr": "Continuer légèrement à gauche en direction de Destination 1",
         "id": "Lanjutkan agak ke kiri menuju Destination 1",
         "it": "Continua a sinistra leggermente verso Destination 1",

--- a/test/fixtures/v5/notification/slight_left_name.json
+++ b/test/fixtures/v5/notification/slight_left_name.json
@@ -10,6 +10,7 @@
         "de": "Leicht links weiterfahren auf Way Name",
         "en": "Continue slight left onto Way Name",
         "es": "Continúe ligeramente a la izquierda en Way Name",
+        "es-ES": "Continúa ligeramente a la izquierda por Way Name",
         "fr": "Continuer légèrement à gauche sur Way Name",
         "id": "Lanjutkan agak ke kiri menuju Way Name",
         "it": "Continua a sinistra leggermente in Way Name",

--- a/test/fixtures/v5/notification/slight_right_default.json
+++ b/test/fixtures/v5/notification/slight_right_default.json
@@ -10,6 +10,7 @@
         "de": "Leicht rechts weiterfahren",
         "en": "Continue slight right",
         "es": "Continúe ligeramente a la derecha",
+        "es-ES": "Continúa ligeramente a la derecha",
         "fr": "Continuer légèrement à droite",
         "id": "Lanjutkan agak ke kanan",
         "it": "Continua a destra leggermente",

--- a/test/fixtures/v5/notification/slight_right_destination.json
+++ b/test/fixtures/v5/notification/slight_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts weiterfahren Richtung Destination 1",
         "en": "Continue slight right towards Destination 1",
         "es": "Continúe ligeramente a la derecha hacia Destination 1",
+        "es-ES": "Continúa ligeramente a la derecha hacia Destination 1",
         "fr": "Continuer légèrement à droite en direction de Destination 1",
         "id": "Lanjutkan agak ke kanan menuju Destination 1",
         "it": "Continua a destra leggermente verso Destination 1",

--- a/test/fixtures/v5/notification/slight_right_exit.json
+++ b/test/fixtures/v5/notification/slight_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts weiterfahren auf Way Name",
         "en": "Continue slight right onto Way Name",
         "es": "Continúe ligeramente a la derecha en Way Name",
+        "es-ES": "Continúa ligeramente a la derecha por Way Name",
         "fr": "Continuer légèrement à droite sur Way Name",
         "id": "Lanjutkan agak ke kanan menuju Way Name",
         "it": "Continua a destra leggermente in Way Name",

--- a/test/fixtures/v5/notification/slight_right_exit_destination.json
+++ b/test/fixtures/v5/notification/slight_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Leicht rechts weiterfahren Richtung Destination 1",
         "en": "Continue slight right towards Destination 1",
         "es": "Continúe ligeramente a la derecha hacia Destination 1",
+        "es-ES": "Continúa ligeramente a la derecha hacia Destination 1",
         "fr": "Continuer légèrement à droite en direction de Destination 1",
         "id": "Lanjutkan agak ke kanan menuju Destination 1",
         "it": "Continua a destra leggermente verso Destination 1",

--- a/test/fixtures/v5/notification/slight_right_name.json
+++ b/test/fixtures/v5/notification/slight_right_name.json
@@ -10,6 +10,7 @@
         "de": "Leicht rechts weiterfahren auf Way Name",
         "en": "Continue slight right onto Way Name",
         "es": "Continúe ligeramente a la derecha en Way Name",
+        "es-ES": "Continúa ligeramente a la derecha por Way Name",
         "fr": "Continuer légèrement à droite sur Way Name",
         "id": "Lanjutkan agak ke kanan menuju Way Name",
         "it": "Continua a destra leggermente in Way Name",

--- a/test/fixtures/v5/notification/straight_default.json
+++ b/test/fixtures/v5/notification/straight_default.json
@@ -10,6 +10,7 @@
         "de": "Geradeaus weiterfahren",
         "en": "Continue straight",
         "es": "Continúe recto",
+        "es-ES": "Continúa recto",
         "fr": "Continuer tout droit",
         "id": "Lanjutkan lurus",
         "it": "Continua a dritto",

--- a/test/fixtures/v5/notification/straight_destination.json
+++ b/test/fixtures/v5/notification/straight_destination.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus weiterfahren Richtung Destination 1",
         "en": "Continue straight towards Destination 1",
         "es": "Continúe recto hacia Destination 1",
+        "es-ES": "Continúa recto hacia Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "id": "Lanjutkan lurus menuju Destination 1",
         "it": "Continua a dritto verso Destination 1",

--- a/test/fixtures/v5/notification/straight_exit.json
+++ b/test/fixtures/v5/notification/straight_exit.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus weiterfahren auf Way Name",
         "en": "Continue straight onto Way Name",
         "es": "Continúe recto en Way Name",
+        "es-ES": "Continúa recto por Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "id": "Lanjutkan lurus menuju Way Name",
         "it": "Continua a dritto in Way Name",

--- a/test/fixtures/v5/notification/straight_exit_destination.json
+++ b/test/fixtures/v5/notification/straight_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Geradeaus weiterfahren Richtung Destination 1",
         "en": "Continue straight towards Destination 1",
         "es": "Continúe recto hacia Destination 1",
+        "es-ES": "Continúa recto hacia Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "id": "Lanjutkan lurus menuju Destination 1",
         "it": "Continua a dritto verso Destination 1",

--- a/test/fixtures/v5/notification/straight_name.json
+++ b/test/fixtures/v5/notification/straight_name.json
@@ -10,6 +10,7 @@
         "de": "Geradeaus weiterfahren auf Way Name",
         "en": "Continue straight onto Way Name",
         "es": "Continúe recto en Way Name",
+        "es-ES": "Continúa recto por Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "id": "Lanjutkan lurus menuju Way Name",
         "it": "Continua a dritto in Way Name",

--- a/test/fixtures/v5/notification/uturn_default.json
+++ b/test/fixtures/v5/notification/uturn_default.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung",
         "en": "Make a U-turn",
         "es": "Haz un cambio de sentido",
+        "es-ES": "Haz un cambio de sentido",
         "fr": "Faire demi-tour",
         "id": "Putar balik",
         "it": "Fai un'inversione a U",

--- a/test/fixtures/v5/notification/uturn_destination.json
+++ b/test/fixtures/v5/notification/uturn_destination.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
+        "es-ES": "Haz un cambio de sentido hacia Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "id": "Putar balik menuju Destination 1",
         "it": "Fai un'inversione a U verso Destination 1",

--- a/test/fixtures/v5/notification/uturn_exit.json
+++ b/test/fixtures/v5/notification/uturn_exit.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung auf Way Name",
         "en": "Make a U-turn onto Way Name",
         "es": "Haz un cambio de sentido en Way Name",
+        "es-ES": "Haz un cambio de sentido en Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "id": "Putar balik ke arah Way Name",
         "it": "Fai un'inversione a U in Way Name",

--- a/test/fixtures/v5/notification/uturn_exit_destination.json
+++ b/test/fixtures/v5/notification/uturn_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "180°-Wendung Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
+        "es-ES": "Haz un cambio de sentido hacia Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "id": "Putar balik menuju Destination 1",
         "it": "Fai un'inversione a U verso Destination 1",

--- a/test/fixtures/v5/notification/uturn_name.json
+++ b/test/fixtures/v5/notification/uturn_name.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung auf Way Name",
         "en": "Make a U-turn onto Way Name",
         "es": "Haz un cambio de sentido en Way Name",
+        "es-ES": "Haz un cambio de sentido en Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "id": "Putar balik ke arah Way Name",
         "it": "Fai un'inversione a U in Way Name",

--- a/test/fixtures/v5/off_ramp/left_default.json
+++ b/test/fixtures/v5/off_ramp/left_default.json
@@ -10,6 +10,7 @@
         "de": "Ausfahrt links nehmen",
         "en": "Take the ramp on the left",
         "es": "Tome la salida en la izquierda",
+        "es-ES": "Coge la cuesta abajo de la izquierda",
         "fr": "Prendre la sortie à gauche",
         "id": "Ambil jalan yang melandai di sebelah kiri",
         "it": "Prendi la rampa a sinistra",

--- a/test/fixtures/v5/off_ramp/left_destination.json
+++ b/test/fixtures/v5/off_ramp/left_destination.json
@@ -11,6 +11,7 @@
         "de": "Ausfahrt links nehmen Richtung Destination 1",
         "en": "Take the ramp on the left towards Destination 1",
         "es": "Tome la salida en la izquierda en Destination 1",
+        "es-ES": "Coge la cuesta abajo de la izquierda hacia Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",

--- a/test/fixtures/v5/off_ramp/left_exit.json
+++ b/test/fixtures/v5/off_ramp/left_exit.json
@@ -11,6 +11,7 @@
         "de": "Ausfahrt 4A links nehmen",
         "en": "Take exit 4A on the left",
         "es": "Tome la salida 4A en la izquierda",
+        "es-ES": "Coge la cuesta abajo 4A a tu izquierda",
         "fr": "Take exit 4A on the left",
         "id": "Take exit 4A on the left",
         "it": "Prendi l'uscita 4A a sinistra",

--- a/test/fixtures/v5/off_ramp/left_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Ausfahrt 4A links nehmen Richtung Destination 1",
         "en": "Take exit 4A on the left towards Destination 1",
         "es": "Tome la salida 4A en la izquierda hacia Destination 1",
+        "es-ES": "Coge la cuesta abajo 4A a tu izquierda hacia Destination 1",
         "fr": "Take exit 4A on the left towards Destination 1",
         "id": "Take exit 4A on the left towards Destination 1",
         "it": "Prendi la 4A uscita a sinistra verso Destination 1",

--- a/test/fixtures/v5/off_ramp/left_name.json
+++ b/test/fixtures/v5/off_ramp/left_name.json
@@ -10,6 +10,7 @@
         "de": "Ausfahrt links nehmen auf Way Name",
         "en": "Take the ramp on the left onto Way Name",
         "es": "Tome la salida en la izquierda en Way Name",
+        "es-ES": "Coge la cuesta abajo de la izquierda por Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",

--- a/test/fixtures/v5/off_ramp/right_default.json
+++ b/test/fixtures/v5/off_ramp/right_default.json
@@ -10,6 +10,7 @@
         "de": "Ausfahrt rechts nehmen",
         "en": "Take the ramp on the right",
         "es": "Tome la salida en la derecha",
+        "es-ES": "Coge la cuesta abajo de la derecha",
         "fr": "Prendre la sortie à droite",
         "id": "Ambil jalan melandai di sebelah kanan",
         "it": "Prendi la rampa a destra",

--- a/test/fixtures/v5/off_ramp/right_destination.json
+++ b/test/fixtures/v5/off_ramp/right_destination.json
@@ -11,6 +11,7 @@
         "de": "Ausfahrt rechts nehmen Richtung Destination 1",
         "en": "Take the ramp on the right towards Destination 1",
         "es": "Tome la salida en la derecha hacia Destination 1",
+        "es-ES": "Coge la cuesta abajo de la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
         "it": "Prendi la rampa a destra verso Destination 1",

--- a/test/fixtures/v5/off_ramp/right_exit.json
+++ b/test/fixtures/v5/off_ramp/right_exit.json
@@ -11,6 +11,7 @@
         "de": "Ausfahrt 4A rechts nehmen",
         "en": "Take exit 4A on the right",
         "es": "Tome la salida 4A en la derecha",
+        "es-ES": "Coge la cuesta abajo 4A",
         "fr": "Take exit 4A on the right",
         "id": "Take exit 4A on the right",
         "it": "Prendi la 4A uscita a destra",

--- a/test/fixtures/v5/off_ramp/right_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Ausfahrt 4A nehmen Richtung Destination 1",
         "en": "Take exit 4A on the right towards Destination 1",
         "es": "Tome la salida 4A en la derecha hacia Destination 1",
+        "es-ES": "Coge la cuesta abajo 4A hacia Destination 1",
         "fr": "Take exit 4A on the right towards Destination 1",
         "id": "Take exit 4A on the right towards Destination 1",
         "it": "Prendi la 4A uscita a destra verso Destination 1",

--- a/test/fixtures/v5/off_ramp/right_name.json
+++ b/test/fixtures/v5/off_ramp/right_name.json
@@ -10,6 +10,7 @@
         "de": "Ausfahrt rechts nehmen Richtung Way Name",
         "en": "Take the ramp on the right onto Way Name",
         "es": "Tome la salida en la derecha en Way Name",
+        "es-ES": "Coge la cuesta abajo de la derecha por Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
         "it": "Prendi la rampa a destra in Way Name",

--- a/test/fixtures/v5/off_ramp/sharp_left_default.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_default.json
@@ -10,6 +10,7 @@
         "de": "Ausfahrt links nehmen",
         "en": "Take the ramp on the left",
         "es": "Ve cuesta abajo en la izquierda",
+        "es-ES": "Coge la cuesta abajo de la izquierda",
         "fr": "Prendre la sortie à gauche",
         "id": "Ambil jalan yang melandai di sebelah kiri",
         "it": "Prendi la rampa a sinistra",

--- a/test/fixtures/v5/off_ramp/sharp_left_destination.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Ausfahrt links nehmen Richtung Destination 1",
         "en": "Take the ramp on the left towards Destination 1",
         "es": "Ve cuesta abajo en la izquierda hacia Destination 1",
+        "es-ES": "Coge la cuesta abajo de la izquierda hacia Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",

--- a/test/fixtures/v5/off_ramp/sharp_left_exit.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Ausfahrt 4A links nehmen",
         "en": "Take exit 4A on the left",
         "es": "Tome la salida 4A en la izquierda",
+        "es-ES": "Coge la cuesta abajo 4A a tu izquierda",
         "fr": "Take exit 4A on the left",
         "id": "Take exit 4A on the left",
         "it": "Prendi l'uscita 4A a sinistra",

--- a/test/fixtures/v5/off_ramp/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Ausfahrt4A links nehmen Richtung Destination 1",
         "en": "Take exit 4A on the left towards Destination 1",
         "es": "Tome la salida 4A en la izquierda hacia Destination 1",
+        "es-ES": "Coge la cuesta abajo 4A a tu izquierda hacia Destination 1",
         "fr": "Take exit 4A on the left towards Destination 1",
         "id": "Take exit 4A on the left towards Destination 1",
         "it": "Prendi la 4A uscita a sinistra verso Destination 1",

--- a/test/fixtures/v5/off_ramp/sharp_left_name.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_name.json
@@ -10,6 +10,7 @@
         "de": "Ausfahrt links Seite nehmen auf Way Name",
         "en": "Take the ramp on the left onto Way Name",
         "es": "Ve cuesta abajo en la izquierda en Way Name",
+        "es-ES": "Coge la cuesta abajo de la izquierda por Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",

--- a/test/fixtures/v5/off_ramp/sharp_right_default.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_default.json
@@ -10,6 +10,7 @@
         "de": "Ausfahrt rechts nehmen",
         "en": "Take the ramp on the right",
         "es": "Ve cuesta abajo en la derecha",
+        "es-ES": "Coge la cuesta abajo de la derecha",
         "fr": "Prendre la sortie à droite",
         "id": "Ambil jalan melandai di sebelah kanan",
         "it": "Prendi la rampa a destra",

--- a/test/fixtures/v5/off_ramp/sharp_right_destination.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Ausfahrt rechts nehmen Richtung Destination 1",
         "en": "Take the ramp on the right towards Destination 1",
         "es": "Ve cuesta abajo en la derecha hacia Destination 1",
+        "es-ES": "Coge la cuesta abajo de la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
         "it": "Prendi la rampa a destra verso Destination 1",

--- a/test/fixtures/v5/off_ramp/sharp_right_exit.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Ausfahrt 4A rechts nehmen",
         "en": "Take exit 4A on the right",
         "es": "Tome la salida 4A en la derecha",
+        "es-ES": "Coge la cuesta abajo 4A",
         "fr": "Take exit 4A on the right",
         "id": "Take exit 4A on the right",
         "it": "Prendi la 4A uscita a destra",

--- a/test/fixtures/v5/off_ramp/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Ausfahrt 4A nehmen Richtung Destination 1",
         "en": "Take exit 4A on the right towards Destination 1",
         "es": "Tome la salida 4A en la derecha hacia Destination 1",
+        "es-ES": "Coge la cuesta abajo 4A hacia Destination 1",
         "fr": "Take exit 4A on the right towards Destination 1",
         "id": "Take exit 4A on the right towards Destination 1",
         "it": "Prendi la 4A uscita a destra verso Destination 1",

--- a/test/fixtures/v5/off_ramp/sharp_right_name.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_name.json
@@ -10,6 +10,7 @@
         "de": "Ausfahrt rechts nehmen auf Way Name",
         "en": "Take the ramp on the right onto Way Name",
         "es": "Ve cuesta abajo en la derecha en Way Name",
+        "es-ES": "Coge la cuesta abajo de la derecha por Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
         "it": "Prendi la rampa a destra in Way Name",

--- a/test/fixtures/v5/off_ramp/slight_left_default.json
+++ b/test/fixtures/v5/off_ramp/slight_left_default.json
@@ -10,6 +10,7 @@
         "de": "Ausfahrt links nehmen",
         "en": "Take the ramp on the left",
         "es": "Ve cuesta abajo en la izquierda",
+        "es-ES": "Coge la cuesta abajo de la izquierda",
         "fr": "Prendre la sortie à gauche",
         "id": "Ambil jalan yang melandai di sebelah kiri",
         "it": "Prendi la rampa a sinistra",

--- a/test/fixtures/v5/off_ramp/slight_left_destination.json
+++ b/test/fixtures/v5/off_ramp/slight_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Ausfahrt links nehmen Richtung Destination 1",
         "en": "Take the ramp on the left towards Destination 1",
         "es": "Ve cuesta abajo en la izquierda hacia Destination 1",
+        "es-ES": "Coge la cuesta abajo de la izquierda hacia Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",

--- a/test/fixtures/v5/off_ramp/slight_left_exit.json
+++ b/test/fixtures/v5/off_ramp/slight_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Ausfahrt 4A nehmen",
         "en": "Take exit 4A on the left",
         "es": "Tome la salida 4A en la izquierda",
+        "es-ES": "Coge la cuesta abajo 4A a tu izquierda",
         "fr": "Take exit 4A on the left",
         "id": "Take exit 4A on the left",
         "it": "Prendi l'uscita 4A a sinistra",

--- a/test/fixtures/v5/off_ramp/slight_left_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/slight_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Ausfahrt 4A links nehmen Richtung Destination 1",
         "en": "Take exit 4A on the left towards Destination 1",
         "es": "Tome la salida 4A en la izquierda hacia Destination 1",
+        "es-ES": "Coge la cuesta abajo 4A a tu izquierda hacia Destination 1",
         "fr": "Take exit 4A on the left towards Destination 1",
         "id": "Take exit 4A on the left towards Destination 1",
         "it": "Prendi la 4A uscita a sinistra verso Destination 1",

--- a/test/fixtures/v5/off_ramp/slight_left_name.json
+++ b/test/fixtures/v5/off_ramp/slight_left_name.json
@@ -10,6 +10,7 @@
         "de": "Ausfahrt links nehmen auf Way Name",
         "en": "Take the ramp on the left onto Way Name",
         "es": "Ve cuesta abajo en la izquierda en Way Name",
+        "es-ES": "Coge la cuesta abajo de la izquierda por Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",

--- a/test/fixtures/v5/off_ramp/slight_right_default.json
+++ b/test/fixtures/v5/off_ramp/slight_right_default.json
@@ -10,6 +10,7 @@
         "de": "Ausfahrt rechts nehmen",
         "en": "Take the ramp on the right",
         "es": "Tome la salida en la derecha",
+        "es-ES": "Coge la cuesta abajo de la derecha",
         "fr": "Prendre la sortie à droite",
         "id": "Ambil jalan melandai di sebelah kanan",
         "it": "Prendi la rampa a destra",

--- a/test/fixtures/v5/off_ramp/slight_right_destination.json
+++ b/test/fixtures/v5/off_ramp/slight_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Ausfahrt rechts nehmen Richtung Destination 1",
         "en": "Take the ramp on the right towards Destination 1",
         "es": "Tome la salida en la derecha hacia Destination 1",
+        "es-ES": "Coge la cuesta abajo de la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
         "it": "Prendi la rampa a destra verso Destination 1",

--- a/test/fixtures/v5/off_ramp/slight_right_exit.json
+++ b/test/fixtures/v5/off_ramp/slight_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Ausfahrt 4A rechts nehmen",
         "en": "Take exit 4A on the right",
         "es": "Tome la salida 4A en la derecha",
+        "es-ES": "Coge la cuesta abajo 4A",
         "fr": "Take exit 4A on the right",
         "id": "Take exit 4A on the right",
         "it": "Prendi la 4A uscita a destra",

--- a/test/fixtures/v5/off_ramp/slight_right_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/slight_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Ausfahrt 4A nehmen Richtung Destination 1",
         "en": "Take exit 4A on the right towards Destination 1",
         "es": "Tome la salida 4A en la derecha hacia Destination 1",
+        "es-ES": "Coge la cuesta abajo 4A hacia Destination 1",
         "fr": "Take exit 4A on the right towards Destination 1",
         "id": "Take exit 4A on the right towards Destination 1",
         "it": "Prendi la 4A uscita a destra verso Destination 1",

--- a/test/fixtures/v5/off_ramp/slight_right_name.json
+++ b/test/fixtures/v5/off_ramp/slight_right_name.json
@@ -10,6 +10,7 @@
         "de": "Ausfahrt rechts nehmen auf Way Name",
         "en": "Take the ramp on the right onto Way Name",
         "es": "Tome la salida en la derecha en Way Name",
+        "es-ES": "Coge la cuesta abajo de la derecha por Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
         "it": "Prendi la rampa a destra in Way Name",

--- a/test/fixtures/v5/off_ramp/straight_default.json
+++ b/test/fixtures/v5/off_ramp/straight_default.json
@@ -10,6 +10,7 @@
         "de": "Ausfahrt nehmen",
         "en": "Take the ramp",
         "es": "Tome la salida",
+        "es-ES": "Coge la cuesta abajo",
         "fr": "Prendre la sortie",
         "id": "Ambil jalan melandai",
         "it": "Prendi la rampa",

--- a/test/fixtures/v5/off_ramp/straight_destination.json
+++ b/test/fixtures/v5/off_ramp/straight_destination.json
@@ -11,6 +11,7 @@
         "de": "Ausfahrt nehmen Richtung Destination 1",
         "en": "Take the ramp towards Destination 1",
         "es": "Tome la salida hacia Destination 1",
+        "es-ES": "Coge la cuesta abajo hacia Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "id": "Ambil jalan melandai menuju Destination 1",
         "it": "Prendi la rampa verso Destination 1",

--- a/test/fixtures/v5/off_ramp/straight_exit.json
+++ b/test/fixtures/v5/off_ramp/straight_exit.json
@@ -11,6 +11,7 @@
         "de": "Ausfahrt 4A nehmen",
         "en": "Take exit 4A",
         "es": "Tome la salida 4A",
+        "es-ES": "Coge la cuesta abajo 4A",
         "fr": "Take exit 4A",
         "id": "Take exit 4A",
         "it": "Prendi l'uscita 4A",

--- a/test/fixtures/v5/off_ramp/straight_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/straight_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Ausfahrt 4A nehmen Richtung Destination 1",
         "en": "Take exit 4A towards Destination 1",
         "es": "Tome la salida 4A hacia Destination 1",
+        "es-ES": "Coge la cuesta abajo 4A hacia Destination 1",
         "fr": "Take exit 4A towards Destination 1",
         "id": "Take exit 4A towards Destination 1",
         "it": "Prendi l'uscita 4A verso Destination 1",

--- a/test/fixtures/v5/off_ramp/straight_name.json
+++ b/test/fixtures/v5/off_ramp/straight_name.json
@@ -10,6 +10,7 @@
         "de": "Ausfahrt nehmen auf Way Name",
         "en": "Take the ramp onto Way Name",
         "es": "Tome la salida en Way Name",
+        "es-ES": "Coge la cuesta abajo por Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "id": "Ambil jalan melandai ke Way Name",
         "it": "Prendi la rampa in Way Name",

--- a/test/fixtures/v5/off_ramp/uturn_default.json
+++ b/test/fixtures/v5/off_ramp/uturn_default.json
@@ -10,6 +10,7 @@
         "de": "Ausfahrt nehmen",
         "en": "Take the ramp",
         "es": "Tome la salida",
+        "es-ES": "Coge la cuesta abajo",
         "fr": "Prendre la sortie",
         "id": "Ambil jalan melandai",
         "it": "Prendi la rampa",

--- a/test/fixtures/v5/off_ramp/uturn_destination.json
+++ b/test/fixtures/v5/off_ramp/uturn_destination.json
@@ -11,6 +11,7 @@
         "de": "Ausfahrt nehmen Richtung Destination 1",
         "en": "Take the ramp towards Destination 1",
         "es": "Tome la salida hacia Destination 1",
+        "es-ES": "Coge la cuesta abajo hacia Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "id": "Ambil jalan melandai menuju Destination 1",
         "it": "Prendi la rampa verso Destination 1",

--- a/test/fixtures/v5/off_ramp/uturn_exit.json
+++ b/test/fixtures/v5/off_ramp/uturn_exit.json
@@ -11,6 +11,7 @@
         "de": "Ausfahrt 4A nehmen",
         "en": "Take exit 4A",
         "es": "Tome la salida 4A",
+        "es-ES": "Coge la cuesta abajo 4A",
         "fr": "Take exit 4A",
         "id": "Take exit 4A",
         "it": "Prendi l'uscita 4A",

--- a/test/fixtures/v5/off_ramp/uturn_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/uturn_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Ausfahrt 4A nehmen Richtung Destination 1",
         "en": "Take exit 4A towards Destination 1",
         "es": "Tome la salida 4A hacia Destination 1",
+        "es-ES": "Coge la cuesta abajo 4A hacia Destination 1",
         "fr": "Take exit 4A towards Destination 1",
         "id": "Take exit 4A towards Destination 1",
         "it": "Prendi l'uscita 4A verso Destination 1",

--- a/test/fixtures/v5/off_ramp/uturn_name.json
+++ b/test/fixtures/v5/off_ramp/uturn_name.json
@@ -10,6 +10,7 @@
         "de": "Ausfahrt nehmen auf Way Name",
         "en": "Take the ramp onto Way Name",
         "es": "Tome la salida en Way Name",
+        "es-ES": "Coge la cuesta abajo por Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "id": "Ambil jalan melandai ke Way Name",
         "it": "Prendi la rampa in Way Name",

--- a/test/fixtures/v5/on_ramp/left_default.json
+++ b/test/fixtures/v5/on_ramp/left_default.json
@@ -10,6 +10,7 @@
         "de": "Auffahrt links nehmen",
         "en": "Take the ramp on the left",
         "es": "Tome la rampa en la izquierda",
+        "es-ES": "Coge la cuesta de la izquierda",
         "fr": "Prendre la sortie à gauche",
         "id": "Ambil jalan yang melandai di sebelah kiri",
         "it": "Prendi la rampa a sinistra",

--- a/test/fixtures/v5/on_ramp/left_destination.json
+++ b/test/fixtures/v5/on_ramp/left_destination.json
@@ -11,6 +11,7 @@
         "de": "Auffahrt links nehmen Richtung Destination 1",
         "en": "Take the ramp on the left towards Destination 1",
         "es": "Tome la rampa en la izquierda hacia Destination 1",
+        "es-ES": "Coge la cuesta de la izquierda hacia Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",

--- a/test/fixtures/v5/on_ramp/left_exit.json
+++ b/test/fixtures/v5/on_ramp/left_exit.json
@@ -11,6 +11,7 @@
         "de": "Auffahrt links nehmen auf Way Name",
         "en": "Take the ramp on the left onto Way Name",
         "es": "Tome la rampa en la izquierda en Way Name",
+        "es-ES": "Coge la cuesta de la izquierda por Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",

--- a/test/fixtures/v5/on_ramp/left_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Auffahrt links nehmen Richtung Destination 1",
         "en": "Take the ramp on the left towards Destination 1",
         "es": "Tome la rampa en la izquierda hacia Destination 1",
+        "es-ES": "Coge la cuesta de la izquierda hacia Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",

--- a/test/fixtures/v5/on_ramp/left_name.json
+++ b/test/fixtures/v5/on_ramp/left_name.json
@@ -10,6 +10,7 @@
         "de": "Auffahrt links nehmen auf Way Name",
         "en": "Take the ramp on the left onto Way Name",
         "es": "Tome la rampa en la izquierda en Way Name",
+        "es-ES": "Coge la cuesta de la izquierda por Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",

--- a/test/fixtures/v5/on_ramp/right_default.json
+++ b/test/fixtures/v5/on_ramp/right_default.json
@@ -10,6 +10,7 @@
         "de": "Auffahrt rechts nehmen",
         "en": "Take the ramp on the right",
         "es": "Tome la rampa en la derecha",
+        "es-ES": "Coge la cuesta de la derecha",
         "fr": "Prendre la sortie à droite",
         "id": "Ambil jalan melandai di sebelah kanan",
         "it": "Prendi la rampa a destra",

--- a/test/fixtures/v5/on_ramp/right_destination.json
+++ b/test/fixtures/v5/on_ramp/right_destination.json
@@ -11,6 +11,7 @@
         "de": "Auffahrt rechts nehmen Richtung Destination 1",
         "en": "Take the ramp on the right towards Destination 1",
         "es": "Tome la rampa en la derecha hacia Destination 1",
+        "es-ES": "Coge la cuesta de la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
         "it": "Prendi la rampa a destra verso Destination 1",

--- a/test/fixtures/v5/on_ramp/right_exit.json
+++ b/test/fixtures/v5/on_ramp/right_exit.json
@@ -11,6 +11,7 @@
         "de": "Auffahrt rechts nehmen auf Way Name",
         "en": "Take the ramp on the right onto Way Name",
         "es": "Tome la rampa en la derecha en Way Name",
+        "es-ES": "Coge la cuesta de la derecha por Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
         "it": "Prendi la rampa a destra in Way Name",

--- a/test/fixtures/v5/on_ramp/right_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Auffahrt rechts nehmen Richtung Destination 1",
         "en": "Take the ramp on the right towards Destination 1",
         "es": "Tome la rampa en la derecha hacia Destination 1",
+        "es-ES": "Coge la cuesta de la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
         "it": "Prendi la rampa a destra verso Destination 1",

--- a/test/fixtures/v5/on_ramp/right_name.json
+++ b/test/fixtures/v5/on_ramp/right_name.json
@@ -10,6 +10,7 @@
         "de": "Auffahrt rechts nehmen auf Way Name",
         "en": "Take the ramp on the right onto Way Name",
         "es": "Tome la rampa en la derecha en Way Name",
+        "es-ES": "Coge la cuesta de la derecha por Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
         "it": "Prendi la rampa a destra in Way Name",

--- a/test/fixtures/v5/on_ramp/sharp_left_default.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_default.json
@@ -10,6 +10,7 @@
         "de": "Auffahrt links nehmen",
         "en": "Take the ramp on the left",
         "es": "Tome la rampa en la izquierda",
+        "es-ES": "Coge la cuesta de la izquierda",
         "fr": "Prendre la sortie à gauche",
         "id": "Ambil jalan yang melandai di sebelah kiri",
         "it": "Prendi la rampa a sinistra",

--- a/test/fixtures/v5/on_ramp/sharp_left_destination.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Auffahrt links nehmen Richtung Destination 1",
         "en": "Take the ramp on the left towards Destination 1",
         "es": "Tome la rampa en la izquierda hacia Destination 1",
+        "es-ES": "Coge la cuesta de la izquierda hacia Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",

--- a/test/fixtures/v5/on_ramp/sharp_left_exit.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Auffahrt links nehmen auf Way Name",
         "en": "Take the ramp on the left onto Way Name",
         "es": "Tome la rampa en la izquierda en Way Name",
+        "es-ES": "Coge la cuesta de la izquierda por Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",

--- a/test/fixtures/v5/on_ramp/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Auffahrt links nehmen Richtung Destination 1",
         "en": "Take the ramp on the left towards Destination 1",
         "es": "Tome la rampa en la izquierda hacia Destination 1",
+        "es-ES": "Coge la cuesta de la izquierda hacia Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",

--- a/test/fixtures/v5/on_ramp/sharp_left_name.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_name.json
@@ -10,6 +10,7 @@
         "de": "Auffahrt links nehmen auf Way Name",
         "en": "Take the ramp on the left onto Way Name",
         "es": "Tome la rampa en la izquierda en Way Name",
+        "es-ES": "Coge la cuesta de la izquierda por Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",

--- a/test/fixtures/v5/on_ramp/sharp_right_default.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_default.json
@@ -10,6 +10,7 @@
         "de": "Auffahrt rechts nehmen",
         "en": "Take the ramp on the right",
         "es": "Tome la rampa en la derecha",
+        "es-ES": "Coge la cuesta de la derecha",
         "fr": "Prendre la sortie à droite",
         "id": "Ambil jalan melandai di sebelah kanan",
         "it": "Prendi la rampa a destra",

--- a/test/fixtures/v5/on_ramp/sharp_right_destination.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Auffahrt rechts nehmen Richtung Destination 1",
         "en": "Take the ramp on the right towards Destination 1",
         "es": "Tome la rampa en la derecha hacia Destination 1",
+        "es-ES": "Coge la cuesta de la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
         "it": "Prendi la rampa a destra verso Destination 1",

--- a/test/fixtures/v5/on_ramp/sharp_right_exit.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Auffahrt rechts nehmen auf Way Name",
         "en": "Take the ramp on the right onto Way Name",
         "es": "Tome la rampa en la derecha en Way Name",
+        "es-ES": "Coge la cuesta de la derecha por Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
         "it": "Prendi la rampa a destra in Way Name",

--- a/test/fixtures/v5/on_ramp/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Auffahrt rechts nehmen Richtung Destination 1",
         "en": "Take the ramp on the right towards Destination 1",
         "es": "Tome la rampa en la derecha hacia Destination 1",
+        "es-ES": "Coge la cuesta de la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
         "it": "Prendi la rampa a destra verso Destination 1",

--- a/test/fixtures/v5/on_ramp/sharp_right_name.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_name.json
@@ -10,6 +10,7 @@
         "de": "Auffahrt rechts nehmen auf Way Name",
         "en": "Take the ramp on the right onto Way Name",
         "es": "Tome la rampa en la derecha en Way Name",
+        "es-ES": "Coge la cuesta de la derecha por Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
         "it": "Prendi la rampa a destra in Way Name",

--- a/test/fixtures/v5/on_ramp/slight_left_default.json
+++ b/test/fixtures/v5/on_ramp/slight_left_default.json
@@ -10,6 +10,7 @@
         "de": "Auffahrt links Seite nehmen",
         "en": "Take the ramp on the left",
         "es": "Tome la rampa en la izquierda",
+        "es-ES": "Coge la cuesta de la izquierda",
         "fr": "Prendre la sortie à gauche",
         "id": "Ambil jalan yang melandai di sebelah kiri",
         "it": "Prendi la rampa a sinistra",

--- a/test/fixtures/v5/on_ramp/slight_left_destination.json
+++ b/test/fixtures/v5/on_ramp/slight_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Auffahrt links nehmen Richtung Destination 1",
         "en": "Take the ramp on the left towards Destination 1",
         "es": "Tome la rampa en la izquierda hacia Destination 1",
+        "es-ES": "Coge la cuesta de la izquierda hacia Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",

--- a/test/fixtures/v5/on_ramp/slight_left_exit.json
+++ b/test/fixtures/v5/on_ramp/slight_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Auffahrt links nehmen auf Way Name",
         "en": "Take the ramp on the left onto Way Name",
         "es": "Tome la rampa en la izquierda en Way Name",
+        "es-ES": "Coge la cuesta de la izquierda por Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",

--- a/test/fixtures/v5/on_ramp/slight_left_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/slight_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Auffahrt links nehmen Richtung Destination 1",
         "en": "Take the ramp on the left towards Destination 1",
         "es": "Tome la rampa en la izquierda hacia Destination 1",
+        "es-ES": "Coge la cuesta de la izquierda hacia Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",

--- a/test/fixtures/v5/on_ramp/slight_left_name.json
+++ b/test/fixtures/v5/on_ramp/slight_left_name.json
@@ -10,6 +10,7 @@
         "de": "Auffahrt links nehmen auf Way Name",
         "en": "Take the ramp on the left onto Way Name",
         "es": "Tome la rampa en la izquierda en Way Name",
+        "es-ES": "Coge la cuesta de la izquierda por Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",

--- a/test/fixtures/v5/on_ramp/slight_right_default.json
+++ b/test/fixtures/v5/on_ramp/slight_right_default.json
@@ -10,6 +10,7 @@
         "de": "Auffahrt rechts nehmen",
         "en": "Take the ramp on the right",
         "es": "Tome la rampa en la derecha",
+        "es-ES": "Coge la cuesta de la derecha",
         "fr": "Prendre la sortie à droite",
         "id": "Ambil jalan melandai di sebelah kanan",
         "it": "Prendi la rampa a destra",

--- a/test/fixtures/v5/on_ramp/slight_right_destination.json
+++ b/test/fixtures/v5/on_ramp/slight_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Auffahrt rechts nehmen Richtung Destination 1",
         "en": "Take the ramp on the right towards Destination 1",
         "es": "Tome la rampa en la derecha hacia Destination 1",
+        "es-ES": "Coge la cuesta de la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
         "it": "Prendi la rampa a destra verso Destination 1",

--- a/test/fixtures/v5/on_ramp/slight_right_exit.json
+++ b/test/fixtures/v5/on_ramp/slight_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Auffahrt rechts nehmen auf Way Name",
         "en": "Take the ramp on the right onto Way Name",
         "es": "Tome la rampa en la derecha en Way Name",
+        "es-ES": "Coge la cuesta de la derecha por Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
         "it": "Prendi la rampa a destra in Way Name",

--- a/test/fixtures/v5/on_ramp/slight_right_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/slight_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Auffahrt rechts nehmen Richtung Destination 1",
         "en": "Take the ramp on the right towards Destination 1",
         "es": "Tome la rampa en la derecha hacia Destination 1",
+        "es-ES": "Coge la cuesta de la derecha hacia Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
         "it": "Prendi la rampa a destra verso Destination 1",

--- a/test/fixtures/v5/on_ramp/slight_right_name.json
+++ b/test/fixtures/v5/on_ramp/slight_right_name.json
@@ -10,6 +10,7 @@
         "de": "Auffahrt rechts nehmen auf Way Name",
         "en": "Take the ramp on the right onto Way Name",
         "es": "Tome la rampa en la derecha en Way Name",
+        "es-ES": "Coge la cuesta de la derecha por Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
         "it": "Prendi la rampa a destra in Way Name",

--- a/test/fixtures/v5/on_ramp/straight_default.json
+++ b/test/fixtures/v5/on_ramp/straight_default.json
@@ -10,6 +10,7 @@
         "de": "Auffahrt nehmen",
         "en": "Take the ramp",
         "es": "Tome la rampa",
+        "es-ES": "Coge la cuesta",
         "fr": "Prendre la sortie",
         "id": "Ambil jalan melandai",
         "it": "Prendi la rampa",

--- a/test/fixtures/v5/on_ramp/straight_destination.json
+++ b/test/fixtures/v5/on_ramp/straight_destination.json
@@ -11,6 +11,7 @@
         "de": "Auffahrt nehmen Richtung Destination 1",
         "en": "Take the ramp towards Destination 1",
         "es": "Tome la rampa hacia Destination 1",
+        "es-ES": "Coge la cuesta hacia Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "id": "Ambil jalan melandai menuju Destination 1",
         "it": "Prendi la rampa verso Destination 1",

--- a/test/fixtures/v5/on_ramp/straight_exit.json
+++ b/test/fixtures/v5/on_ramp/straight_exit.json
@@ -11,6 +11,7 @@
         "de": "Auffahrt nehmen auf Way Name",
         "en": "Take the ramp onto Way Name",
         "es": "Tome la rampa en Way Name",
+        "es-ES": "Coge la cuesta por Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "id": "Ambil jalan melandai ke Way Name",
         "it": "Prendi la rampa in Way Name",

--- a/test/fixtures/v5/on_ramp/straight_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/straight_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Auffahrt nehmen Richtung Destination 1",
         "en": "Take the ramp towards Destination 1",
         "es": "Tome la rampa hacia Destination 1",
+        "es-ES": "Coge la cuesta hacia Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "id": "Ambil jalan melandai menuju Destination 1",
         "it": "Prendi la rampa verso Destination 1",

--- a/test/fixtures/v5/on_ramp/straight_name.json
+++ b/test/fixtures/v5/on_ramp/straight_name.json
@@ -10,6 +10,7 @@
         "de": "Auffahrt nehmen auf Way Name",
         "en": "Take the ramp onto Way Name",
         "es": "Tome la rampa en Way Name",
+        "es-ES": "Coge la cuesta por Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "id": "Ambil jalan melandai ke Way Name",
         "it": "Prendi la rampa in Way Name",

--- a/test/fixtures/v5/on_ramp/uturn_default.json
+++ b/test/fixtures/v5/on_ramp/uturn_default.json
@@ -10,6 +10,7 @@
         "de": "Auffahrt nehmen",
         "en": "Take the ramp",
         "es": "Tome la rampa",
+        "es-ES": "Coge la cuesta",
         "fr": "Prendre la sortie",
         "id": "Ambil jalan melandai",
         "it": "Prendi la rampa",

--- a/test/fixtures/v5/on_ramp/uturn_destination.json
+++ b/test/fixtures/v5/on_ramp/uturn_destination.json
@@ -11,6 +11,7 @@
         "de": "Auffahrt nehmen Richtung Destination 1",
         "en": "Take the ramp towards Destination 1",
         "es": "Tome la rampa hacia Destination 1",
+        "es-ES": "Coge la cuesta hacia Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "id": "Ambil jalan melandai menuju Destination 1",
         "it": "Prendi la rampa verso Destination 1",

--- a/test/fixtures/v5/on_ramp/uturn_exit.json
+++ b/test/fixtures/v5/on_ramp/uturn_exit.json
@@ -11,6 +11,7 @@
         "de": "Auffahrt nehmen auf Way Name",
         "en": "Take the ramp onto Way Name",
         "es": "Tome la rampa en Way Name",
+        "es-ES": "Coge la cuesta por Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "id": "Ambil jalan melandai ke Way Name",
         "it": "Prendi la rampa in Way Name",

--- a/test/fixtures/v5/on_ramp/uturn_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/uturn_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Auffahrt nehmen Richtung Destination 1",
         "en": "Take the ramp towards Destination 1",
         "es": "Tome la rampa hacia Destination 1",
+        "es-ES": "Coge la cuesta hacia Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "id": "Ambil jalan melandai menuju Destination 1",
         "it": "Prendi la rampa verso Destination 1",

--- a/test/fixtures/v5/on_ramp/uturn_name.json
+++ b/test/fixtures/v5/on_ramp/uturn_name.json
@@ -10,6 +10,7 @@
         "de": "Auffahrt nehmen auf Way Name",
         "en": "Take the ramp onto Way Name",
         "es": "Tome la rampa en Way Name",
+        "es-ES": "Coge la cuesta por Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "id": "Ambil jalan melandai ke Way Name",
         "it": "Prendi la rampa in Way Name",

--- a/test/fixtures/v5/other/invalid_type.json
+++ b/test/fixtures/v5/other/invalid_type.json
@@ -10,6 +10,7 @@
         "de": "Links abbiegen auf Way Name",
         "en": "Turn left onto Way Name",
         "es": "Gire a la izquierda en Way Name",
+        "es-ES": "Gira a la izquierda por Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "id": "Belok kiri ke Way Name",
         "it": "Svolta a sinistra in Way Name",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_left.json
@@ -11,6 +11,7 @@
         "de": "Links weiterfahren auf Cool highway",
         "en": "Turn left to stay on Cool highway",
         "es": "Cruce a laizquierda en Cool highway",
+        "es-ES": "Cruce a laa la izquierda en Cool highway",
         "fr": "Continuer à gauche sur Cool highway",
         "id": "Terus kiri ke Cool highway",
         "it": "Continua a sinistra per stare su Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_right.json
@@ -11,6 +11,7 @@
         "de": "Rechts weiterfahren auf Cool highway",
         "en": "Turn right to stay on Cool highway",
         "es": "Cruce a laderecha en Cool highway",
+        "es-ES": "Cruce a laa la derecha en Cool highway",
         "fr": "Continuer à droite sur Cool highway",
         "id": "Terus kanan ke Cool highway",
         "it": "Continua a destra per stare su Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_sharp left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_sharp left.json
@@ -11,6 +11,7 @@
         "de": "Scharf links weiterfahren auf Cool highway",
         "en": "Make a sharp left to stay on Cool highway",
         "es": "Gire a la izquierda en Cool highway",
+        "es-ES": "Gire a la izquierda en Cool highway",
         "fr": "Make a sharp left to stay on Cool highway",
         "id": "Make a sharp left to stay on Cool highway",
         "it": "Make a sharp left to stay on Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_sharp right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_sharp right.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts weiterfahren auf Cool highway",
         "en": "Make a sharp right to stay on Cool highway",
         "es": "Gire a la derecha en Cool highway",
+        "es-ES": "Gire a la derecha en Cool highway",
         "fr": "Make a sharp right to stay on Cool highway",
         "id": "Make a sharp right to stay on Cool highway",
         "it": "Make a sharp right to stay on Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_slight left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_slight left.json
@@ -11,6 +11,7 @@
         "de": "Leicht links weiter auf Cool highway",
         "en": "Make a slight left to stay on Cool highway",
         "es": "Doble levemente a la izquierda en Cool highway",
+        "es-ES": "Doble levemente a la izquierda en Cool highway",
         "fr": "Continuer légèrement à gauche sur Cool highway",
         "id": "Tetap agak di kiri ke Cool highway",
         "it": "Continua leggermente a sinistra per stare su Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_slight right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_slight right.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts weiter auf Cool highway",
         "en": "Make a slight right to stay on Cool highway",
         "es": "Doble levemente a la derecha en Cool highway",
+        "es-ES": "Doble levemente a la derecha en Cool highway",
         "fr": "Continuer légèrement à droite sur Cool highway",
         "id": "Tetap agak di kanan ke Cool highway",
         "it": "Continua leggermente a destra per stare su Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_straight.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_straight.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus weiterfahren auf Cool highway",
         "en": "Continue straight to stay on Cool highway",
         "es": "Continúe en Cool highway",
+        "es-ES": "Continúe en Cool highway",
         "fr": "Continuer tout droit sur Cool highway",
         "id": "Terus ke Cool highway",
         "it": "Continua dritto per stare su Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_uturn.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_uturn.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung auf Cool highway",
         "en": "Make a U-turn and continue on Cool highway",
         "es": "Haz un cambio de sentido y continúe en Cool highway",
+        "es-ES": "Haz un cambio de sentido y continúe en Cool highway",
         "fr": "Faire demi-tour sur Cool highway",
         "id": "Putar balik ke arah Cool highway",
         "it": "Fai un'inversione ad U poi continua su Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_number_left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_left.json
@@ -11,6 +11,7 @@
         "de": "Links weiterfahren auf Ref1",
         "en": "Turn left to stay on Ref1",
         "es": "Cruce a laizquierda en Ref1",
+        "es-ES": "Cruce a laa la izquierda en Ref1",
         "fr": "Continuer à gauche sur Ref1",
         "id": "Terus kiri ke Ref1",
         "it": "Continua a sinistra per stare su Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_right.json
@@ -11,6 +11,7 @@
         "de": "Rechts weiterfahren auf Ref1",
         "en": "Turn right to stay on Ref1",
         "es": "Cruce a laderecha en Ref1",
+        "es-ES": "Cruce a laa la derecha en Ref1",
         "fr": "Continuer à droite sur Ref1",
         "id": "Terus kanan ke Ref1",
         "it": "Continua a destra per stare su Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_sharp left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_sharp left.json
@@ -11,6 +11,7 @@
         "de": "Scharf links weiterfahren auf Ref1",
         "en": "Make a sharp left to stay on Ref1",
         "es": "Gire a la izquierda en Ref1",
+        "es-ES": "Gire a la izquierda en Ref1",
         "fr": "Make a sharp left to stay on Ref1",
         "id": "Make a sharp left to stay on Ref1",
         "it": "Make a sharp left to stay on Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_sharp right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_sharp right.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts weiterfahren auf Ref1",
         "en": "Make a sharp right to stay on Ref1",
         "es": "Gire a la derecha en Ref1",
+        "es-ES": "Gire a la derecha en Ref1",
         "fr": "Make a sharp right to stay on Ref1",
         "id": "Make a sharp right to stay on Ref1",
         "it": "Make a sharp right to stay on Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_slight left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_slight left.json
@@ -11,6 +11,7 @@
         "de": "Leicht links weiter auf Ref1",
         "en": "Make a slight left to stay on Ref1",
         "es": "Doble levemente a la izquierda en Ref1",
+        "es-ES": "Doble levemente a la izquierda en Ref1",
         "fr": "Continuer légèrement à gauche sur Ref1",
         "id": "Tetap agak di kiri ke Ref1",
         "it": "Continua leggermente a sinistra per stare su Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_slight right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_slight right.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts weiter auf Ref1",
         "en": "Make a slight right to stay on Ref1",
         "es": "Doble levemente a la derecha en Ref1",
+        "es-ES": "Doble levemente a la derecha en Ref1",
         "fr": "Continuer légèrement à droite sur Ref1",
         "id": "Tetap agak di kanan ke Ref1",
         "it": "Continua leggermente a destra per stare su Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_straight.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_straight.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus weiterfahren auf Ref1",
         "en": "Continue straight to stay on Ref1",
         "es": "Continúe en Ref1",
+        "es-ES": "Continúe en Ref1",
         "fr": "Continuer tout droit sur Ref1",
         "id": "Terus ke Ref1",
         "it": "Continua dritto per stare su Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_uturn.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_uturn.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung auf Ref1",
         "en": "Make a U-turn and continue on Ref1",
         "es": "Haz un cambio de sentido y continúe en Ref1",
+        "es-ES": "Haz un cambio de sentido y continúe en Ref1",
         "fr": "Faire demi-tour sur Ref1",
         "id": "Putar balik ke arah Ref1",
         "it": "Fai un'inversione ad U poi continua su Ref1",

--- a/test/fixtures/v5/other/way_name_class_ferry_left.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_left.json
@@ -11,6 +11,7 @@
         "de": "Links weiterfahren auf Cool highway (Ref1)",
         "en": "Turn left to stay on Cool highway (Ref1)",
         "es": "Cruce a laizquierda en Cool highway (Ref1)",
+        "es-ES": "Cruce a laa la izquierda en Cool highway (Ref1)",
         "fr": "Continuer à gauche sur Cool highway (Ref1)",
         "id": "Terus kiri ke Cool highway (Ref1)",
         "it": "Continua a sinistra per stare su Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_right.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_right.json
@@ -11,6 +11,7 @@
         "de": "Rechts weiterfahren auf Cool highway (Ref1)",
         "en": "Turn right to stay on Cool highway (Ref1)",
         "es": "Cruce a laderecha en Cool highway (Ref1)",
+        "es-ES": "Cruce a laa la derecha en Cool highway (Ref1)",
         "fr": "Continuer à droite sur Cool highway (Ref1)",
         "id": "Terus kanan ke Cool highway (Ref1)",
         "it": "Continua a destra per stare su Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_sharp left.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_sharp left.json
@@ -11,6 +11,7 @@
         "de": "Scharf links weiterfahren auf Cool highway (Ref1)",
         "en": "Make a sharp left to stay on Cool highway (Ref1)",
         "es": "Gire a la izquierda en Cool highway (Ref1)",
+        "es-ES": "Gire a la izquierda en Cool highway (Ref1)",
         "fr": "Make a sharp left to stay on Cool highway (Ref1)",
         "id": "Make a sharp left to stay on Cool highway (Ref1)",
         "it": "Make a sharp left to stay on Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_sharp right.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_sharp right.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts weiterfahren auf Cool highway (Ref1)",
         "en": "Make a sharp right to stay on Cool highway (Ref1)",
         "es": "Gire a la derecha en Cool highway (Ref1)",
+        "es-ES": "Gire a la derecha en Cool highway (Ref1)",
         "fr": "Make a sharp right to stay on Cool highway (Ref1)",
         "id": "Make a sharp right to stay on Cool highway (Ref1)",
         "it": "Make a sharp right to stay on Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_slight left.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_slight left.json
@@ -11,6 +11,7 @@
         "de": "Leicht links weiter auf Cool highway (Ref1)",
         "en": "Make a slight left to stay on Cool highway (Ref1)",
         "es": "Doble levemente a la izquierda en Cool highway (Ref1)",
+        "es-ES": "Doble levemente a la izquierda en Cool highway (Ref1)",
         "fr": "Continuer légèrement à gauche sur Cool highway (Ref1)",
         "id": "Tetap agak di kiri ke Cool highway (Ref1)",
         "it": "Continua leggermente a sinistra per stare su Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_slight right.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_slight right.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts weiter auf Cool highway (Ref1)",
         "en": "Make a slight right to stay on Cool highway (Ref1)",
         "es": "Doble levemente a la derecha en Cool highway (Ref1)",
+        "es-ES": "Doble levemente a la derecha en Cool highway (Ref1)",
         "fr": "Continuer légèrement à droite sur Cool highway (Ref1)",
         "id": "Tetap agak di kanan ke Cool highway (Ref1)",
         "it": "Continua leggermente a destra per stare su Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_straight.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_straight.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus weiterfahren auf Cool highway (Ref1)",
         "en": "Continue straight to stay on Cool highway (Ref1)",
         "es": "Continúe en Cool highway (Ref1)",
+        "es-ES": "Continúe en Cool highway (Ref1)",
         "fr": "Continuer tout droit sur Cool highway (Ref1)",
         "id": "Terus ke Cool highway (Ref1)",
         "it": "Continua dritto per stare su Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_uturn.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_uturn.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung auf Cool highway (Ref1)",
         "en": "Make a U-turn and continue on Cool highway (Ref1)",
         "es": "Haz un cambio de sentido y continúe en Cool highway (Ref1)",
+        "es-ES": "Haz un cambio de sentido y continúe en Cool highway (Ref1)",
         "fr": "Faire demi-tour sur Cool highway (Ref1)",
         "id": "Putar balik ke arah Cool highway (Ref1)",
         "it": "Fai un'inversione ad U poi continua su Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_ref.json
+++ b/test/fixtures/v5/other/way_name_ref.json
@@ -11,6 +11,7 @@
         "de": "Links abbiegen auf Ref1",
         "en": "Turn left onto Ref1",
         "es": "Gire a la izquierda en Ref1",
+        "es-ES": "Gira a la izquierda por Ref1",
         "fr": "Tourner à gauche sur Ref1",
         "id": "Belok kiri ke Ref1",
         "it": "Svolta a sinistra in Ref1",

--- a/test/fixtures/v5/other/way_name_ref_destinations.json
+++ b/test/fixtures/v5/other/way_name_ref_destinations.json
@@ -12,6 +12,7 @@
         "de": "Links abbiegen Richtung Destination 1",
         "en": "Turn left towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Gira a la izquierda hacia Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "id": "Belok kiri menuju Destination 1",
         "it": "Svolta a sinistra verso Destination 1",

--- a/test/fixtures/v5/other/way_name_ref_mapbox_hack_1.json
+++ b/test/fixtures/v5/other/way_name_ref_mapbox_hack_1.json
@@ -11,6 +11,7 @@
         "de": "Links abbiegen auf Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
         "en": "Turn left onto Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
         "es": "Gire a la izquierda en Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
+        "es-ES": "Gira a la izquierda por Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
         "fr": "Tourner à gauche sur Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
         "id": "Belok kiri ke Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
         "it": "Svolta a sinistra in Way Name (Ref1 (Another+Way \\ (Ref1.1)))",

--- a/test/fixtures/v5/other/way_name_ref_mapbox_hack_2.json
+++ b/test/fixtures/v5/other/way_name_ref_mapbox_hack_2.json
@@ -11,6 +11,7 @@
         "de": "Links abbiegen auf Way Name (Ref0)",
         "en": "Turn left onto Way Name (Ref0)",
         "es": "Gire a la izquierda en Way Name (Ref0)",
+        "es-ES": "Gira a la izquierda por Way Name (Ref0)",
         "fr": "Tourner à gauche sur Way Name (Ref0)",
         "id": "Belok kiri ke Way Name (Ref0)",
         "it": "Svolta a sinistra in Way Name (Ref0)",

--- a/test/fixtures/v5/other/way_name_ref_mapbox_hack_3.json
+++ b/test/fixtures/v5/other/way_name_ref_mapbox_hack_3.json
@@ -11,6 +11,7 @@
         "de": "Links abbiegen auf Ref0",
         "en": "Turn left onto Ref0",
         "es": "Gire a la izquierda en Ref0",
+        "es-ES": "Gira a la izquierda por Ref0",
         "fr": "Tourner à gauche sur Ref0",
         "id": "Belok kiri ke Ref0",
         "it": "Svolta a sinistra in Ref0",

--- a/test/fixtures/v5/other/way_name_ref_name.json
+++ b/test/fixtures/v5/other/way_name_ref_name.json
@@ -11,6 +11,7 @@
         "de": "Links abbiegen auf Way Name (Ref1)",
         "en": "Turn left onto Way Name (Ref1)",
         "es": "Gire a la izquierda en Way Name (Ref1)",
+        "es-ES": "Gira a la izquierda por Way Name (Ref1)",
         "fr": "Tourner à gauche sur Way Name (Ref1)",
         "id": "Belok kiri ke Way Name (Ref1)",
         "it": "Svolta a sinistra in Way Name (Ref1)",

--- a/test/fixtures/v5/phrase/one_in_distance.json
+++ b/test/fixtures/v5/phrase/one_in_distance.json
@@ -7,6 +7,7 @@
         "de": "In 0 units, Do something",
         "en": "In 0 units, Do something",
         "es": "A 0 units, Do something",
+        "es-ES": "A 0 units, Do something",
         "fr": "In 0 units, Do something",
         "id": "In 0 units, Do something",
         "it": "Tra 0 units Do something",

--- a/test/fixtures/v5/phrase/two_linked.json
+++ b/test/fixtures/v5/phrase/two_linked.json
@@ -7,6 +7,7 @@
         "de": "Do this danach Do that",
         "en": "Do this, then Do that",
         "es": "Do this y luego Do that",
+        "es-ES": "Do this y luego Do that",
         "fr": "Do this then Do that",
         "id": "Do this then Do that",
         "it": "Do this poi Do that",

--- a/test/fixtures/v5/phrase/two_linked_by_distance.json
+++ b/test/fixtures/v5/phrase/two_linked_by_distance.json
@@ -8,6 +8,7 @@
         "de": "Do this danach in 0 units Do that",
         "en": "Do this, then, in 0 units, Do that",
         "es": "Do this y luego en 0 units, Do that",
+        "es-ES": "Do this y luego en 0 units, Do that",
         "fr": "Do this then in 0 units Do that",
         "id": "Do this then in 0 units Do that",
         "it": "Do this, poi tra 0 units Do that",

--- a/test/fixtures/v5/rotary/default_default.json
+++ b/test/fixtures/v5/rotary/default_default.json
@@ -10,6 +10,7 @@
         "de": "In den Kreisverkehr fahren",
         "en": "Enter the rotary",
         "es": "Entra en la rotonda",
+        "es-ES": "Incorpórate en la rotonda",
         "fr": "Prendre le rond-point",
         "id": "Masuk bundaran",
         "it": "Immettiti nella rotonda",

--- a/test/fixtures/v5/rotary/default_destination.json
+++ b/test/fixtures/v5/rotary/default_destination.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die Ausfahrt Richtung Destination 1 nehmen",
         "en": "Enter the rotary and exit towards Destination 1",
         "es": "Entra en la rotonda y sal hacia Destination 1",
+        "es-ES": "En la rotonda sal hacia Destination 1",
         "fr": "Prendre le rond-point et sortir en direction de Destination 1",
         "id": "Masuk bundaran dan keluar menuju Destination 1",
         "it": "Immettiti nella ritonda ed esci verso Destination 1",

--- a/test/fixtures/v5/rotary/default_exit.json
+++ b/test/fixtures/v5/rotary/default_exit.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die Ausfahrt auf Way Name nehmen",
         "en": "Enter the rotary and exit onto Way Name",
         "es": "Entra en la rotonda y sal en Way Name",
+        "es-ES": "En la rotonda sal por Way Name",
         "fr": "Prendre le rond-point et sortir par Way Name",
         "id": "Masuk bundaran dan keluar arah Way Name",
         "it": "Immettiti nella ritonda ed esci in Way Name",

--- a/test/fixtures/v5/rotary/default_exit_destination.json
+++ b/test/fixtures/v5/rotary/default_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Im Kreisverkehr die Ausfahrt Richtung Destination 1 nehmen",
         "en": "Enter the rotary and exit towards Destination 1",
         "es": "Entra en la rotonda y sal hacia Destination 1",
+        "es-ES": "En la rotonda sal hacia Destination 1",
         "fr": "Prendre le rond-point et sortir en direction de Destination 1",
         "id": "Masuk bundaran dan keluar menuju Destination 1",
         "it": "Immettiti nella ritonda ed esci verso Destination 1",

--- a/test/fixtures/v5/rotary/default_name.json
+++ b/test/fixtures/v5/rotary/default_name.json
@@ -10,6 +10,7 @@
         "de": "Im Kreisverkehr die Ausfahrt auf Way Name nehmen",
         "en": "Enter the rotary and exit onto Way Name",
         "es": "Entra en la rotonda y sal en Way Name",
+        "es-ES": "En la rotonda sal por Way Name",
         "fr": "Prendre le rond-point et sortir par Way Name",
         "id": "Masuk bundaran dan keluar arah Way Name",
         "it": "Immettiti nella ritonda ed esci in Way Name",

--- a/test/fixtures/v5/rotary/exit_10.json
+++ b/test/fixtures/v5/rotary/exit_10.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die zehnte Ausfahrt nehmen",
         "en": "Enter the rotary and take the 10th exit",
         "es": "Entra en la rotonda y toma la 10ª salida",
+        "es-ES": "En la rotonda toma la 10ª salida",
         "fr": "Prendre le rond-point et prendre la dixième sortie",
         "id": "Masuk bundaran dan ambil jalan keluar 10",
         "it": "Immettiti nella rotonda e prendi la 10ª uscita",

--- a/test/fixtures/v5/rotary/exit_11.json
+++ b/test/fixtures/v5/rotary/exit_11.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die Ausfahrt nehmen",
         "en": "Enter the rotary and take the exit",
         "es": "Entra en la rotonda y toma la salida",
+        "es-ES": "En la rotonda toma la salida",
         "fr": "Prendre le rond-point et prendre la sortie",
         "id": "Masuk bundaran dan ambil jalan keluar ",
         "it": "Immettiti nella rotonda e prendi la uscita",

--- a/test/fixtures/v5/rotary/exit_1_default.json
+++ b/test/fixtures/v5/rotary/exit_1_default.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen",
         "en": "Enter the rotary and take the 1st exit",
         "es": "Entra en la rotonda y toma la 1ª salida",
+        "es-ES": "En la rotonda toma la 1ª salida",
         "fr": "Prendre le rond-point et prendre la première sortie",
         "id": "Masuk bundaran dan ambil jalan keluar 1",
         "it": "Immettiti nella rotonda e prendi la 1ª uscita",

--- a/test/fixtures/v5/rotary/exit_1_destination.json
+++ b/test/fixtures/v5/rotary/exit_1_destination.json
@@ -12,6 +12,7 @@
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen Richtung Destination 1",
         "en": "Enter the rotary and take the 1st exit towards Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
+        "es-ES": "En la rotonda toma la 1ª salida hacia Destination 1",
         "fr": "Prendre le rond-point et prendre la première sortie en direction de Destination 1",
         "id": "Masuk bundaran dan ambil jalan keluar 1 menuju Destination 1",
         "it": "Immettiti nella rotonda e prendi la 1ª uscita verso  Destination 1",

--- a/test/fixtures/v5/rotary/exit_1_exit.json
+++ b/test/fixtures/v5/rotary/exit_1_exit.json
@@ -12,6 +12,7 @@
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen auf Way Name",
         "en": "Enter the rotary and take the 1st exit onto Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
+        "es-ES": "En la rotonda toma la 1ª salida por Way Name",
         "fr": "Prendre le rond-point et prendre la première sortie sur Way Name",
         "id": "Masuk bundaran dan ambil jalan keluar 1 arah Way Name",
         "it": "Immettiti nella rotonda e prendi la 1ª uscita in Way Name",

--- a/test/fixtures/v5/rotary/exit_1_exit_destination.json
+++ b/test/fixtures/v5/rotary/exit_1_exit_destination.json
@@ -13,6 +13,7 @@
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen Richtung Destination 1",
         "en": "Enter the rotary and take the 1st exit towards Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
+        "es-ES": "En la rotonda toma la 1ª salida hacia Destination 1",
         "fr": "Prendre le rond-point et prendre la première sortie en direction de Destination 1",
         "id": "Masuk bundaran dan ambil jalan keluar 1 menuju Destination 1",
         "it": "Immettiti nella rotonda e prendi la 1ª uscita verso  Destination 1",

--- a/test/fixtures/v5/rotary/exit_1_name.json
+++ b/test/fixtures/v5/rotary/exit_1_name.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen auf Way Name",
         "en": "Enter the rotary and take the 1st exit onto Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
+        "es-ES": "En la rotonda toma la 1ª salida por Way Name",
         "fr": "Prendre le rond-point et prendre la première sortie sur Way Name",
         "id": "Masuk bundaran dan ambil jalan keluar 1 arah Way Name",
         "it": "Immettiti nella rotonda e prendi la 1ª uscita in Way Name",

--- a/test/fixtures/v5/rotary/exit_2.json
+++ b/test/fixtures/v5/rotary/exit_2.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die zweite Ausfahrt nehmen",
         "en": "Enter the rotary and take the 2nd exit",
         "es": "Entra en la rotonda y toma la 2ª salida",
+        "es-ES": "En la rotonda toma la 2ª salida",
         "fr": "Prendre le rond-point et prendre la seconde sortie",
         "id": "Masuk bundaran dan ambil jalan keluar 2",
         "it": "Immettiti nella rotonda e prendi la 2ª uscita",

--- a/test/fixtures/v5/rotary/exit_3.json
+++ b/test/fixtures/v5/rotary/exit_3.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die dritte Ausfahrt nehmen",
         "en": "Enter the rotary and take the 3rd exit",
         "es": "Entra en la rotonda y toma la 3ª salida",
+        "es-ES": "En la rotonda toma la 3ª salida",
         "fr": "Prendre le rond-point et prendre la troisième sortie",
         "id": "Masuk bundaran dan ambil jalan keluar 3",
         "it": "Immettiti nella rotonda e prendi la 3ª uscita",

--- a/test/fixtures/v5/rotary/exit_4.json
+++ b/test/fixtures/v5/rotary/exit_4.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die vierte Ausfahrt nehmen",
         "en": "Enter the rotary and take the 4th exit",
         "es": "Entra en la rotonda y toma la 4ª salida",
+        "es-ES": "En la rotonda toma la 4ª salida",
         "fr": "Prendre le rond-point et prendre la quatrième sortie",
         "id": "Masuk bundaran dan ambil jalan keluar 4",
         "it": "Immettiti nella rotonda e prendi la 4ª uscita",

--- a/test/fixtures/v5/rotary/exit_5.json
+++ b/test/fixtures/v5/rotary/exit_5.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die fünfte Ausfahrt nehmen",
         "en": "Enter the rotary and take the 5th exit",
         "es": "Entra en la rotonda y toma la 5ª salida",
+        "es-ES": "En la rotonda toma la 5ª salida",
         "fr": "Prendre le rond-point et prendre la cinquième sortie",
         "id": "Masuk bundaran dan ambil jalan keluar 5",
         "it": "Immettiti nella rotonda e prendi la 5ª uscita",

--- a/test/fixtures/v5/rotary/exit_6.json
+++ b/test/fixtures/v5/rotary/exit_6.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die sechste Ausfahrt nehmen",
         "en": "Enter the rotary and take the 6th exit",
         "es": "Entra en la rotonda y toma la 6ª salida",
+        "es-ES": "En la rotonda toma la 6ª salida",
         "fr": "Prendre le rond-point et prendre la sixième sortie",
         "id": "Masuk bundaran dan ambil jalan keluar 6",
         "it": "Immettiti nella rotonda e prendi la 6ª uscita",

--- a/test/fixtures/v5/rotary/exit_7.json
+++ b/test/fixtures/v5/rotary/exit_7.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die siebente Ausfahrt nehmen",
         "en": "Enter the rotary and take the 7th exit",
         "es": "Entra en la rotonda y toma la 7ª salida",
+        "es-ES": "En la rotonda toma la 7ª salida",
         "fr": "Prendre le rond-point et prendre la septième sortie",
         "id": "Masuk bundaran dan ambil jalan keluar 7",
         "it": "Immettiti nella rotonda e prendi la 7ª uscita",

--- a/test/fixtures/v5/rotary/exit_8.json
+++ b/test/fixtures/v5/rotary/exit_8.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die achte Ausfahrt nehmen",
         "en": "Enter the rotary and take the 8th exit",
         "es": "Entra en la rotonda y toma la 8ª salida",
+        "es-ES": "En la rotonda toma la 8ª salida",
         "fr": "Prendre le rond-point et prendre la huitième sortie",
         "id": "Masuk bundaran dan ambil jalan keluar 8",
         "it": "Immettiti nella rotonda e prendi la 8ª uscita",

--- a/test/fixtures/v5/rotary/exit_9.json
+++ b/test/fixtures/v5/rotary/exit_9.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die neunte Ausfahrt nehmen",
         "en": "Enter the rotary and take the 9th exit",
         "es": "Entra en la rotonda y toma la 9ª salida",
+        "es-ES": "En la rotonda toma la 9ª salida",
         "fr": "Prendre le rond-point et prendre la neuvième sortie",
         "id": "Masuk bundaran dan ambil jalan keluar 9",
         "it": "Immettiti nella rotonda e prendi la 9ª uscita",

--- a/test/fixtures/v5/rotary/name_default.json
+++ b/test/fixtures/v5/rotary/name_default.json
@@ -11,6 +11,7 @@
         "de": "In Rotary Name fahren",
         "en": "Enter Rotary Name",
         "es": "Entra en Rotary Name",
+        "es-ES": "En Rotary Name",
         "fr": "Prendre le rond-point Rotary Name",
         "id": "Masuk Rotary Name",
         "it": "Immettiti in Rotary Name",

--- a/test/fixtures/v5/rotary/name_destination.json
+++ b/test/fixtures/v5/rotary/name_destination.json
@@ -12,6 +12,7 @@
         "de": "In Rotary Name die Ausfahrt Richtung Destination 1 nehmen",
         "en": "Enter Rotary Name and exit towards Destination 1",
         "es": "Entra en Rotary Name y sal hacia Destination 1",
+        "es-ES": "En Rotary Name sal hacia Destination 1",
         "fr": "Prendre le rond-point Rotary Name et sortir en direction de Destination 1",
         "id": "Masuk Rotary Name dan keluar menuju Destination 1",
         "it": "Immettiti in Rotary Name ed esci verso Destination 1",

--- a/test/fixtures/v5/rotary/name_exit.json
+++ b/test/fixtures/v5/rotary/name_exit.json
@@ -12,6 +12,7 @@
         "de": "In Rotary Name die Ausfahrt auf Way Name nehmen",
         "en": "Enter Rotary Name and exit onto Way Name",
         "es": "Entra en Rotary Name y sal en Way Name",
+        "es-ES": "En Rotary Name sal por Way Name",
         "fr": "Prendre le rond-point Rotary Name et sortir par Way Name",
         "id": "Masuk Rotary Name dan keluar arah Way Name",
         "it": "Immettiti in Rotary Name ed esci su Way Name",

--- a/test/fixtures/v5/rotary/name_exit_default.json
+++ b/test/fixtures/v5/rotary/name_exit_default.json
@@ -12,6 +12,7 @@
         "de": "In den Kreisverkehr fahren und zweite Ausfahrt nehmen",
         "en": "Enter Rotary Name and take the 2nd exit",
         "es": "Entra en Rotary Name y coge la 2ª salida",
+        "es-ES": "En Rotary Name toma la 2ª salida",
         "fr": "Prendre le rond-point Rotary Name et prendre la seconde sortie",
         "id": "Masuk Rotary Name dan ambil jalan keluar 2",
         "it": "Immettiti in Rotary Name e prendi la 2ª uscita",

--- a/test/fixtures/v5/rotary/name_exit_destination.json
+++ b/test/fixtures/v5/rotary/name_exit_destination.json
@@ -13,6 +13,7 @@
         "de": "In den Kreisverkehr fahren und zweite Ausfahrt nehmen Richtung Destination 1",
         "en": "Enter Rotary Name and take the 2nd exit towards Destination 1",
         "es": "Entra en Rotary Name y coge la 2ª salida hacia Destination 1",
+        "es-ES": "En Rotary Name toma la 2ª salida hacia Destination 1",
         "fr": "Prendre le rond-point Rotary Name et prendre la seconde sortie en direction de Destination 1",
         "id": "Masuk Rotary Name dan ambil jalan keluar 2 menuju Destination 1",
         "it": "Immettiti in Rotary Name e prendi la 2ª uscita verso Destination 1",

--- a/test/fixtures/v5/rotary/name_exit_exit.json
+++ b/test/fixtures/v5/rotary/name_exit_exit.json
@@ -13,6 +13,7 @@
         "de": "In den Kreisverkehr fahren und zweite Ausfahrt nehmen auf Way Name",
         "en": "Enter Rotary Name and take the 2nd exit onto Way Name",
         "es": "Entra en Rotary Name y coge la 2ª salida en Way Name",
+        "es-ES": "En Rotary Name toma la 2ª salida por Way Name",
         "fr": "Prendre le rond-point Rotary Name et prendre la seconde sortie sur Way Name",
         "id": "Masuk Rotary Name dan ambil jalan keluar 2 arah Way Name",
         "it": "Immettiti in Rotary Name e prendi la 2ª uscita in Way Name",

--- a/test/fixtures/v5/rotary/name_exit_exit_destination.json
+++ b/test/fixtures/v5/rotary/name_exit_exit_destination.json
@@ -14,6 +14,7 @@
         "de": "In den Kreisverkehr fahren und zweite Ausfahrt nehmen Richtung Destination 1",
         "en": "Enter Rotary Name and take the 2nd exit towards Destination 1",
         "es": "Entra en Rotary Name y coge la 2ª salida hacia Destination 1",
+        "es-ES": "En Rotary Name toma la 2ª salida hacia Destination 1",
         "fr": "Prendre le rond-point Rotary Name et prendre la seconde sortie en direction de Destination 1",
         "id": "Masuk Rotary Name dan ambil jalan keluar 2 menuju Destination 1",
         "it": "Immettiti in Rotary Name e prendi la 2ª uscita verso Destination 1",

--- a/test/fixtures/v5/rotary/name_exit_name.json
+++ b/test/fixtures/v5/rotary/name_exit_name.json
@@ -12,6 +12,7 @@
         "de": "In den Kreisverkehr fahren und zweite Ausfahrt nehmen auf Way Name",
         "en": "Enter Rotary Name and take the 2nd exit onto Way Name",
         "es": "Entra en Rotary Name y coge la 2ª salida en Way Name",
+        "es-ES": "En Rotary Name toma la 2ª salida por Way Name",
         "fr": "Prendre le rond-point Rotary Name et prendre la seconde sortie sur Way Name",
         "id": "Masuk Rotary Name dan ambil jalan keluar 2 arah Way Name",
         "it": "Immettiti in Rotary Name e prendi la 2ª uscita in Way Name",

--- a/test/fixtures/v5/rotary/name_name.json
+++ b/test/fixtures/v5/rotary/name_name.json
@@ -11,6 +11,7 @@
         "de": "In Rotary Name die Ausfahrt auf Way Name nehmen",
         "en": "Enter Rotary Name and exit onto Way Name",
         "es": "Entra en Rotary Name y sal en Way Name",
+        "es-ES": "En Rotary Name sal por Way Name",
         "fr": "Prendre le rond-point Rotary Name et sortir par Way Name",
         "id": "Masuk Rotary Name dan keluar arah Way Name",
         "it": "Immettiti in Rotary Name ed esci su Way Name",

--- a/test/fixtures/v5/roundabout/default_default.json
+++ b/test/fixtures/v5/roundabout/default_default.json
@@ -10,6 +10,7 @@
         "de": "In den Kreisverkehr fahren",
         "en": "Enter the roundabout",
         "es": "Entra en la rotonda",
+        "es-ES": "Entra en la rotonda",
         "fr": "Prendre le rond-point",
         "id": "Masuk bundaran",
         "it": "Entra nella rotonda",

--- a/test/fixtures/v5/roundabout/default_destination.json
+++ b/test/fixtures/v5/roundabout/default_destination.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die Ausfahrt Richtung Destination 1 nehmen",
         "en": "Enter the roundabout and exit towards Destination 1",
         "es": "Entra en la rotonda y sal hacia Destination 1",
+        "es-ES": "Entra en la rotonda y sal hacia Destination 1",
         "fr": "Prendre le rond-point et sortir en direction de Destination 1",
         "id": "Masuk bundaran dan keluar menuju Destination 1",
         "it": "Entra nella rotonda e prendi l'uscita verso Destination 1",

--- a/test/fixtures/v5/roundabout/default_exit.json
+++ b/test/fixtures/v5/roundabout/default_exit.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die Ausfahrt auf Way Name nehmen",
         "en": "Enter the roundabout and exit onto Way Name",
         "es": "Entra en la rotonda y sal en Way Name",
+        "es-ES": "Entra en la rotonda y sal por Way Name",
         "fr": "Prendre le rond-point et sortir par Way Name",
         "id": "Masuk bundaran dan keluar arah Way Name",
         "it": "Entra nella rotonda e prendi l'uscita in Way Name",

--- a/test/fixtures/v5/roundabout/default_exit_destination.json
+++ b/test/fixtures/v5/roundabout/default_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Im Kreisverkehr die Ausfahrt Richtung Destination 1 nehmen",
         "en": "Enter the roundabout and exit towards Destination 1",
         "es": "Entra en la rotonda y sal hacia Destination 1",
+        "es-ES": "Entra en la rotonda y sal hacia Destination 1",
         "fr": "Prendre le rond-point et sortir en direction de Destination 1",
         "id": "Masuk bundaran dan keluar menuju Destination 1",
         "it": "Entra nella rotonda e prendi l'uscita verso Destination 1",

--- a/test/fixtures/v5/roundabout/default_name.json
+++ b/test/fixtures/v5/roundabout/default_name.json
@@ -10,6 +10,7 @@
         "de": "Im Kreisverkehr die Ausfahrt auf Way Name nehmen",
         "en": "Enter the roundabout and exit onto Way Name",
         "es": "Entra en la rotonda y sal en Way Name",
+        "es-ES": "Entra en la rotonda y sal por Way Name",
         "fr": "Prendre le rond-point et sortir par Way Name",
         "id": "Masuk bundaran dan keluar arah Way Name",
         "it": "Entra nella rotonda e prendi l'uscita in Way Name",

--- a/test/fixtures/v5/roundabout/exit_default.json
+++ b/test/fixtures/v5/roundabout/exit_default.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen",
         "en": "Enter the roundabout and take the 1st exit",
         "es": "Entra en la rotonda y toma la 1ª salida",
+        "es-ES": "Entra en la rotonda y toma la 1ª salida",
         "fr": "Prendre le rond-point et prendre la première sortie",
         "id": "Masuk bundaran dan ambil jalan keluar 1",
         "it": "Immettiti nella rotonda e prendi la 1ª uscita",

--- a/test/fixtures/v5/roundabout/exit_destination.json
+++ b/test/fixtures/v5/roundabout/exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen Richtung Destination 1",
         "en": "Enter the roundabout and take the 1st exit towards Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
+        "es-ES": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "fr": "Prendre le rond-point et prendre la première sortie en direction de Destination 1",
         "id": "Masuk bundaran dan ambil jalan keluar 1 menuju Destination 1",
         "it": "Immettiti nella rotonda e prendi la 1ª uscita verso Destination 1",

--- a/test/fixtures/v5/roundabout/exit_exit.json
+++ b/test/fixtures/v5/roundabout/exit_exit.json
@@ -12,6 +12,7 @@
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen auf Way Name",
         "en": "Enter the roundabout and take the 1st exit onto Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
+        "es-ES": "Entra en la rotonda y toma la 1ª salida por Way Name",
         "fr": "Prendre le rond-point et prendre la première sortie sur Way Name",
         "id": "Masuk bundaran dan ambil jalan keluar 1 arah Way Name",
         "it": "Immettiti nella rotonda e prendi la 1ª uscita in Way Name",

--- a/test/fixtures/v5/roundabout/exit_exit_destination.json
+++ b/test/fixtures/v5/roundabout/exit_exit_destination.json
@@ -13,6 +13,7 @@
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen Richtung Destination 1",
         "en": "Enter the roundabout and take the 1st exit towards Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
+        "es-ES": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "fr": "Prendre le rond-point et prendre la première sortie en direction de Destination 1",
         "id": "Masuk bundaran dan ambil jalan keluar 1 menuju Destination 1",
         "it": "Immettiti nella rotonda e prendi la 1ª uscita verso Destination 1",

--- a/test/fixtures/v5/roundabout/exit_name.json
+++ b/test/fixtures/v5/roundabout/exit_name.json
@@ -11,6 +11,7 @@
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen auf Way Name",
         "en": "Enter the roundabout and take the 1st exit onto Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
+        "es-ES": "Entra en la rotonda y toma la 1ª salida por Way Name",
         "fr": "Prendre le rond-point et prendre la première sortie sur Way Name",
         "id": "Masuk bundaran dan ambil jalan keluar 1 arah Way Name",
         "it": "Immettiti nella rotonda e prendi la 1ª uscita in Way Name",

--- a/test/fixtures/v5/roundabout_turn/left_default.json
+++ b/test/fixtures/v5/roundabout_turn/left_default.json
@@ -10,6 +10,7 @@
         "de": "Am Kreisverkehr links abbiegen",
         "en": "At the roundabout turn left",
         "es": "En la rotonda gira a la izquierda",
+        "es-ES": "En la rotonda gira a la izquierda",
         "fr": "Au rond-point, tourner à gauche",
         "id": "Di bundaran belok kiri",
         "it": "Alla rotonda svolta a sinistra",

--- a/test/fixtures/v5/roundabout_turn/left_destination.json
+++ b/test/fixtures/v5/roundabout_turn/left_destination.json
@@ -11,6 +11,7 @@
         "de": "Am Kreisverkehr links Richtung Destination 1",
         "en": "At the roundabout turn left towards Destination 1",
         "es": "En la rotonda gira a la izquierda hacia Destination 1",
+        "es-ES": "En la rotonda gira a la izquierda hacia Destination 1",
         "fr": "Au rond-point, tourner à gauche en direction de Destination 1",
         "id": "Di bundaran, belok kiri menuju Destination 1",
         "it": "Alla rotonda svolta a sinistra verso Destination 1",

--- a/test/fixtures/v5/roundabout_turn/left_exit.json
+++ b/test/fixtures/v5/roundabout_turn/left_exit.json
@@ -11,6 +11,7 @@
         "de": "Am Kreisverkehr links auf Way Name",
         "en": "At the roundabout turn left onto Way Name",
         "es": "En la rotonda gira a la izquierda en Way Name",
+        "es-ES": "En la rotonda gira a la izquierda por Way Name",
         "fr": "Au rond-point, tourner à gauche sur Way Name",
         "id": "Di bundaran, belok kiri arah Way Name",
         "it": "Alla rotonda svolta a sinistra in Way Name",

--- a/test/fixtures/v5/roundabout_turn/left_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Am Kreisverkehr links Richtung Destination 1",
         "en": "At the roundabout turn left towards Destination 1",
         "es": "En la rotonda gira a la izquierda hacia Destination 1",
+        "es-ES": "En la rotonda gira a la izquierda hacia Destination 1",
         "fr": "Au rond-point, tourner à gauche en direction de Destination 1",
         "id": "Di bundaran, belok kiri menuju Destination 1",
         "it": "Alla rotonda svolta a sinistra verso Destination 1",

--- a/test/fixtures/v5/roundabout_turn/left_name.json
+++ b/test/fixtures/v5/roundabout_turn/left_name.json
@@ -10,6 +10,7 @@
         "de": "Am Kreisverkehr links auf Way Name",
         "en": "At the roundabout turn left onto Way Name",
         "es": "En la rotonda gira a la izquierda en Way Name",
+        "es-ES": "En la rotonda gira a la izquierda por Way Name",
         "fr": "Au rond-point, tourner à gauche sur Way Name",
         "id": "Di bundaran, belok kiri arah Way Name",
         "it": "Alla rotonda svolta a sinistra in Way Name",

--- a/test/fixtures/v5/roundabout_turn/right_default.json
+++ b/test/fixtures/v5/roundabout_turn/right_default.json
@@ -10,6 +10,7 @@
         "de": "Am Kreisverkehr rechts abbiegen",
         "en": "At the roundabout turn right",
         "es": "En la rotonda gira a la derecha",
+        "es-ES": "En la rotonda gira a la derecha",
         "fr": "Au rond-point, tourner à droite",
         "id": "Di bundaran belok kanan",
         "it": "Alla rotonda svolta a destra",

--- a/test/fixtures/v5/roundabout_turn/right_destination.json
+++ b/test/fixtures/v5/roundabout_turn/right_destination.json
@@ -11,6 +11,7 @@
         "de": "Am Kreisverkehr rechts Richtung Destination 1",
         "en": "At the roundabout turn right towards Destination 1",
         "es": "En la rotonda gira a la derecha hacia Destination 1",
+        "es-ES": "En la rotonda gira a la derecha hacia Destination 1",
         "fr": "Au rond-point, tourner à droite en direction de Destination 1",
         "id": "Di bundaran belok kanan menuju Destination 1",
         "it": "Alla rotonda svolta a destra verso Destination 1",

--- a/test/fixtures/v5/roundabout_turn/right_exit.json
+++ b/test/fixtures/v5/roundabout_turn/right_exit.json
@@ -11,6 +11,7 @@
         "de": "Am Kreisverkehr rechts auf Way Name",
         "en": "At the roundabout turn right onto Way Name",
         "es": "En la rotonda gira a la derecha en Way Name",
+        "es-ES": "En la rotonda gira a la derecha por Way Name",
         "fr": "Au rond-point, tourner à droite sur Way Name",
         "id": "Di bundaran belok kanan ke arah Way Name",
         "it": "Alla rotonda svolta a destra in Way Name",

--- a/test/fixtures/v5/roundabout_turn/right_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Am Kreisverkehr rechts Richtung Destination 1",
         "en": "At the roundabout turn right towards Destination 1",
         "es": "En la rotonda gira a la derecha hacia Destination 1",
+        "es-ES": "En la rotonda gira a la derecha hacia Destination 1",
         "fr": "Au rond-point, tourner à droite en direction de Destination 1",
         "id": "Di bundaran belok kanan menuju Destination 1",
         "it": "Alla rotonda svolta a destra verso Destination 1",

--- a/test/fixtures/v5/roundabout_turn/right_name.json
+++ b/test/fixtures/v5/roundabout_turn/right_name.json
@@ -10,6 +10,7 @@
         "de": "Am Kreisverkehr rechts auf Way Name",
         "en": "At the roundabout turn right onto Way Name",
         "es": "En la rotonda gira a la derecha en Way Name",
+        "es-ES": "En la rotonda gira a la derecha por Way Name",
         "fr": "Au rond-point, tourner à droite sur Way Name",
         "id": "Di bundaran belok kanan ke arah Way Name",
         "it": "Alla rotonda svolta a destra in Way Name",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_default.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_default.json
@@ -10,6 +10,7 @@
         "de": "Am Kreisverkehr scharf links",
         "en": "At the roundabout make a sharp left",
         "es": "En la rotonda siga cerrada a la izquierda",
+        "es-ES": "En la rotonda siga cerrada a la izquierda",
         "fr": "Au rond-point, tourner franchement à gauche",
         "id": "Di bundaran, lakukan tajam kiri",
         "it": "Alla rotonda fai una sinistra",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Am Kreisverkehr scharf links Richtung Destination 1",
         "en": "At the roundabout make a sharp left towards Destination 1",
         "es": "En la rotonda siga cerrada a la izquierda hacia Destination 1",
+        "es-ES": "En la rotonda siga cerrada a la izquierda hacia Destination 1",
         "fr": "Au rond-point, tourner franchement à gauche en direction de Destination 1",
         "id": "Di bundaran, lakukan tajam kiri menuju Destination 1",
         "it": "Alla rotonda fai una sinistra verso Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_exit.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Am Kreisverkehr scharf links auf Way Name",
         "en": "At the roundabout make a sharp left onto Way Name",
         "es": "En la rotonda siga cerrada a la izquierda en Way Name",
+        "es-ES": "En la rotonda siga cerrada a la izquierda por Way Name",
         "fr": "Au rond-point, tourner franchement à gauche sur Way Name",
         "id": "Di bundaran, lakukan tajam kiri ke arah Way Name",
         "it": "Alla rotonda fai una sinistra in Way Name",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Am Kreisverkehr scharf links Richtung Destination 1",
         "en": "At the roundabout make a sharp left towards Destination 1",
         "es": "En la rotonda siga cerrada a la izquierda hacia Destination 1",
+        "es-ES": "En la rotonda siga cerrada a la izquierda hacia Destination 1",
         "fr": "Au rond-point, tourner franchement à gauche en direction de Destination 1",
         "id": "Di bundaran, lakukan tajam kiri menuju Destination 1",
         "it": "Alla rotonda fai una sinistra verso Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_name.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_name.json
@@ -10,6 +10,7 @@
         "de": "Am Kreisverkehr scharf links auf Way Name",
         "en": "At the roundabout make a sharp left onto Way Name",
         "es": "En la rotonda siga cerrada a la izquierda en Way Name",
+        "es-ES": "En la rotonda siga cerrada a la izquierda por Way Name",
         "fr": "Au rond-point, tourner franchement à gauche sur Way Name",
         "id": "Di bundaran, lakukan tajam kiri ke arah Way Name",
         "it": "Alla rotonda fai una sinistra in Way Name",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_default.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_default.json
@@ -10,6 +10,7 @@
         "de": "Am Kreisverkehr scharf rechts",
         "en": "At the roundabout make a sharp right",
         "es": "En la rotonda siga cerrada a la derecha",
+        "es-ES": "En la rotonda siga cerrada a la derecha",
         "fr": "Au rond-point, tourner franchement à droite",
         "id": "Di bundaran, lakukan tajam kanan",
         "it": "Alla rotonda fai una destra",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Am Kreisverkehr scharf rechts Richtung Destination 1",
         "en": "At the roundabout make a sharp right towards Destination 1",
         "es": "En la rotonda siga cerrada a la derecha hacia Destination 1",
+        "es-ES": "En la rotonda siga cerrada a la derecha hacia Destination 1",
         "fr": "Au rond-point, tourner franchement à droite en direction de Destination 1",
         "id": "Di bundaran, lakukan tajam kanan menuju Destination 1",
         "it": "Alla rotonda fai una destra verso Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_exit.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Am Kreisverkehr scharf rechts auf Way Name",
         "en": "At the roundabout make a sharp right onto Way Name",
         "es": "En la rotonda siga cerrada a la derecha en Way Name",
+        "es-ES": "En la rotonda siga cerrada a la derecha por Way Name",
         "fr": "Au rond-point, tourner franchement à droite sur Way Name",
         "id": "Di bundaran, lakukan tajam kanan ke arah Way Name",
         "it": "Alla rotonda fai una destra in Way Name",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Am Kreisverkehr scharf rechts Richtung Destination 1",
         "en": "At the roundabout make a sharp right towards Destination 1",
         "es": "En la rotonda siga cerrada a la derecha hacia Destination 1",
+        "es-ES": "En la rotonda siga cerrada a la derecha hacia Destination 1",
         "fr": "Au rond-point, tourner franchement à droite en direction de Destination 1",
         "id": "Di bundaran, lakukan tajam kanan menuju Destination 1",
         "it": "Alla rotonda fai una destra verso Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_name.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_name.json
@@ -10,6 +10,7 @@
         "de": "Am Kreisverkehr scharf rechts auf Way Name",
         "en": "At the roundabout make a sharp right onto Way Name",
         "es": "En la rotonda siga cerrada a la derecha en Way Name",
+        "es-ES": "En la rotonda siga cerrada a la derecha por Way Name",
         "fr": "Au rond-point, tourner franchement à droite sur Way Name",
         "id": "Di bundaran, lakukan tajam kanan ke arah Way Name",
         "it": "Alla rotonda fai una destra in Way Name",

--- a/test/fixtures/v5/roundabout_turn/slight_left_default.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_default.json
@@ -10,6 +10,7 @@
         "de": "Am Kreisverkehr leicht links",
         "en": "At the roundabout make a slight left",
         "es": "En la rotonda siga ligeramente a la izquierda",
+        "es-ES": "En la rotonda siga ligeramente a la izquierda",
         "fr": "Au rond-point, tourner légèrement à gauche",
         "id": "Di bundaran, lakukan agak ke kiri",
         "it": "Alla rotonda fai una sinistra leggermente",

--- a/test/fixtures/v5/roundabout_turn/slight_left_destination.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Am Kreisverkehr leicht links Richtung Destination 1",
         "en": "At the roundabout make a slight left towards Destination 1",
         "es": "En la rotonda siga ligeramente a la izquierda hacia Destination 1",
+        "es-ES": "En la rotonda siga ligeramente a la izquierda hacia Destination 1",
         "fr": "Au rond-point, tourner légèrement à gauche en direction de Destination 1",
         "id": "Di bundaran, lakukan agak ke kiri menuju Destination 1",
         "it": "Alla rotonda fai una sinistra leggermente verso Destination 1",

--- a/test/fixtures/v5/roundabout_turn/slight_left_exit.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Am Kreisverkehr leicht links auf Way Name",
         "en": "At the roundabout make a slight left onto Way Name",
         "es": "En la rotonda siga ligeramente a la izquierda en Way Name",
+        "es-ES": "En la rotonda siga ligeramente a la izquierda por Way Name",
         "fr": "Au rond-point, tourner légèrement à gauche sur Way Name",
         "id": "Di bundaran, lakukan agak ke kiri ke arah Way Name",
         "it": "Alla rotonda fai una sinistra leggermente in Way Name",

--- a/test/fixtures/v5/roundabout_turn/slight_left_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Am Kreisverkehr leicht links Richtung Destination 1",
         "en": "At the roundabout make a slight left towards Destination 1",
         "es": "En la rotonda siga ligeramente a la izquierda hacia Destination 1",
+        "es-ES": "En la rotonda siga ligeramente a la izquierda hacia Destination 1",
         "fr": "Au rond-point, tourner légèrement à gauche en direction de Destination 1",
         "id": "Di bundaran, lakukan agak ke kiri menuju Destination 1",
         "it": "Alla rotonda fai una sinistra leggermente verso Destination 1",

--- a/test/fixtures/v5/roundabout_turn/slight_left_name.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_name.json
@@ -10,6 +10,7 @@
         "de": "Am Kreisverkehr leicht links auf Way Name",
         "en": "At the roundabout make a slight left onto Way Name",
         "es": "En la rotonda siga ligeramente a la izquierda en Way Name",
+        "es-ES": "En la rotonda siga ligeramente a la izquierda por Way Name",
         "fr": "Au rond-point, tourner légèrement à gauche sur Way Name",
         "id": "Di bundaran, lakukan agak ke kiri ke arah Way Name",
         "it": "Alla rotonda fai una sinistra leggermente in Way Name",

--- a/test/fixtures/v5/roundabout_turn/slight_right_default.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_default.json
@@ -10,6 +10,7 @@
         "de": "Am Kreisverkehr leicht rechts",
         "en": "At the roundabout make a slight right",
         "es": "En la rotonda siga ligeramente a la derecha",
+        "es-ES": "En la rotonda siga ligeramente a la derecha",
         "fr": "Au rond-point, tourner légèrement à droite",
         "id": "Di bundaran, lakukan agak ke kanan",
         "it": "Alla rotonda fai una destra leggermente",

--- a/test/fixtures/v5/roundabout_turn/slight_right_destination.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Am Kreisverkehr leicht rechts Richtung Destination 1",
         "en": "At the roundabout make a slight right towards Destination 1",
         "es": "En la rotonda siga ligeramente a la derecha hacia Destination 1",
+        "es-ES": "En la rotonda siga ligeramente a la derecha hacia Destination 1",
         "fr": "Au rond-point, tourner légèrement à droite en direction de Destination 1",
         "id": "Di bundaran, lakukan agak ke kanan menuju Destination 1",
         "it": "Alla rotonda fai una destra leggermente verso Destination 1",

--- a/test/fixtures/v5/roundabout_turn/slight_right_exit.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Am Kreisverkehr leicht rechts auf Way Name",
         "en": "At the roundabout make a slight right onto Way Name",
         "es": "En la rotonda siga ligeramente a la derecha en Way Name",
+        "es-ES": "En la rotonda siga ligeramente a la derecha por Way Name",
         "fr": "Au rond-point, tourner légèrement à droite sur Way Name",
         "id": "Di bundaran, lakukan agak ke kanan ke arah Way Name",
         "it": "Alla rotonda fai una destra leggermente in Way Name",

--- a/test/fixtures/v5/roundabout_turn/slight_right_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Am Kreisverkehr leicht rechts Richtung Destination 1",
         "en": "At the roundabout make a slight right towards Destination 1",
         "es": "En la rotonda siga ligeramente a la derecha hacia Destination 1",
+        "es-ES": "En la rotonda siga ligeramente a la derecha hacia Destination 1",
         "fr": "Au rond-point, tourner légèrement à droite en direction de Destination 1",
         "id": "Di bundaran, lakukan agak ke kanan menuju Destination 1",
         "it": "Alla rotonda fai una destra leggermente verso Destination 1",

--- a/test/fixtures/v5/roundabout_turn/slight_right_name.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_name.json
@@ -10,6 +10,7 @@
         "de": "Am Kreisverkehr leicht rechts auf Way Name",
         "en": "At the roundabout make a slight right onto Way Name",
         "es": "En la rotonda siga ligeramente a la derecha en Way Name",
+        "es-ES": "En la rotonda siga ligeramente a la derecha por Way Name",
         "fr": "Au rond-point, tourner légèrement à droite sur Way Name",
         "id": "Di bundaran, lakukan agak ke kanan ke arah Way Name",
         "it": "Alla rotonda fai una destra leggermente in Way Name",

--- a/test/fixtures/v5/roundabout_turn/straight_default.json
+++ b/test/fixtures/v5/roundabout_turn/straight_default.json
@@ -10,6 +10,7 @@
         "de": "Am Kreisverkehr geradeaus weiterfahren",
         "en": "At the roundabout continue straight",
         "es": "En la rotonda continúe recto",
+        "es-ES": "En la rotonda continúa recto",
         "fr": "Au rond-point, continuer tout droit",
         "id": "Di bundaran tetap lurus",
         "it": "Alla rotonda prosegui dritto",

--- a/test/fixtures/v5/roundabout_turn/straight_destination.json
+++ b/test/fixtures/v5/roundabout_turn/straight_destination.json
@@ -11,6 +11,7 @@
         "de": "Am Kreisverkehr geradeaus weiterfahren Richtung Destination 1",
         "en": "At the roundabout continue straight towards Destination 1",
         "es": "En la rotonda continúe recto hacia Destination 1",
+        "es-ES": "En la rotonda continúa recto hacia Destination 1",
         "fr": "Au rond-point, continuer tout droit en direction de Destination 1",
         "id": "Di bundaran tetap lurus menuju Destination 1",
         "it": "Alla rotonda prosegui dritto verso Destination 1",

--- a/test/fixtures/v5/roundabout_turn/straight_exit.json
+++ b/test/fixtures/v5/roundabout_turn/straight_exit.json
@@ -11,6 +11,7 @@
         "de": "Am Kreisverkehr geradeaus weiterfahren auf Way Name",
         "en": "At the roundabout continue straight onto Way Name",
         "es": "En la rotonda continúe recto en Way Name",
+        "es-ES": "En la rotonda continúa recto por Way Name",
         "fr": "Au rond-point, continuer tout droit sur Way Name",
         "id": "Di bundaran tetap lurus ke arah Way Name",
         "it": "Alla rotonda prosegui dritto in Way Name",

--- a/test/fixtures/v5/roundabout_turn/straight_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/straight_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Am Kreisverkehr geradeaus weiterfahren Richtung Destination 1",
         "en": "At the roundabout continue straight towards Destination 1",
         "es": "En la rotonda continúe recto hacia Destination 1",
+        "es-ES": "En la rotonda continúa recto hacia Destination 1",
         "fr": "Au rond-point, continuer tout droit en direction de Destination 1",
         "id": "Di bundaran tetap lurus menuju Destination 1",
         "it": "Alla rotonda prosegui dritto verso Destination 1",

--- a/test/fixtures/v5/roundabout_turn/straight_name.json
+++ b/test/fixtures/v5/roundabout_turn/straight_name.json
@@ -10,6 +10,7 @@
         "de": "Am Kreisverkehr geradeaus weiterfahren auf Way Name",
         "en": "At the roundabout continue straight onto Way Name",
         "es": "En la rotonda continúe recto en Way Name",
+        "es-ES": "En la rotonda continúa recto por Way Name",
         "fr": "Au rond-point, continuer tout droit sur Way Name",
         "id": "Di bundaran tetap lurus ke arah Way Name",
         "it": "Alla rotonda prosegui dritto in Way Name",

--- a/test/fixtures/v5/roundabout_turn/uturn_default.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_default.json
@@ -10,6 +10,7 @@
         "de": "Am Kreisverkehr 180°-Wendung",
         "en": "At the roundabout make a U-turn",
         "es": "En la rotonda siga cambio de sentido",
+        "es-ES": "En la rotonda siga cambio de sentido",
         "fr": "Au rond-point, tourner demi-tour",
         "id": "Di bundaran, lakukan putar balik",
         "it": "Alla rotonda fai una inversione a U",

--- a/test/fixtures/v5/roundabout_turn/uturn_destination.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_destination.json
@@ -11,6 +11,7 @@
         "de": "Am Kreisverkehr 180°-Wendung Richtung Destination 1",
         "en": "At the roundabout make a U-turn towards Destination 1",
         "es": "En la rotonda siga cambio de sentido hacia Destination 1",
+        "es-ES": "En la rotonda siga cambio de sentido hacia Destination 1",
         "fr": "Au rond-point, tourner demi-tour en direction de Destination 1",
         "id": "Di bundaran, lakukan putar balik menuju Destination 1",
         "it": "Alla rotonda fai una inversione a U verso Destination 1",

--- a/test/fixtures/v5/roundabout_turn/uturn_exit.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_exit.json
@@ -11,6 +11,7 @@
         "de": "Am Kreisverkehr 180°-Wendung auf Way Name",
         "en": "At the roundabout make a U-turn onto Way Name",
         "es": "En la rotonda siga cambio de sentido en Way Name",
+        "es-ES": "En la rotonda siga cambio de sentido por Way Name",
         "fr": "Au rond-point, tourner demi-tour sur Way Name",
         "id": "Di bundaran, lakukan putar balik ke arah Way Name",
         "it": "Alla rotonda fai una inversione a U in Way Name",

--- a/test/fixtures/v5/roundabout_turn/uturn_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Am Kreisverkehr 180°-Wendung Richtung Destination 1",
         "en": "At the roundabout make a U-turn towards Destination 1",
         "es": "En la rotonda siga cambio de sentido hacia Destination 1",
+        "es-ES": "En la rotonda siga cambio de sentido hacia Destination 1",
         "fr": "Au rond-point, tourner demi-tour en direction de Destination 1",
         "id": "Di bundaran, lakukan putar balik menuju Destination 1",
         "it": "Alla rotonda fai una inversione a U verso Destination 1",

--- a/test/fixtures/v5/roundabout_turn/uturn_name.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_name.json
@@ -10,6 +10,7 @@
         "de": "Am Kreisverkehr 180°-Wendung auf Way Name",
         "en": "At the roundabout make a U-turn onto Way Name",
         "es": "En la rotonda siga cambio de sentido en Way Name",
+        "es-ES": "En la rotonda siga cambio de sentido por Way Name",
         "fr": "Au rond-point, tourner demi-tour sur Way Name",
         "id": "Di bundaran, lakukan putar balik ke arah Way Name",
         "it": "Alla rotonda fai una inversione a U in Way Name",

--- a/test/fixtures/v5/turn/left_default.json
+++ b/test/fixtures/v5/turn/left_default.json
@@ -10,6 +10,7 @@
         "de": "Links abbiegen",
         "en": "Turn left",
         "es": "Gire a la izquierda",
+        "es-ES": "Gira a la izquierda",
         "fr": "Tourner à gauche",
         "id": "Belok kiri",
         "it": "Svolta a sinistra",

--- a/test/fixtures/v5/turn/left_destination.json
+++ b/test/fixtures/v5/turn/left_destination.json
@@ -11,6 +11,7 @@
         "de": "Links abbiegen Richtung Destination 1",
         "en": "Turn left towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Gira a la izquierda hacia Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "id": "Belok kiri menuju Destination 1",
         "it": "Svolta a sinistra verso Destination 1",

--- a/test/fixtures/v5/turn/left_exit.json
+++ b/test/fixtures/v5/turn/left_exit.json
@@ -11,6 +11,7 @@
         "de": "Links abbiegen auf Way Name",
         "en": "Turn left onto Way Name",
         "es": "Gire a la izquierda en Way Name",
+        "es-ES": "Gira a la izquierda por Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "id": "Belok kiri ke Way Name",
         "it": "Svolta a sinistra in Way Name",

--- a/test/fixtures/v5/turn/left_exit_destination.json
+++ b/test/fixtures/v5/turn/left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Links abbiegen Richtung Destination 1",
         "en": "Turn left towards Destination 1",
         "es": "Gire a la izquierda hacia Destination 1",
+        "es-ES": "Gira a la izquierda hacia Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "id": "Belok kiri menuju Destination 1",
         "it": "Svolta a sinistra verso Destination 1",

--- a/test/fixtures/v5/turn/left_name.json
+++ b/test/fixtures/v5/turn/left_name.json
@@ -10,6 +10,7 @@
         "de": "Links abbiegen auf Way Name",
         "en": "Turn left onto Way Name",
         "es": "Gire a la izquierda en Way Name",
+        "es-ES": "Gira a la izquierda por Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "id": "Belok kiri ke Way Name",
         "it": "Svolta a sinistra in Way Name",

--- a/test/fixtures/v5/turn/right_default.json
+++ b/test/fixtures/v5/turn/right_default.json
@@ -10,6 +10,7 @@
         "de": "Rechts abbiegen",
         "en": "Turn right",
         "es": "Gire a la derecha",
+        "es-ES": "Gira a la derecha",
         "fr": "Tourner à droite",
         "id": "Belok kanan",
         "it": "Gira a destra",

--- a/test/fixtures/v5/turn/right_destination.json
+++ b/test/fixtures/v5/turn/right_destination.json
@@ -11,6 +11,7 @@
         "de": "Rechts abbiegen Richtung Destination 1",
         "en": "Turn right towards Destination 1",
         "es": "Gire a la derecha hacia Destination 1",
+        "es-ES": "Gira a la derecha hacia Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "id": "Belok kanan menuju Destination 1",
         "it": "Svolta a destra verso Destination 1",

--- a/test/fixtures/v5/turn/right_exit.json
+++ b/test/fixtures/v5/turn/right_exit.json
@@ -11,6 +11,7 @@
         "de": "Rechts abbiegen auf Way Name",
         "en": "Turn right onto Way Name",
         "es": "Gire a la derecha en Way Name",
+        "es-ES": "Gira a la derecha por Way Name",
         "fr": "Tourner à droite sur Way Name",
         "id": "Belok kanan ke Way Name",
         "it": "Svolta a destra in Way Name",

--- a/test/fixtures/v5/turn/right_exit_destination.json
+++ b/test/fixtures/v5/turn/right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Rechts abbiegen Richtung Destination 1",
         "en": "Turn right towards Destination 1",
         "es": "Gire a la derecha hacia Destination 1",
+        "es-ES": "Gira a la derecha hacia Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "id": "Belok kanan menuju Destination 1",
         "it": "Svolta a destra verso Destination 1",

--- a/test/fixtures/v5/turn/right_name.json
+++ b/test/fixtures/v5/turn/right_name.json
@@ -10,6 +10,7 @@
         "de": "Rechts abbiegen auf Way Name",
         "en": "Turn right onto Way Name",
         "es": "Gire a la derecha en Way Name",
+        "es-ES": "Gira a la derecha por Way Name",
         "fr": "Tourner à droite sur Way Name",
         "id": "Belok kanan ke Way Name",
         "it": "Svolta a destra in Way Name",

--- a/test/fixtures/v5/turn/sharp_left_default.json
+++ b/test/fixtures/v5/turn/sharp_left_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf links abbiegen",
         "en": "Make a sharp left",
         "es": "Siga cerrada a la izquierda",
+        "es-ES": "Gira cerrada a la izquierda",
         "fr": "Tourner franchement à gauche",
         "id": "Lakukan tajam kiri",
         "it": "Fai una sinistra",

--- a/test/fixtures/v5/turn/sharp_left_destination.json
+++ b/test/fixtures/v5/turn/sharp_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf links abbiegen Richtung Destination 1",
         "en": "Make a sharp left towards Destination 1",
         "es": "Siga cerrada a la izquierda hacia Destination 1",
+        "es-ES": "Gira cerrada a la izquierda hacia Destination 1",
         "fr": "Tourner franchement à gauche en direction de Destination 1",
         "id": "Lakukan tajam kiri menuju Destination 1",
         "it": "Fai una sinistra verso Destination 1",

--- a/test/fixtures/v5/turn/sharp_left_exit.json
+++ b/test/fixtures/v5/turn/sharp_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf links abbiegen auf Way Name",
         "en": "Make a sharp left onto Way Name",
         "es": "Siga cerrada a la izquierda en Way Name",
+        "es-ES": "Gira cerrada a la izquierda por Way Name",
         "fr": "Tourner franchement à gauche sur Way Name",
         "id": "Lakukan tajam kiri ke arah Way Name",
         "it": "Fai una sinistra in Way Name",

--- a/test/fixtures/v5/turn/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/turn/sharp_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf links abbiegen Richtung Destination 1",
         "en": "Make a sharp left towards Destination 1",
         "es": "Siga cerrada a la izquierda hacia Destination 1",
+        "es-ES": "Gira cerrada a la izquierda hacia Destination 1",
         "fr": "Tourner franchement à gauche en direction de Destination 1",
         "id": "Lakukan tajam kiri menuju Destination 1",
         "it": "Fai una sinistra verso Destination 1",

--- a/test/fixtures/v5/turn/sharp_left_name.json
+++ b/test/fixtures/v5/turn/sharp_left_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf links abbiegen auf Way Name",
         "en": "Make a sharp left onto Way Name",
         "es": "Siga cerrada a la izquierda en Way Name",
+        "es-ES": "Gira cerrada a la izquierda por Way Name",
         "fr": "Tourner franchement à gauche sur Way Name",
         "id": "Lakukan tajam kiri ke arah Way Name",
         "it": "Fai una sinistra in Way Name",

--- a/test/fixtures/v5/turn/sharp_right_default.json
+++ b/test/fixtures/v5/turn/sharp_right_default.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts abbiegen",
         "en": "Make a sharp right",
         "es": "Siga cerrada a la derecha",
+        "es-ES": "Gira cerrada a la derecha",
         "fr": "Tourner franchement à droite",
         "id": "Lakukan tajam kanan",
         "it": "Fai una destra",

--- a/test/fixtures/v5/turn/sharp_right_destination.json
+++ b/test/fixtures/v5/turn/sharp_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts abbiegen Richtung Destination 1",
         "en": "Make a sharp right towards Destination 1",
         "es": "Siga cerrada a la derecha hacia Destination 1",
+        "es-ES": "Gira cerrada a la derecha hacia Destination 1",
         "fr": "Tourner franchement à droite en direction de Destination 1",
         "id": "Lakukan tajam kanan menuju Destination 1",
         "it": "Fai una destra verso Destination 1",

--- a/test/fixtures/v5/turn/sharp_right_exit.json
+++ b/test/fixtures/v5/turn/sharp_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Scharf rechts abbiegen auf Way Name",
         "en": "Make a sharp right onto Way Name",
         "es": "Siga cerrada a la derecha en Way Name",
+        "es-ES": "Gira cerrada a la derecha por Way Name",
         "fr": "Tourner franchement à droite sur Way Name",
         "id": "Lakukan tajam kanan ke arah Way Name",
         "it": "Fai una destra in Way Name",

--- a/test/fixtures/v5/turn/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/turn/sharp_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Scharf rechts abbiegen Richtung Destination 1",
         "en": "Make a sharp right towards Destination 1",
         "es": "Siga cerrada a la derecha hacia Destination 1",
+        "es-ES": "Gira cerrada a la derecha hacia Destination 1",
         "fr": "Tourner franchement à droite en direction de Destination 1",
         "id": "Lakukan tajam kanan menuju Destination 1",
         "it": "Fai una destra verso Destination 1",

--- a/test/fixtures/v5/turn/sharp_right_name.json
+++ b/test/fixtures/v5/turn/sharp_right_name.json
@@ -10,6 +10,7 @@
         "de": "Scharf rechts abbiegen auf Way Name",
         "en": "Make a sharp right onto Way Name",
         "es": "Siga cerrada a la derecha en Way Name",
+        "es-ES": "Gira cerrada a la derecha por Way Name",
         "fr": "Tourner franchement à droite sur Way Name",
         "id": "Lakukan tajam kanan ke arah Way Name",
         "it": "Fai una destra in Way Name",

--- a/test/fixtures/v5/turn/slight_left_default.json
+++ b/test/fixtures/v5/turn/slight_left_default.json
@@ -10,6 +10,7 @@
         "de": "Leicht links abbiegen",
         "en": "Make a slight left",
         "es": "Siga ligeramente a la izquierda",
+        "es-ES": "Gira ligeramente a la izquierda",
         "fr": "Tourner légèrement à gauche",
         "id": "Lakukan agak ke kiri",
         "it": "Fai una sinistra leggermente",

--- a/test/fixtures/v5/turn/slight_left_destination.json
+++ b/test/fixtures/v5/turn/slight_left_destination.json
@@ -11,6 +11,7 @@
         "de": "Leicht links abbiegen Richtung Destination 1",
         "en": "Make a slight left towards Destination 1",
         "es": "Siga ligeramente a la izquierda hacia Destination 1",
+        "es-ES": "Gira ligeramente a la izquierda hacia Destination 1",
         "fr": "Tourner légèrement à gauche en direction de Destination 1",
         "id": "Lakukan agak ke kiri menuju Destination 1",
         "it": "Fai una sinistra leggermente verso Destination 1",

--- a/test/fixtures/v5/turn/slight_left_exit.json
+++ b/test/fixtures/v5/turn/slight_left_exit.json
@@ -11,6 +11,7 @@
         "de": "Leicht links abbiegen auf Way Name",
         "en": "Make a slight left onto Way Name",
         "es": "Siga ligeramente a la izquierda en Way Name",
+        "es-ES": "Gira ligeramente a la izquierda por Way Name",
         "fr": "Tourner légèrement à gauche sur Way Name",
         "id": "Lakukan agak ke kiri ke arah Way Name",
         "it": "Fai una sinistra leggermente in Way Name",

--- a/test/fixtures/v5/turn/slight_left_exit_destination.json
+++ b/test/fixtures/v5/turn/slight_left_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Leicht links abbiegen Richtung Destination 1",
         "en": "Make a slight left towards Destination 1",
         "es": "Siga ligeramente a la izquierda hacia Destination 1",
+        "es-ES": "Gira ligeramente a la izquierda hacia Destination 1",
         "fr": "Tourner légèrement à gauche en direction de Destination 1",
         "id": "Lakukan agak ke kiri menuju Destination 1",
         "it": "Fai una sinistra leggermente verso Destination 1",

--- a/test/fixtures/v5/turn/slight_left_name.json
+++ b/test/fixtures/v5/turn/slight_left_name.json
@@ -10,6 +10,7 @@
         "de": "Leicht links abbiegen auf Way Name",
         "en": "Make a slight left onto Way Name",
         "es": "Siga ligeramente a la izquierda en Way Name",
+        "es-ES": "Gira ligeramente a la izquierda por Way Name",
         "fr": "Tourner légèrement à gauche sur Way Name",
         "id": "Lakukan agak ke kiri ke arah Way Name",
         "it": "Fai una sinistra leggermente in Way Name",

--- a/test/fixtures/v5/turn/slight_right_default.json
+++ b/test/fixtures/v5/turn/slight_right_default.json
@@ -10,6 +10,7 @@
         "de": "Leicht rechts abbiegen",
         "en": "Make a slight right",
         "es": "Siga ligeramente a la derecha",
+        "es-ES": "Gira ligeramente a la derecha",
         "fr": "Tourner légèrement à droite",
         "id": "Lakukan agak ke kanan",
         "it": "Fai una destra leggermente",

--- a/test/fixtures/v5/turn/slight_right_destination.json
+++ b/test/fixtures/v5/turn/slight_right_destination.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts abbiegen Richtung Destination 1",
         "en": "Make a slight right towards Destination 1",
         "es": "Siga ligeramente a la derecha hacia Destination 1",
+        "es-ES": "Gira ligeramente a la derecha hacia Destination 1",
         "fr": "Tourner légèrement à droite en direction de Destination 1",
         "id": "Lakukan agak ke kanan menuju Destination 1",
         "it": "Fai una destra leggermente verso Destination 1",

--- a/test/fixtures/v5/turn/slight_right_exit.json
+++ b/test/fixtures/v5/turn/slight_right_exit.json
@@ -11,6 +11,7 @@
         "de": "Leicht rechts abbiegen auf Way Name",
         "en": "Make a slight right onto Way Name",
         "es": "Siga ligeramente a la derecha en Way Name",
+        "es-ES": "Gira ligeramente a la derecha por Way Name",
         "fr": "Tourner légèrement à droite sur Way Name",
         "id": "Lakukan agak ke kanan ke arah Way Name",
         "it": "Fai una destra leggermente in Way Name",

--- a/test/fixtures/v5/turn/slight_right_exit_destination.json
+++ b/test/fixtures/v5/turn/slight_right_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Leicht rechts abbiegen Richtung Destination 1",
         "en": "Make a slight right towards Destination 1",
         "es": "Siga ligeramente a la derecha hacia Destination 1",
+        "es-ES": "Gira ligeramente a la derecha hacia Destination 1",
         "fr": "Tourner légèrement à droite en direction de Destination 1",
         "id": "Lakukan agak ke kanan menuju Destination 1",
         "it": "Fai una destra leggermente verso Destination 1",

--- a/test/fixtures/v5/turn/slight_right_name.json
+++ b/test/fixtures/v5/turn/slight_right_name.json
@@ -10,6 +10,7 @@
         "de": "Leicht rechts abbiegen auf Way Name",
         "en": "Make a slight right onto Way Name",
         "es": "Siga ligeramente a la derecha en Way Name",
+        "es-ES": "Gira ligeramente a la derecha por Way Name",
         "fr": "Tourner légèrement à droite sur Way Name",
         "id": "Lakukan agak ke kanan ke arah Way Name",
         "it": "Fai una destra leggermente in Way Name",

--- a/test/fixtures/v5/turn/straight_default.json
+++ b/test/fixtures/v5/turn/straight_default.json
@@ -10,6 +10,7 @@
         "de": "Geradeaus weiterfahren",
         "en": "Go straight",
         "es": "Ve recto",
+        "es-ES": "Continúa recto",
         "fr": "Aller tout droit",
         "id": "Lurus",
         "it": "Prosegui dritto",

--- a/test/fixtures/v5/turn/straight_destination.json
+++ b/test/fixtures/v5/turn/straight_destination.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus weiterfahren Richtung Destination 1",
         "en": "Go straight towards Destination 1",
         "es": "Ve recto hacia Destination 1",
+        "es-ES": "Continúa recto hacia Destination 1",
         "fr": "Aller tout droit en direction de Destination 1",
         "id": "Lurus menuju Destination 1",
         "it": "Continua verso Destination 1",

--- a/test/fixtures/v5/turn/straight_exit.json
+++ b/test/fixtures/v5/turn/straight_exit.json
@@ -11,6 +11,7 @@
         "de": "Geradeaus weiterfahren auf Way Name",
         "en": "Go straight onto Way Name",
         "es": "Ve recto en Way Name",
+        "es-ES": "Continúa recto por Way Name",
         "fr": "Aller tout droit sur Way Name",
         "id": "Lurus arah Way Name",
         "it": "Continua su Way Name",

--- a/test/fixtures/v5/turn/straight_exit_destination.json
+++ b/test/fixtures/v5/turn/straight_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "Geradeaus weiterfahren Richtung Destination 1",
         "en": "Go straight towards Destination 1",
         "es": "Ve recto hacia Destination 1",
+        "es-ES": "Continúa recto hacia Destination 1",
         "fr": "Aller tout droit en direction de Destination 1",
         "id": "Lurus menuju Destination 1",
         "it": "Continua verso Destination 1",

--- a/test/fixtures/v5/turn/straight_name.json
+++ b/test/fixtures/v5/turn/straight_name.json
@@ -10,6 +10,7 @@
         "de": "Geradeaus weiterfahren auf Way Name",
         "en": "Go straight onto Way Name",
         "es": "Ve recto en Way Name",
+        "es-ES": "Continúa recto por Way Name",
         "fr": "Aller tout droit sur Way Name",
         "id": "Lurus arah Way Name",
         "it": "Continua su Way Name",

--- a/test/fixtures/v5/turn/uturn_default.json
+++ b/test/fixtures/v5/turn/uturn_default.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung abbiegen",
         "en": "Make a U-turn",
         "es": "Siga cambio de sentido",
+        "es-ES": "Gira cambio de sentido",
         "fr": "Tourner demi-tour",
         "id": "Lakukan putar balik",
         "it": "Fai una inversione a U",

--- a/test/fixtures/v5/turn/uturn_destination.json
+++ b/test/fixtures/v5/turn/uturn_destination.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung abbiegen Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
         "es": "Siga cambio de sentido hacia Destination 1",
+        "es-ES": "Gira cambio de sentido hacia Destination 1",
         "fr": "Tourner demi-tour en direction de Destination 1",
         "id": "Lakukan putar balik menuju Destination 1",
         "it": "Fai una inversione a U verso Destination 1",

--- a/test/fixtures/v5/turn/uturn_exit.json
+++ b/test/fixtures/v5/turn/uturn_exit.json
@@ -11,6 +11,7 @@
         "de": "180°-Wendung abbiegen auf Way Name",
         "en": "Make a U-turn onto Way Name",
         "es": "Siga cambio de sentido en Way Name",
+        "es-ES": "Gira cambio de sentido por Way Name",
         "fr": "Tourner demi-tour sur Way Name",
         "id": "Lakukan putar balik ke arah Way Name",
         "it": "Fai una inversione a U in Way Name",

--- a/test/fixtures/v5/turn/uturn_exit_destination.json
+++ b/test/fixtures/v5/turn/uturn_exit_destination.json
@@ -12,6 +12,7 @@
         "de": "180°-Wendung abbiegen Richtung Destination 1",
         "en": "Make a U-turn towards Destination 1",
         "es": "Siga cambio de sentido hacia Destination 1",
+        "es-ES": "Gira cambio de sentido hacia Destination 1",
         "fr": "Tourner demi-tour en direction de Destination 1",
         "id": "Lakukan putar balik menuju Destination 1",
         "it": "Fai una inversione a U verso Destination 1",

--- a/test/fixtures/v5/turn/uturn_name.json
+++ b/test/fixtures/v5/turn/uturn_name.json
@@ -10,6 +10,7 @@
         "de": "180°-Wendung abbiegen auf Way Name",
         "en": "Make a U-turn onto Way Name",
         "es": "Siga cambio de sentido en Way Name",
+        "es-ES": "Gira cambio de sentido por Way Name",
         "fr": "Tourner demi-tour sur Way Name",
         "id": "Lakukan putar balik ke arah Way Name",
         "it": "Fai una inversione a U in Way Name",

--- a/test/fixtures/v5/use_lane/o.json
+++ b/test/fixtures/v5/use_lane/o.json
@@ -36,6 +36,7 @@
         "de": "Geradeaus weiterfahren",
         "en": "Continue straight",
         "es": "Continúe recto",
+        "es-ES": "Continúa recto",
         "fr": "Continuer tout droit",
         "id": "Lurus terus",
         "it": "Continua dritto",

--- a/test/fixtures/v5/use_lane/ooo.json
+++ b/test/fixtures/v5/use_lane/ooo.json
@@ -48,6 +48,7 @@
         "de": "Geradeaus weiterfahren",
         "en": "Continue straight",
         "es": "Continúe recto",
+        "es-ES": "Continúa recto",
         "fr": "Continuer tout droit",
         "id": "Lurus terus",
         "it": "Continua dritto",

--- a/test/fixtures/v5/use_lane/oooxxo.json
+++ b/test/fixtures/v5/use_lane/oooxxo.json
@@ -66,6 +66,7 @@
         "de": "Rechts oder links halten",
         "en": "Keep left or right",
         "es": "Mantengase a la izquierda o derecha",
+        "es-ES": "Mantente a la izquierda o a la derecha",
         "fr": "Rester à gauche ou à droite",
         "id": "Tetap di kiri atau kanan",
         "it": "Mantieni la destra o la sinistra",

--- a/test/fixtures/v5/use_lane/oox.json
+++ b/test/fixtures/v5/use_lane/oox.json
@@ -48,6 +48,7 @@
         "de": "Links halten",
         "en": "Keep left",
         "es": "Mantengase a la izquierda",
+        "es-ES": "Mantente a la izquierda",
         "fr": "Serrer à gauche",
         "id": "Tetap di kiri",
         "it": "Mantieni la sinistra",

--- a/test/fixtures/v5/use_lane/ooxx.json
+++ b/test/fixtures/v5/use_lane/ooxx.json
@@ -54,6 +54,7 @@
         "de": "Links halten",
         "en": "Keep left",
         "es": "Mantengase a la izquierda",
+        "es-ES": "Mantente a la izquierda",
         "fr": "Serrer à gauche",
         "id": "Tetap di kiri",
         "it": "Mantieni la sinistra",

--- a/test/fixtures/v5/use_lane/oxo.json
+++ b/test/fixtures/v5/use_lane/oxo.json
@@ -48,6 +48,7 @@
         "de": "Rechts oder links halten",
         "en": "Keep left or right",
         "es": "Mantengase a la izquierda o derecha",
+        "es-ES": "Mantente a la izquierda o a la derecha",
         "fr": "Rester à gauche ou à droite",
         "id": "Tetap di kiri atau kanan",
         "it": "Mantieni la destra o la sinistra",

--- a/test/fixtures/v5/use_lane/xoo.json
+++ b/test/fixtures/v5/use_lane/xoo.json
@@ -48,6 +48,7 @@
         "de": "Rechts halten",
         "en": "Keep right",
         "es": "Mantengase a la derecha",
+        "es-ES": "Mantente a la derecha",
         "fr": "Serrer à droite",
         "id": "Tetap di kanan",
         "it": "Mantieni la destra",

--- a/test/fixtures/v5/use_lane/xox.json
+++ b/test/fixtures/v5/use_lane/xox.json
@@ -48,6 +48,7 @@
         "de": "Mittlere Spur nutzen",
         "en": "Keep in the middle",
         "es": "Mantengase en el medio",
+        "es-ES": "Mantente en el medio",
         "fr": "Rester au milieu",
         "id": "Tetap di tengah",
         "it": "Rimani in mezzo",

--- a/test/fixtures/v5/use_lane/xxoo.json
+++ b/test/fixtures/v5/use_lane/xxoo.json
@@ -54,6 +54,7 @@
         "de": "Rechts halten",
         "en": "Keep right",
         "es": "Mantengase a la derecha",
+        "es-ES": "Mantente a la derecha",
         "fr": "Serrer à droite",
         "id": "Tetap di kanan",
         "it": "Mantieni la destra",

--- a/test/fixtures/v5/use_lane/xxooxx.json
+++ b/test/fixtures/v5/use_lane/xxooxx.json
@@ -66,6 +66,7 @@
         "de": "Mittlere Spur nutzen",
         "en": "Keep in the middle",
         "es": "Mantengase en el medio",
+        "es-ES": "Mantente en el medio",
         "fr": "Rester au milieu",
         "id": "Tetap di tengah",
         "it": "Rimani in mezzo",

--- a/test/fixtures/v5/use_lane/xxoxo.json
+++ b/test/fixtures/v5/use_lane/xxoxo.json
@@ -60,6 +60,7 @@
         "de": "Geradeaus weiterfahren",
         "en": "Continue straight",
         "es": "Continúe recto",
+        "es-ES": "Continúa recto",
         "fr": "Continuer tout droit",
         "id": "Lurus terus",
         "it": "Continua dritto",


### PR DESCRIPTION
Pulled in the 100% complete Castilian Spanish localization from Transifex.

@Sealos, can you check the test fixtures to make sure the generated strings match your expectations? You might also want to compare the Castilian Spanish translations to the generic Spanish translations, which would primarily be shown to Latin American Spanish speakers. ¡Muchas gracias!

/ref #161
/cc @Guardiola31337