### PR TITLE
Respect locale when capitalizing

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ module.exports = function(version, _options) {
     });
 
     return {
-        capitalizeFirstLetter: function(string) {
-            return string.charAt(0).toUpperCase() + string.slice(1);
+        capitalizeFirstLetter: function(language, string) {
+            return string.charAt(0).toLocaleUpperCase(language) + string.slice(1);
         },
         ordinalize: function(language, number) {
             // Transform numbers to their translated ordinalized value
@@ -206,7 +206,7 @@ module.exports = function(version, _options) {
             .replace(/ {2}/g, ' '); // remove excess spaces
 
             if (instructions[language].meta.capitalizeFirstLetter) {
-                return this.capitalizeFirstLetter(output);
+                return this.capitalizeFirstLetter(language, output);
             }
 
             return output;


### PR DESCRIPTION
#158 added a localization in Turkish, which has capitalization rules that differ from the C locale used by `String.prototype.toUpperCase()`. This change uses [`String.prototype.toLocaleUpperCase()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase) to respect the instruction language’s capitalization rules.

A number of strings in the Turkish localization are affected because a token appears at the beginning of the string. For example, this change:

```diff
diff --git a/test/fixtures/v5/arrive_waypoint/left.json b/test/fixtures/v5/arrive_waypoint/left.json
index 4723017..6e8752c 100644
--- a/test/fixtures/v5/arrive_waypoint/left.json
+++ b/test/fixtures/v5/arrive_waypoint/left.json
@@ -25,7 +25,7 @@
         "zh-Hans": "您已经到达您的第一个目的地，在道路左侧"
     },
     "options": {
-        "legIndex": 0,
-        "legCount": 2
+        "legIndex": 1,
+        "legCount": 3
     }
 }
```

causes `{nth}` to be replaced by “ikinci”. When capitalized, the output string now becomes:

> İkinci hedefinize ulaştınız, hedefiniz solunuzdadır

rather than this misspelling (which is thus mispronounced):

> Ikinci hedefinize ulaştınız, hedefiniz solunuzdadır

/cc @malte777 @allierowan @mcwhittemore