### PR TITLE
expose getWayName from compile for other use cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. For change 
 ## master
 
 - Added grammatical cases support for Russian way names [#102](https://github.com/Project-OSRM/osrm-text-instructions/pull/102)
+- Adds `osrmti.getWayName` to the public api. You MUST NOT change the result before passing it into `osrmti.tokenize`. [#167](https://github.com/Project-OSRM/osrm-text-instructions/pull/167)
 
 ## 0.7.1 2017-09-26
 

--- a/index.js
+++ b/index.js
@@ -69,6 +69,45 @@ module.exports = function(version, _options) {
 
             return config.join('');
         },
+        getWayName: function(language, step, options) {
+            var classes = options ? options.classes || [] : [];
+            if (typeof step !== 'object') throw new Error('step must be an Object');
+            if (!Array.isArray(classes)) throw new Error('classes must be an Array or undefined');
+
+            var wayName;
+            var name = step.name || '';
+            var ref = (step.ref || '').split(';')[0];
+
+            // Remove hacks from Mapbox Directions mixing ref into name
+            if (name === step.ref) {
+                // if both are the same we assume that there used to be an empty name, with the ref being filled in for it
+                // we only need to retain the ref then
+                name = '';
+            }
+            name = name.replace(' (' + step.ref + ')', '');
+
+            // In attempt to avoid using the highway name of a way,
+            // check and see if the step has a class which should signal
+            // the ref should be used instead of the name.
+            var wayMotorway = classes.indexOf('motorway') !== -1;
+
+            if (name && ref && name !== ref && !wayMotorway) {
+                var phrase = instructions[language][version].phrase['name and ref'] ||
+                    instructions.en[version].phrase['name and ref'];
+                wayName = this.tokenize(language, phrase, {
+                    name: name,
+                    ref: ref
+                });
+            } else if (name && ref && wayMotorway && (/\d/).test(ref)) {
+                wayName = ref;
+            } else if (!name && ref) {
+                wayName = ref;
+            } else {
+                wayName = name;
+            }
+
+            return wayName;
+        },
         compile: function(language, step, options) {
             if (!language) throw new Error('No language code provided');
             if (languages.supportedCodes.indexOf(language) === -1) throw new Error('language code ' + language + ' not loaded');
@@ -127,40 +166,7 @@ module.exports = function(version, _options) {
             }
 
             // Decide way_name with special handling for name and ref
-            var wayName;
-            var name = step.name || '';
-            var ref = (step.ref || '').split(';')[0];
-
-            // Remove hacks from Mapbox Directions mixing ref into name
-            if (name === step.ref) {
-                // if both are the same we assume that there used to be an empty name, with the ref being filled in for it
-                // we only need to retain the ref then
-                name = '';
-            }
-            name = name.replace(' (' + step.ref + ')', '');
-
-            // In attempt to avoid using the highway name of a way,
-            // check and see if the step has a class which should signal
-            // the ref should be used instead of the name.
-            var wayMotorway = false;
-            if (options && options.classes) {
-                wayMotorway = options.classes.indexOf('motorway') !== -1;
-            }
-
-            if (name && ref && name !== ref && !wayMotorway) {
-                var phrase = instructions[language][version].phrase['name and ref'] ||
-                    instructions.en[version].phrase['name and ref'];
-                wayName = this.tokenize(language, phrase, {
-                    name: name,
-                    ref: ref
-                });
-            } else if (name && ref && wayMotorway && (/\d/).test(ref)) {
-                wayName = ref;
-            } else if (!name && ref) {
-                wayName = ref;
-            } else {
-                wayName = name;
-            }
+            var wayName = this.getWayName(language, step, options);
 
             // Decide which instruction string to use
             // Destination takes precedence over name

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -83,6 +83,52 @@ tape.test('v5 directionFromDegree', function(assert) {
     assert.end();
 });
 
+tape.test('v5 wayName', function(assert) {
+    var v5Compiler = compiler('v5');
+
+    function makeStep(ref, name) {
+        return {
+            ref: ref,
+            name: name
+        };
+    }
+
+    [
+        [makeStep('', ''), ''],
+        [makeStep('ref', 'name'), 'Name (ref)'],
+        [makeStep('ref', 'name (ref)'), 'Name (ref)'],
+        [makeStep('ref; other', 'name (ref; other)'), 'Name (ref)'],
+        [makeStep('ref1; ref2', 'name'), 'Name (ref1)'],
+        [makeStep('ref1; ref2', 'name (ref1; ref2)'), 'Name (ref1)']
+    ].forEach((c, i) => {
+        assert.equal(v5Compiler.getWayName('en', c[0]), c[1], `correct way name for non motorway test ${i}`);
+    });
+
+    [
+        [makeStep('', ''), ''],
+        [makeStep('ref', 'name'), 'name'],
+        [makeStep('ref1', 'name'), 'ref1'],
+        [makeStep('ref', 'name (ref)'), 'name'],
+        [makeStep('ref1', 'name (ref1)'), 'ref1'],
+        [makeStep('ref1; ref2', 'name'), 'ref1'],
+        [makeStep('ref1; ref2', 'name (ref1; ref2)'), 'ref1']
+    ].forEach((c, i) => {
+        assert.equal(v5Compiler.getWayName('en', c[0], {classes: ['motorway']}), c[1], `correct way name for motorway test ${i}`);
+    });
+
+    assert.throws(
+        () => { v5Compiler.getWayName(); },
+        'throws when no step is passed'
+    );
+
+    assert.throws(
+        () => { v5Compiler.getWayName({}, 1); },
+        'throws when classes is invalid'
+    );
+
+    assert.end();
+});
+
 tape.test('v5 laneDiagram', function(assert) {
     var v5Compiler = compiler('v5');
 


### PR DESCRIPTION
New functionality to allow users of this module to have the same `wayName` logic as used in compile.