### PR TITLE
Add fallback code for unsupported locales

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -80,7 +80,7 @@
         "lines-around-comment": "error",
         "max-depth": "error",
         "max-len": "off",
-        "max-lines": "error",
+        "max-lines": "off",
         "max-nested-callbacks": "error",
         "max-params": "error",
         "max-statements": "off",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
+## Master
+
+- Added `getBestMatchingLanguage` for determining the best language when it's unknown if the users locale is supported.
+
 ## 0.8.0 2017-10-04
 
 - Added grammatical cases support for Russian way names [#102](https://github.com/Project-OSRM/osrm-text-instructions/pull/102)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file. For change 
 
 ## Master
 
-- Added `getBestMatchingLanguage` for determining the best language when it's unknown if the users locale is supported.
+- Added `getBestMatchingLanguage` for determining the closest available language. Pass a user locale into this method before passing the return value into `compile`. [#168](https://github.com/Project-OSRM/osrm-text-instructions/pull/168)
 
 ## 0.8.0 2017-10-04
 

--- a/Readme.md
+++ b/Readme.md
@@ -27,9 +27,9 @@ Grammatical cases and other translated strings customization after [Transifex](h
 var version = 'v5';
 var osrmTextInstructions = require('osrm-text-instructions')(version);
 
-// make your request against the API, save result to response variable
+// If you are unsure if the users locale is supported, use `getBestMatchingLanguage` method to find an appropriate language.
+var language = osrmTextInstructions.getBestMatchingLanguage('en');
 
-var language = 'en';
 response.legs.forEach(function(leg) {
   leg.steps.forEach(function(step) {
     instruction = osrmTextInstructions.compile(language, step, options)

--- a/Readme.md
+++ b/Readme.md
@@ -27,8 +27,8 @@ Grammatical cases and other translated strings customization after [Transifex](h
 var version = 'v5';
 var osrmTextInstructions = require('osrm-text-instructions')(version);
 
-// If you are unsure if the users locale is supported, use `getBestMatchingLanguage` method to find an appropriate language.
-var language = osrmTextInstructions.getBestMatchingLanguage('en');
+// If you’re unsure if the user’s locale is supported, use `getBestMatchingLanguage` method to find an appropriate language.
+var language = osrmTextInstructions.getBestMatchingLanguage('en-US');
 
 response.legs.forEach(function(leg) {
   leg.steps.forEach(function(step) {

--- a/index.js
+++ b/index.js
@@ -286,8 +286,8 @@ module.exports = function(version, _options) {
             } else if (languages.instructions[languageCode]) {
                 return languageCode;
 
-            // Same language code and any script code (lng-Scpx)
-            } else if (supportedLanguageCodes.indexOf(languageCode) > -1 && scriptCode) {
+            // Same language code and any script code (lng-Scpx) and the found language contains a script
+            } else if (supportedLanguageCodes.indexOf(languageCode) > -1 && scriptCode && languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)].split('-')[1].length === 4) {
                 return languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)];
 
             // Same language code and any country code (lng-CX)

--- a/index.js
+++ b/index.js
@@ -277,6 +277,10 @@ module.exports = function(version, _options) {
                 countryCode = splitLocale[2];
             }
 
+            var supportedLanguageCode = languages.supportedCodes.map(function(locale) {
+                return locale.toLowerCase().split('-')[0];
+            });
+
             // Same language code and script code (lng-Scpt)
             if (languages.instructions[languageCode + '-' + scriptCode]) {
                 return languageCode + '-' + scriptCode;
@@ -286,16 +290,16 @@ module.exports = function(version, _options) {
                 return languageCode + '-' + countryCode;
 
             // Same language code (lng)
-            } else if (languages.instructions[languageCode]) {
-                return languageCode;
+            } else if (supportedLanguageCode.indexOf(languageCode) > -1) {
+                return languages.supportedCodes[supportedLanguageCode.indexOf(languageCode)];
 
             // Same language code and any script code (lng-Scpx)
-            } else if (languages.instructions[languageCode] && scriptCode) {
-                return languageCode;
+            } else if (supportedLanguageCode.indexOf(languageCode) > -1 && scriptCode) {
+                return languages.supportedCodes[supportedLanguageCode.indexOf(languageCode)];
 
             // Same language code and any country code (lng-CX)
-            } else if (languages.instructions[languageCode] && countryCode) {
-                return languageCode;
+            } else if (supportedLanguageCode.indexOf(languageCode) > -1 && countryCode) {
+                return languages.supportedCodes[supportedLanguageCode.indexOf(languageCode)];
             } else {
                 return 'en';
             }

--- a/index.js
+++ b/index.js
@@ -13,20 +13,17 @@ module.exports = function(version, _options) {
 
     return {
         capitalizeFirstLetter: function(language, string) {
-            return string.charAt(0).toLocaleUpperCase(this.getBestMatchingLanguage(language)) + string.slice(1);
+            return string.charAt(0).toLocaleUpperCase(language) + string.slice(1);
         },
-        ordinalize: function(originalLanguage, number) {
+        ordinalize: function(language, number) {
             // Transform numbers to their translated ordinalized value
-            if (!originalLanguage) throw new Error('No language code provided');
-
-            var language = this.getBestMatchingLanguage(originalLanguage);
+            if (!language) throw new Error('No language code provided');
 
             return instructions[language][version].constants.ordinalize[number.toString()] || '';
         },
-        directionFromDegree: function(originalLanguage, degree) {
+        directionFromDegree: function(language, degree) {
             // Transform degrees to their translated compass direction
-            if (!originalLanguage) throw new Error('No language code provided');
-            var language = this.getBestMatchingLanguage(originalLanguage);
+            if (!language) throw new Error('No language code provided');
             if (!degree && degree !== 0) {
                 // step had no bearing_after degree, ignoring
                 return '';
@@ -75,6 +72,7 @@ module.exports = function(version, _options) {
         getWayName: function(language, step, options) {
             var classes = options ? options.classes || [] : [];
             if (typeof step !== 'object') throw new Error('step must be an Object');
+            if (!language) throw new Error('No language code provided');
             if (!Array.isArray(classes)) throw new Error('classes must be an Array or undefined');
 
             var wayName;
@@ -111,10 +109,9 @@ module.exports = function(version, _options) {
 
             return wayName;
         },
-        compile: function(originalLanguage, step, options) {
-            if (!originalLanguage) throw new Error('No language code provided');
-            var language = this.getBestMatchingLanguage(originalLanguage);
-
+        compile: function(language, step, options) {
+            if (!language) throw new Error('No language code provided');
+            if (languages.supportedCodes.indexOf(language) === -1) throw new Error('language code ' + language + ' not loaded');
             if (!step.maneuver) throw new Error('No step maneuver provided');
 
             var type = step.maneuver.type;
@@ -209,10 +206,8 @@ module.exports = function(version, _options) {
 
             return this.tokenize(language, instruction, replaceTokens);
         },
-        grammarize: function(originalLanguage, name, grammar) {
-            if (!originalLanguage) throw new Error('No language code provided');
-
-            var language = this.getBestMatchingLanguage(originalLanguage);
+        grammarize: function(language, name, grammar) {
+            if (!language) throw new Error('No language code provided');
             // Process way/rotary name with applying grammar rules if any
             if (name && grammar && grammars && grammars[language] && grammars[language][version]) {
                 var rules = grammars[language][version][grammar];
@@ -231,10 +226,8 @@ module.exports = function(version, _options) {
 
             return name;
         },
-        tokenize: function(originalLanguage, instruction, tokens) {
-            if (!originalLanguage) throw new Error('No language code provided');
-
-            var language = this.getBestMatchingLanguage(originalLanguage);
+        tokenize: function(language, instruction, tokens) {
+            if (!language) throw new Error('No language code provided');
             // Keep this function context to use in inline function below (no arrow functions in ES4)
             var that = this;
             var output = instruction.replace(/\{(\w+):?(\w+)?\}/g, function(token, tag, grammar) {

--- a/index.js
+++ b/index.js
@@ -270,7 +270,7 @@ module.exports = function(version, _options) {
                 return languageCode;
             // Same language code and any script code (lng-Scpx) and the found language contains a script
             } else if (languages.parsedSupportedCodes.find(function (language) {
-                return language.language === languageCode && language.scriptCode;
+                return language.languageCode === languageCode && language.scriptCode;
             })) {
                 return languages.parsedSupportedCodes.find(function (language) {
                     return language.languageCode === languageCode && language.scriptCode;

--- a/index.js
+++ b/index.js
@@ -256,7 +256,20 @@ module.exports = function(version, _options) {
             var scriptCode = false;
             var countryCode = false;
 
-            if (splitLocale.lenth === 1) {
+            /**
+             Documentation on how the language tag is being split: https://en.wikipedia.org/wiki/IETF_language_tag#Syntax_of_language_tags
+
+             Example: zh-Hant-TW
+             language code: zh
+             script code: Hant
+             country code: TW
+
+             Example: en-US
+             language code: en
+             country code: US
+            */
+
+            if (splitLocale.length === 1) {
                 languageCode = splitLocale[0];
             } else if (splitLocale.length === 2 && splitLocale[1].length === 4) {
                 languageCode = splitLocale[0];
@@ -277,21 +290,17 @@ module.exports = function(version, _options) {
             // Same language code and script code (lng-Scpt)
             if (languages.instructions[languageCode + '-' + scriptCode]) {
                 return languageCode + '-' + scriptCode;
-
             // Same language code and country code (lng-CC)
             } else if (languages.instructions[languageCode + '-' + countryCode]) {
                 return languageCode + '-' + countryCode;
-
             // Same language code (lng)
             } else if (languages.instructions[languageCode]) {
                 return languageCode;
-
             // Same language code and any script code (lng-Scpx) and the found language contains a script
             } else if (supportedLanguageCodes.indexOf(languageCode) > -1 && scriptCode &&
                 languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)].split('-').length > 1 &&
                 languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)].split('-')[1].length === 4) {
                 return languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)];
-
             // Same language code and any country code (lng-CX)
             } else if (supportedLanguageCodes.indexOf(languageCode) > -1 && countryCode) {
                 return languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)];

--- a/index.js
+++ b/index.js
@@ -262,33 +262,44 @@ module.exports = function(version, _options) {
             // Same language code and script code (lng-Scpt)
             if (languages.instructions[languageCode + '-' + scriptCode]) {
                 return languageCode + '-' + scriptCode;
+            }
+
             // Same language code and country code (lng-CC)
-            } else if (languages.instructions[languageCode + '-' + countryCode]) {
+            if (languages.instructions[languageCode + '-' + countryCode]) {
                 return languageCode + '-' + countryCode;
+            }
+
             // Same language code (lng)
-            } else if (supportedLanguageCodes[languageCode]) {
+            if (supportedLanguageCodes[languageCode]) {
                 return languageCode;
+            }
+
             // Same language code and any script code (lng-Scpx) and the found language contains a script
-            } else if (languages.parsedSupportedCodes.find(function (language) {
+            var anyScript = languages.parsedSupportedCodes.find(function (language) {
                 return language.languageCode === languageCode && language.scriptCode;
-            })) {
-                return languages.parsedSupportedCodes.find(function (language) {
-                    return language.languageCode === languageCode && language.scriptCode;
-                }).locale;
+            });
+            if (anyScript) {
+                return anyScript.locale;
+            }
+
             // Same language code and any country code (lng-CX)
-            } else if (supportedLanguageCodes.indexOf(languageCode) > -1 && countryCode) {
-                return languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)];
+            var anyCountry = languages.parsedSupportedCodes.find(function (language) {
+                return language.languageCode === languageCode && language.scriptCode;
+            });
+            if (anyCountry) {
+                return anyCountry.locale;
+            }
+
             // Only language code provided, but we on support this language code
             // with either script/country code.
-            } else if (languages.parsedSupportedCodes.find(function (language) {
+            var sameLanguage = languages.parsedSupportedCodes.find(function (language) {
                 return language.languageCode === languageCode;
-            })) {
-                return (languages.parsedSupportedCodes.find(function (language) {
-                    return language.languageCode === languageCode;
-                })).locale;
-            } else {
-                return 'en';
+            });
+            if (sameLanguage) {
+                return sameLanguage.locale;
             }
+
+            return 'en';
         }
     };
 };

--- a/index.js
+++ b/index.js
@@ -266,11 +266,11 @@ module.exports = function(version, _options) {
             } else if (languages.instructions[languageCode + '-' + countryCode]) {
                 return languageCode + '-' + countryCode;
             // Same language code (lng)
-            } else if (languages.instructions[languageCode]) {
+            } else if (supportedLanguageCodes[languageCode]) {
                 return languageCode;
             // Same language code and any script code (lng-Scpx) and the found language contains a script
             } else if (languages.parsedSupportedCodes.find(function (language) {
-                return language.languageCode === languageCode && language.scriptCode;
+                return language.language === languageCode && language.scriptCode;
             })) {
                 return languages.parsedSupportedCodes.find(function (language) {
                     return language.languageCode === languageCode && language.scriptCode;
@@ -278,6 +278,14 @@ module.exports = function(version, _options) {
             // Same language code and any country code (lng-CX)
             } else if (supportedLanguageCodes.indexOf(languageCode) > -1 && countryCode) {
                 return languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)];
+            // Only language code provided, but we on support this language code
+            // with either script/country code.
+            } else if (languages.parsedSupportedCodes.find(function (language) {
+                return language.languageCode === languageCode;
+            })) {
+                return (languages.parsedSupportedCodes.find(function (language) {
+                    return language.languageCode === languageCode;
+                })).locale;
             } else {
                 return 'en';
             }

--- a/index.js
+++ b/index.js
@@ -251,9 +251,9 @@ module.exports = function(version, _options) {
             if (languages.instructions[language]) return language;
 
             var codes = languages.parseLanguageIntoCodes(language);
-            var languageCode = codes.languageCode;
-            var scriptCode = codes.scriptCode;
-            var countryCode = codes.countryCode;
+            var languageCode = codes.language;
+            var scriptCode = codes.script;
+            var regionCode = codes.region;
 
             var supportedLanguageCodes = languages.supportedCodes.map(function(language) {
                 return language.toLowerCase().split('-')[0];
@@ -264,9 +264,9 @@ module.exports = function(version, _options) {
                 return languageCode + '-' + scriptCode;
             }
 
-            // Same language code and country code (lng-CC)
-            if (languages.instructions[languageCode + '-' + countryCode]) {
-                return languageCode + '-' + countryCode;
+            // Same language code and region code (lng-CC)
+            if (languages.instructions[languageCode + '-' + regionCode]) {
+                return languageCode + '-' + regionCode;
             }
 
             // Same language code (lng)
@@ -276,24 +276,24 @@ module.exports = function(version, _options) {
 
             // Same language code and any script code (lng-Scpx) and the found language contains a script
             var anyScript = languages.parsedSupportedCodes.find(function (language) {
-                return language.languageCode === languageCode && language.scriptCode;
+                return language.language === languageCode && language.script;
             });
             if (anyScript) {
                 return anyScript.locale;
             }
 
-            // Same language code and any country code (lng-CX)
+            // Same language code and any region code (lng-CX)
             var anyCountry = languages.parsedSupportedCodes.find(function (language) {
-                return language.languageCode === languageCode && language.scriptCode;
+                return language.language === languageCode && language.script;
             });
             if (anyCountry) {
                 return anyCountry.locale;
             }
 
             // Only language code provided, but we on support this language code
-            // with either script/country code.
+            // with either script/region code.
             var sameLanguage = languages.parsedSupportedCodes.find(function (language) {
-                return language.languageCode === languageCode;
+                return language.language === languageCode;
             });
             if (sameLanguage) {
                 return sameLanguage.locale;

--- a/index.js
+++ b/index.js
@@ -255,26 +255,50 @@ module.exports = function(version, _options) {
             return output;
         },
         getBestMatchingLanguage: function(language) {
-            if (languages.supportedCodes.indexOf(language) > -1) return language;
+            if (languages.instructions[language]) return language;
 
             // If the language is not found, try a little harder
-            var languageCode = language.toLowerCase().split('-')[0];
+            var splitLocale = language.toLowerCase().split('-');
+            var languageCode = false;
+            var scriptCode = false;
+            var countryCode = false;
 
-            var filteredSupportedLanguages = languages.supportedCodes.filter(function(locale) {
-                return locale.toLowerCase().split('-')[0] === languageCode;
-            });
-
-            if (filteredSupportedLanguages.length === 1) {
-                return filteredSupportedLanguages[0];
-            } else if (filteredSupportedLanguages.length > 1) {
-                // If more than one language is found, use the most generic version,
-                // no country code needed.
-                return filteredSupportedLanguages.sort(function(a, b) {
-                    return a.length - b.length;
-                })[0];
+            if (splitLocale.lenth === 1) {
+                languageCode = splitLocale[0];
+            } else if (splitLocale.length === 2 && splitLocale[1].length === 4) {
+                languageCode = splitLocale[0];
+                scriptCode = splitLocale[1];
+            } else if (splitLocale.length === 2 && splitLocale[1].length === 2) {
+                languageCode = splitLocale[0];
+                countryCode = splitLocale[1];
+            } else if (splitLocale.length === 3) {
+                languageCode = splitLocale[0];
+                scriptCode = splitLocale[1];
+                countryCode = splitLocale[2];
             }
 
-            return 'en';
+            // Same language code and script code (lng-Scpt)
+            if (languages.instructions[languageCode + '-' + scriptCode]) {
+                return languageCode + '-' + scriptCode;
+
+            // Same language code and country code (lng-CC)
+            } else if (languages.instructions[languageCode + '-' + countryCode]) {
+                return languageCode + '-' + countryCode;
+
+            // Same language code (lng)
+            } else if (languages.instructions[languageCode]) {
+                return languageCode;
+
+            // Same language code and any script code (lng-Scpx)
+            } else if (languages.instructions[languageCode] && scriptCode) {
+                return languageCode;
+
+            // Same language code and any country code (lng-CX)
+            } else if (languages.instructions[languageCode] && countryCode) {
+                return languageCode;
+            } else {
+                return 'en';
+            }
         }
     };
 };

--- a/index.js
+++ b/index.js
@@ -287,7 +287,9 @@ module.exports = function(version, _options) {
                 return languageCode;
 
             // Same language code and any script code (lng-Scpx) and the found language contains a script
-            } else if (supportedLanguageCodes.indexOf(languageCode) > -1 && scriptCode && languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)].split('-')[1].length === 4) {
+            } else if (supportedLanguageCodes.indexOf(languageCode) > -1 && scriptCode &&
+                languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)].split('-').length > 1 &&
+                languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)].split('-')[1].length === 4) {
                 return languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)];
 
             // Same language code and any country code (lng-CX)

--- a/index.js
+++ b/index.js
@@ -249,9 +249,8 @@ module.exports = function(version, _options) {
         },
         getBestMatchingLanguage: function(language) {
             if (languages.instructions[language]) return language;
-            var that = this;
 
-            var codes = that.divideLanguageCodes(language);
+            var codes = languages.parseLanguageIntoCodes(language);
             var languageCode = codes.languageCode;
             var scriptCode = codes.scriptCode;
             var countryCode = codes.countryCode;
@@ -261,7 +260,7 @@ module.exports = function(version, _options) {
             });
 
             var availableLanguages = languages.supportedCodes.map(function(language) {
-                return that.divideLanguageCodes(language);
+                return languages.parseLanguageIntoCodes(language);
             });
 
             // Same language code and script code (lng-Scpt)
@@ -284,41 +283,6 @@ module.exports = function(version, _options) {
             } else {
                 return 'en';
             }
-        },
-        divideLanguageCodes: function(language) {
-            // If the language is not found, try a little harder
-            var splitLocale = language.toLowerCase().split('-');
-            var languageCode = splitLocale[0];
-            var scriptCode = false;
-            var countryCode = false;
-
-            /**
-             Documentation on how the language tag is being split: https://en.wikipedia.org/wiki/IETF_language_tag#Syntax_of_language_tags
-
-             Example: zh-Hant-TW
-             language code: zh
-             script code: Hant
-             country code: TW
-
-             Example: en-US
-             language code: en
-             country code: US
-            */
-
-            if (splitLocale.length === 2 && splitLocale[1].length === 4) {
-                scriptCode = splitLocale[1];
-            } else if (splitLocale.length === 2 && splitLocale[1].length === 2) {
-                countryCode = splitLocale[1];
-            } else if (splitLocale.length === 3) {
-                scriptCode = splitLocale[1];
-                countryCode = splitLocale[2];
-            }
-
-            return {
-                languageCode: languageCode,
-                scriptCode: scriptCode,
-                countryCode: countryCode
-            };
         }
     };
 };

--- a/index.js
+++ b/index.js
@@ -272,7 +272,9 @@ module.exports = function(version, _options) {
             } else if (languages.parsedSupportedCodes.find(function (language) {
                 return language.languageCode === languageCode && language.scriptCode;
             })) {
-                return languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)];
+                return languages.parsedSupportedCodes.find(function (language) {
+                    return language.languageCode === languageCode && language.scriptCode;
+                }).locale;
             // Same language code and any country code (lng-CX)
             } else if (supportedLanguageCodes.indexOf(languageCode) > -1 && countryCode) {
                 return languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)];

--- a/index.js
+++ b/index.js
@@ -288,7 +288,6 @@ module.exports = function(version, _options) {
 
             // Same language code and any script code (lng-Scpx)
             } else if (supportedLanguageCodes.indexOf(languageCode) > -1 && scriptCode) {
-                console.log('hit');
                 return languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)];
 
             // Same language code and any country code (lng-CX)

--- a/index.js
+++ b/index.js
@@ -255,10 +255,6 @@ module.exports = function(version, _options) {
             var scriptCode = codes.script;
             var regionCode = codes.region;
 
-            var supportedLanguageCodes = languages.supportedCodes.map(function(language) {
-                return language.toLowerCase().split('-')[0];
-            });
-
             // Same language code and script code (lng-Scpt)
             if (languages.instructions[languageCode + '-' + scriptCode]) {
                 return languageCode + '-' + scriptCode;
@@ -270,7 +266,7 @@ module.exports = function(version, _options) {
             }
 
             // Same language code (lng)
-            if (supportedLanguageCodes[languageCode]) {
+            if (languages.instructions[languageCode]) {
                 return languageCode;
             }
 
@@ -284,19 +280,10 @@ module.exports = function(version, _options) {
 
             // Same language code and any region code (lng-CX)
             var anyCountry = languages.parsedSupportedCodes.find(function (language) {
-                return language.language === languageCode && language.script;
+                return language.language === languageCode && language.region;
             });
             if (anyCountry) {
                 return anyCountry.locale;
-            }
-
-            // Only language code provided, but we on support this language code
-            // with either script/region code.
-            var sameLanguage = languages.parsedSupportedCodes.find(function (language) {
-                return language.language === languageCode;
-            });
-            if (sameLanguage) {
-                return sameLanguage.locale;
             }
 
             return 'en';

--- a/index.js
+++ b/index.js
@@ -259,10 +259,6 @@ module.exports = function(version, _options) {
                 return language.toLowerCase().split('-')[0];
             });
 
-            var availableLanguages = languages.supportedCodes.map(function(language) {
-                return languages.parseLanguageIntoCodes(language);
-            });
-
             // Same language code and script code (lng-Scpt)
             if (languages.instructions[languageCode + '-' + scriptCode]) {
                 return languageCode + '-' + scriptCode;
@@ -273,7 +269,7 @@ module.exports = function(version, _options) {
             } else if (languages.instructions[languageCode]) {
                 return languageCode;
             // Same language code and any script code (lng-Scpx) and the found language contains a script
-            } else if (availableLanguages.find(function (language) {
+            } else if (languages.parsedSupportedCodes.find(function (language) {
                 return language.languageCode === languageCode && language.scriptCode;
             })) {
                 return languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)];

--- a/index.js
+++ b/index.js
@@ -270,7 +270,7 @@ module.exports = function(version, _options) {
                 countryCode = splitLocale[2];
             }
 
-            var supportedLanguageCode = languages.supportedCodes.map(function(locale) {
+            var supportedLanguageCodes = languages.supportedCodes.map(function(locale) {
                 return locale.toLowerCase().split('-')[0];
             });
 
@@ -283,16 +283,17 @@ module.exports = function(version, _options) {
                 return languageCode + '-' + countryCode;
 
             // Same language code (lng)
-            } else if (supportedLanguageCode.indexOf(languageCode) > -1) {
-                return languages.supportedCodes[supportedLanguageCode.indexOf(languageCode)];
+            } else if (languages.instructions[languageCode]) {
+                return languageCode;
 
             // Same language code and any script code (lng-Scpx)
-            } else if (supportedLanguageCode.indexOf(languageCode) > -1 && scriptCode) {
-                return languages.supportedCodes[supportedLanguageCode.indexOf(languageCode)];
+            } else if (supportedLanguageCodes.indexOf(languageCode) > -1 && scriptCode) {
+                console.log('hit');
+                return languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)];
 
             // Same language code and any country code (lng-CX)
-            } else if (supportedLanguageCode.indexOf(languageCode) > -1 && countryCode) {
-                return languages.supportedCodes[supportedLanguageCode.indexOf(languageCode)];
+            } else if (supportedLanguageCodes.indexOf(languageCode) > -1 && countryCode) {
+                return languages.supportedCodes[supportedLanguageCodes.indexOf(languageCode)];
             } else {
                 return 'en';
             }

--- a/index.js
+++ b/index.js
@@ -256,8 +256,8 @@ module.exports = function(version, _options) {
             var scriptCode = codes.scriptCode;
             var countryCode = codes.countryCode;
 
-            var supportedLanguageCodes = languages.supportedCodes.map(function(locale) {
-                return locale.toLowerCase().split('-')[0];
+            var supportedLanguageCodes = languages.supportedCodes.map(function(language) {
+                return language.toLowerCase().split('-')[0];
             });
 
             var availableLanguages = languages.supportedCodes.map(function(language) {

--- a/languages.js
+++ b/languages.js
@@ -50,39 +50,26 @@ var grammars = {
 };
 
 function parseLanguageIntoCodes (language) {
-    // If the language is not found, try a little harder
-    var splitLocale = language.toLowerCase().split('-');
-    var languageCode = splitLocale[0];
-    var scriptCode = false;
-    var countryCode = false;
-
-    /**
-     Documentation on how the language tag is being split: https://en.wikipedia.org/wiki/IETF_language_tag#Syntax_of_language_tags
-
-     Example: zh-Hant-TW
-     language code: zh
-     script code: Hant
-     country code: TW
-
-     Example: en-US
-     language code: en
-     country code: US
-    */
-
-    if (splitLocale.length === 2 && splitLocale[1].length === 4) {
-        scriptCode = splitLocale[1];
-    } else if (splitLocale.length === 2 && splitLocale[1].length === 2) {
-        countryCode = splitLocale[1];
-    } else if (splitLocale.length === 3) {
-        scriptCode = splitLocale[1];
-        countryCode = splitLocale[2];
+    var match = language.match(/(\w\w)(?:-(\w\w\w\w))?(?:-(\w\w))?/i);
+    var locale = [];
+    if (match[1]) {
+        match[1] = match[1].toLowerCase();
+        locale.push(match[1]);
+    }
+    if (match[2]) {
+        match[2] = match[2][0].toUpperCase() + match[2].substring(1).toLowerCase();
+        locale.push(match[2]);
+    }
+    if (match[3]) {
+        match[3] = match[3].toUpperCase();
+        locale.push(match[3]);
     }
 
     return {
-        locale: language,
-        languageCode: languageCode,
-        scriptCode: scriptCode,
-        countryCode: countryCode
+        locale: locale.join('-'),
+        languageCode: match[1],
+        scriptCode: match[2],
+        countryCode: match[3]
     };
 }
 

--- a/languages.js
+++ b/languages.js
@@ -79,6 +79,7 @@ function parseLanguageIntoCodes (language) {
     }
 
     return {
+        locale: language,
         languageCode: languageCode,
         scriptCode: scriptCode,
         countryCode: countryCode

--- a/languages.js
+++ b/languages.js
@@ -67,9 +67,9 @@ function parseLanguageIntoCodes (language) {
 
     return {
         locale: locale.join('-'),
-        languageCode: match[1],
-        scriptCode: match[2],
-        countryCode: match[3]
+        language: match[1],
+        script: match[2],
+        region: match[3]
     };
 }
 

--- a/languages.js
+++ b/languages.js
@@ -49,8 +49,45 @@ var grammars = {
     'ru': grammarRu
 };
 
+function parseLanguageIntoCodes (language) {
+    // If the language is not found, try a little harder
+    var splitLocale = language.toLowerCase().split('-');
+    var languageCode = splitLocale[0];
+    var scriptCode = false;
+    var countryCode = false;
+
+    /**
+     Documentation on how the language tag is being split: https://en.wikipedia.org/wiki/IETF_language_tag#Syntax_of_language_tags
+
+     Example: zh-Hant-TW
+     language code: zh
+     script code: Hant
+     country code: TW
+
+     Example: en-US
+     language code: en
+     country code: US
+    */
+
+    if (splitLocale.length === 2 && splitLocale[1].length === 4) {
+        scriptCode = splitLocale[1];
+    } else if (splitLocale.length === 2 && splitLocale[1].length === 2) {
+        countryCode = splitLocale[1];
+    } else if (splitLocale.length === 3) {
+        scriptCode = splitLocale[1];
+        countryCode = splitLocale[2];
+    }
+
+    return {
+        languageCode: languageCode,
+        scriptCode: scriptCode,
+        countryCode: countryCode
+    };
+}
+
 module.exports = {
     supportedCodes: Object.keys(instructions),
     instructions: instructions,
-    grammars: grammars
+    grammars: grammars,
+    parseLanguageIntoCodes: parseLanguageIntoCodes
 };

--- a/languages.js
+++ b/languages.js
@@ -87,6 +87,9 @@ function parseLanguageIntoCodes (language) {
 
 module.exports = {
     supportedCodes: Object.keys(instructions),
+    parsedSupportedCodes: Object.keys(instructions).map(function(language) {
+        return parseLanguageIntoCodes(language);
+    }),
     instructions: instructions,
     grammars: grammars,
     parseLanguageIntoCodes: parseLanguageIntoCodes

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -270,6 +270,13 @@ tape.test('v5 compile', function(t) {
         assert.end();
     });
 
+    t.test('getBestMatchingLanguage', function(t) {
+        t.assert(compiler('v5').getBestMatchingLanguage('zh-Hant'), 'zh-Hans');
+        t.assert(compiler('v5').getBestMatchingLanguage('zh-Hant-TW'), 'zh-Hans');
+        t.assert(compiler('v5').getBestMatchingLanguage('zh'), 'zh-Hans');
+        t.end();
+    });
+
     t.test('respects options.instructionStringHook', function(assert) {
         var v5Compiler = compiler('v5', {
             hooks: {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -185,24 +185,21 @@ tape.test('v5 compile', function(t) {
         assert.end();
     });
 
-    t.test('Fallback to en if unsupported language', function(assert) {
+    t.test('throws an error if a non supported language code is provided', function(assert) {
         var v5Compiler = compiler('v5');
 
-        assert.equal(v5Compiler.compile('foo', {
-            maneuver: {
-                type: 'turn',
-                modifier: 'left'
-            },
-            name: 'Way Name'
-        }), 'Turn left onto Way Name');
+        assert.throws(function() {
+            v5Compiler.compile('foo');
+        }, /language code foo not loaded/);
 
         assert.end();
     });
 
     t.test('en-US fallback to en', function(assert) {
         var v5Compiler = compiler('v5');
+        var language = v5Compiler.getBestMatchingLanguage('en-us');
 
-        assert.equal(v5Compiler.compile('en-US', {
+        assert.equal(v5Compiler.compile(language, {
             maneuver: {
                 type: 'turn',
                 modifier: 'left'
@@ -215,8 +212,9 @@ tape.test('v5 compile', function(t) {
 
     t.test('zh-CN fallback to zh-Hans', function(assert) {
         var v5Compiler = compiler('v5');
+        var language = v5Compiler.getBestMatchingLanguage('zh-CN');
 
-        assert.equal(v5Compiler.compile('zh-CN', {
+        assert.equal(v5Compiler.compile(language, {
             maneuver: {
                 type: 'turn',
                 modifier: 'left'
@@ -229,8 +227,9 @@ tape.test('v5 compile', function(t) {
 
     t.test('zh-Hant fallback to zh-Hanz', function(assert) {
         var v5Compiler = compiler('v5');
+        var language = v5Compiler.getBestMatchingLanguage('zh-Hant');
 
-        assert.equal(v5Compiler.compile('zh-Hant', {
+        assert.equal(v5Compiler.compile(language, {
             maneuver: {
                 type: 'turn',
                 modifier: 'left'
@@ -243,8 +242,9 @@ tape.test('v5 compile', function(t) {
 
     t.test('zh-Hant-TW fallback to zh-Hant', function(assert) {
         var v5Compiler = compiler('v5');
+        var language = v5Compiler.getBestMatchingLanguage('zh-Hant-TW');
 
-        assert.equal(v5Compiler.compile('zh-Hant', {
+        assert.equal(v5Compiler.compile(language, {
             maneuver: {
                 type: 'turn',
                 modifier: 'left'
@@ -257,8 +257,9 @@ tape.test('v5 compile', function(t) {
 
     t.test('es-MX fallback to es', function(assert) {
         var v5Compiler = compiler('v5');
+        var language = v5Compiler.getBestMatchingLanguage('es-MX');
 
-        assert.equal(v5Compiler.compile('es-MX', {
+        assert.equal(v5Compiler.compile(language, {
             maneuver: {
                 type: 'turn',
                 modifier: 'straight'

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -287,16 +287,16 @@ tape.test('v5 compile', function(t) {
 
     /* eslint-disable */
     t.test('parseLanguageIntoCodes', function(t) {
-        t.deepEqual(languages.parseLanguageIntoCodes('foo'), { countryCode: undefined, languageCode: 'fo', locale: 'fo', scriptCode: undefined });
-        t.deepEqual(languages.parseLanguageIntoCodes('en-US'), { countryCode: 'US', languageCode: 'en', locale: 'en-US', scriptCode: undefined });
-        t.deepEqual(languages.parseLanguageIntoCodes('zh-CN'), { countryCode: 'CN', languageCode: 'zh', locale: 'zh-CN', scriptCode: undefined });
-        t.deepEqual(languages.parseLanguageIntoCodes('zh-Hant'),  { countryCode: undefined, languageCode: 'zh', locale: 'zh-Hant', scriptCode: 'Hant' });
-        t.deepEqual(languages.parseLanguageIntoCodes('zh-Hant-TW'),  { countryCode: 'TW', languageCode: 'zh', locale: 'zh-Hant-TW', scriptCode: 'Hant' });
-        t.deepEqual(languages.parseLanguageIntoCodes('zh'), { countryCode: undefined, languageCode: 'zh', locale: 'zh', scriptCode: undefined });
-        t.deepEqual(languages.parseLanguageIntoCodes('es-MX'), { countryCode: 'MX', languageCode: 'es', locale: 'es-MX', scriptCode: undefined });
-        t.deepEqual(languages.parseLanguageIntoCodes('es-ES'), { countryCode: 'ES', languageCode: 'es', locale: 'es-ES', scriptCode: undefined });
-        t.deepEqual(languages.parseLanguageIntoCodes('pt-PT'),  { countryCode: 'PT', languageCode: 'pt', locale: 'pt-PT', scriptCode: undefined });
-        t.deepEqual(languages.parseLanguageIntoCodes('pt'), { countryCode: undefined, languageCode: 'pt', locale: 'pt', scriptCode: undefined });
+        t.deepEqual(languages.parseLanguageIntoCodes('foo'), { region: undefined, language: 'fo', locale: 'fo', script: undefined });
+        t.deepEqual(languages.parseLanguageIntoCodes('en-US'), { region: 'US', language: 'en', locale: 'en-US', script: undefined });
+        t.deepEqual(languages.parseLanguageIntoCodes('zh-CN'), { region: 'CN', language: 'zh', locale: 'zh-CN', script: undefined });
+        t.deepEqual(languages.parseLanguageIntoCodes('zh-Hant'),  { region: undefined, language: 'zh', locale: 'zh-Hant', script: 'Hant' });
+        t.deepEqual(languages.parseLanguageIntoCodes('zh-Hant-TW'),  { region: 'TW', language: 'zh', locale: 'zh-Hant-TW', script: 'Hant' });
+        t.deepEqual(languages.parseLanguageIntoCodes('zh'), { region: undefined, language: 'zh', locale: 'zh', script: undefined });
+        t.deepEqual(languages.parseLanguageIntoCodes('es-MX'), { region: 'MX', language: 'es', locale: 'es-MX', script: undefined });
+        t.deepEqual(languages.parseLanguageIntoCodes('es-ES'), { region: 'ES', language: 'es', locale: 'es-ES', script: undefined });
+        t.deepEqual(languages.parseLanguageIntoCodes('pt-PT'),  { region: 'PT', language: 'pt', locale: 'pt-PT', script: undefined });
+        t.deepEqual(languages.parseLanguageIntoCodes('pt'), { region: undefined, language: 'pt', locale: 'pt', script: undefined });
         t.end();
     });
     /* eslint-enable */

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -227,6 +227,20 @@ tape.test('v5 compile', function(t) {
         assert.end();
     });
 
+    t.test('zh-Hant fallback to zh-Hanz', function(assert) {
+        var v5Compiler = compiler('v5');
+
+        assert.equal(v5Compiler.compile('zh-Hant', {
+            maneuver: {
+                type: 'turn',
+                modifier: 'left'
+            },
+            name: 'Way Name'
+        }), '左转，上Way Name');
+
+        assert.end();
+    });
+
     t.test('zh-Hant-TW fallback to zh-Hant', function(assert) {
         var v5Compiler = compiler('v5');
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -271,9 +271,14 @@ tape.test('v5 compile', function(t) {
     });
 
     t.test('getBestMatchingLanguage', function(t) {
+        t.assert(compiler('v5').getBestMatchingLanguage('foo'), 'en');
+        t.assert(compiler('v5').getBestMatchingLanguage('en-US'), 'en');
+        t.assert(compiler('v5').getBestMatchingLanguage('zh-CN'), 'zh-Hans');
         t.assert(compiler('v5').getBestMatchingLanguage('zh-Hant'), 'zh-Hans');
         t.assert(compiler('v5').getBestMatchingLanguage('zh-Hant-TW'), 'zh-Hans');
         t.assert(compiler('v5').getBestMatchingLanguage('zh'), 'zh-Hans');
+        t.assert(compiler('v5').getBestMatchingLanguage('es-MX'), 'es');
+        t.assert(compiler('v5').getBestMatchingLanguage('es-es'), 'es-es');
         t.end();
     });
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -185,13 +185,72 @@ tape.test('v5 compile', function(t) {
         assert.end();
     });
 
-    t.test('throws an error if a non supported language code is provided', function(assert) {
+    t.test('Fallback to en if unsupported language', function(assert) {
         var v5Compiler = compiler('v5');
 
-        assert.throws(function() {
-            v5Compiler.compile('foo');
-        }, /language code foo not loaded/
-    );
+        assert.equal(v5Compiler.compile('foo', {
+            maneuver: {
+                type: 'turn',
+                modifier: 'left'
+            },
+            name: 'Way Name'
+        }), 'Turn left onto Way Name');
+
+        assert.end();
+    });
+
+    t.test('en-US fallback to en', function(assert) {
+        var v5Compiler = compiler('v5');
+
+        assert.equal(v5Compiler.compile('en-US', {
+            maneuver: {
+                type: 'turn',
+                modifier: 'left'
+            },
+            name: 'Way Name'
+        }), 'Turn left onto Way Name');
+
+        assert.end();
+    });
+
+    t.test('zh-CN fallback to zh-Hans', function(assert) {
+        var v5Compiler = compiler('v5');
+
+        assert.equal(v5Compiler.compile('zh-CN', {
+            maneuver: {
+                type: 'turn',
+                modifier: 'left'
+            },
+            name: 'Way Name'
+        }), '左转，上Way Name');
+
+        assert.end();
+    });
+
+    t.test('zh-Hant-TW fallback to zh-Hant', function(assert) {
+        var v5Compiler = compiler('v5');
+
+        assert.equal(v5Compiler.compile('zh-Hant', {
+            maneuver: {
+                type: 'turn',
+                modifier: 'left'
+            },
+            name: 'Way Name'
+        }), '左转，上Way Name');
+
+        assert.end();
+    });
+
+    t.test('es-MX fallback to es', function(assert) {
+        var v5Compiler = compiler('v5');
+
+        assert.equal(v5Compiler.compile('es-MX', {
+            maneuver: {
+                type: 'turn',
+                modifier: 'straight'
+            },
+            name: 'Way Name'
+        }), 'Ve recto en Way Name');
 
         assert.end();
     });

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -285,22 +285,6 @@ tape.test('v5 compile', function(t) {
         t.end();
     });
 
-    /* eslint-disable */
-    t.test('parseLanguageIntoCodes', function(t) {
-        t.deepEqual(languages.parseLanguageIntoCodes('foo'), { region: undefined, language: 'fo', locale: 'fo', script: undefined });
-        t.deepEqual(languages.parseLanguageIntoCodes('en-US'), { region: 'US', language: 'en', locale: 'en-US', script: undefined });
-        t.deepEqual(languages.parseLanguageIntoCodes('zh-CN'), { region: 'CN', language: 'zh', locale: 'zh-CN', script: undefined });
-        t.deepEqual(languages.parseLanguageIntoCodes('zh-Hant'),  { region: undefined, language: 'zh', locale: 'zh-Hant', script: 'Hant' });
-        t.deepEqual(languages.parseLanguageIntoCodes('zh-Hant-TW'),  { region: 'TW', language: 'zh', locale: 'zh-Hant-TW', script: 'Hant' });
-        t.deepEqual(languages.parseLanguageIntoCodes('zh'), { region: undefined, language: 'zh', locale: 'zh', script: undefined });
-        t.deepEqual(languages.parseLanguageIntoCodes('es-MX'), { region: 'MX', language: 'es', locale: 'es-MX', script: undefined });
-        t.deepEqual(languages.parseLanguageIntoCodes('es-ES'), { region: 'ES', language: 'es', locale: 'es-ES', script: undefined });
-        t.deepEqual(languages.parseLanguageIntoCodes('pt-PT'),  { region: 'PT', language: 'pt', locale: 'pt-PT', script: undefined });
-        t.deepEqual(languages.parseLanguageIntoCodes('pt'), { region: undefined, language: 'pt', locale: 'pt', script: undefined });
-        t.end();
-    });
-    /* eslint-enable */
-
     t.test('respects options.instructionStringHook', function(assert) {
         var v5Compiler = compiler('v5', {
             hooks: {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -271,16 +271,34 @@ tape.test('v5 compile', function(t) {
     });
 
     t.test('getBestMatchingLanguage', function(t) {
-        t.assert(compiler('v5').getBestMatchingLanguage('foo'), 'en');
-        t.assert(compiler('v5').getBestMatchingLanguage('en-US'), 'en');
-        t.assert(compiler('v5').getBestMatchingLanguage('zh-CN'), 'zh-Hans');
-        t.assert(compiler('v5').getBestMatchingLanguage('zh-Hant'), 'zh-Hans');
-        t.assert(compiler('v5').getBestMatchingLanguage('zh-Hant-TW'), 'zh-Hans');
-        t.assert(compiler('v5').getBestMatchingLanguage('zh'), 'zh-Hans');
-        t.assert(compiler('v5').getBestMatchingLanguage('es-MX'), 'es');
-        t.assert(compiler('v5').getBestMatchingLanguage('es-es'), 'es-es');
+        t.equal(compiler('v5').getBestMatchingLanguage('foo'), 'en');
+        t.equal(compiler('v5').getBestMatchingLanguage('en-US'), 'en');
+        t.equal(compiler('v5').getBestMatchingLanguage('zh-CN'), 'zh-Hans');
+        t.equal(compiler('v5').getBestMatchingLanguage('zh-Hant'), 'zh-Hans');
+        t.equal(compiler('v5').getBestMatchingLanguage('zh-Hant-TW'), 'zh-Hans');
+        t.equal(compiler('v5').getBestMatchingLanguage('zh'), 'zh-Hans');
+        t.equal(compiler('v5').getBestMatchingLanguage('es-MX'), 'es');
+        t.equal(compiler('v5').getBestMatchingLanguage('es-ES'), 'es-ES');
+        t.equal(compiler('v5').getBestMatchingLanguage('pt-PT'), 'pt-BR');
+        t.equal(compiler('v5').getBestMatchingLanguage('pt'), 'pt-BR');
         t.end();
     });
+
+    /* eslint-disable */
+    t.test('parseLanguageIntoCodes', function(t) {
+        t.deepEqual(languages.parseLanguageIntoCodes('foo'), { countryCode: false, languageCode: 'foo', locale: 'foo', scriptCode: false });
+        t.deepEqual(languages.parseLanguageIntoCodes('en-US'), { countryCode: 'us', languageCode: 'en', locale: 'en-US', scriptCode: false });
+        t.deepEqual(languages.parseLanguageIntoCodes('zh-CN'), { countryCode: 'cn', languageCode: 'zh', locale: 'zh-CN', scriptCode: false });
+        t.deepEqual(languages.parseLanguageIntoCodes('zh-Hant'),  { countryCode: false, languageCode: 'zh', locale: 'zh-Hant', scriptCode: 'hant' });
+        t.deepEqual(languages.parseLanguageIntoCodes('zh-Hant-TW'),  { countryCode: 'tw', languageCode: 'zh', locale: 'zh-Hant-TW', scriptCode: 'hant' });
+        t.deepEqual(languages.parseLanguageIntoCodes('zh'), { countryCode: false, languageCode: 'zh', locale: 'zh', scriptCode: false });
+        t.deepEqual(languages.parseLanguageIntoCodes('es-MX'), { countryCode: 'mx', languageCode: 'es', locale: 'es-MX', scriptCode: false });
+        t.deepEqual(languages.parseLanguageIntoCodes('es-ES'), { countryCode: 'es', languageCode: 'es', locale: 'es-ES', scriptCode: false });
+        t.deepEqual(languages.parseLanguageIntoCodes('pt-PT'),  { countryCode: 'pt', languageCode: 'pt', locale: 'pt-PT', scriptCode: false });
+        t.deepEqual(languages.parseLanguageIntoCodes('pt'), { countryCode: false, languageCode: 'pt', locale: 'pt', scriptCode: false });
+        t.end();
+    });
+    /* eslint-enable */
 
     t.test('respects options.instructionStringHook', function(assert) {
         var v5Compiler = compiler('v5', {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -281,6 +281,7 @@ tape.test('v5 compile', function(t) {
         t.equal(compiler('v5').getBestMatchingLanguage('es-ES'), 'es-ES');
         t.equal(compiler('v5').getBestMatchingLanguage('pt-PT'), 'pt-BR');
         t.equal(compiler('v5').getBestMatchingLanguage('pt'), 'pt-BR');
+        t.equal(compiler('v5').getBestMatchingLanguage('pt-pt'), 'pt-BR');
         t.end();
     });
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -286,16 +286,16 @@ tape.test('v5 compile', function(t) {
 
     /* eslint-disable */
     t.test('parseLanguageIntoCodes', function(t) {
-        t.deepEqual(languages.parseLanguageIntoCodes('foo'), { countryCode: false, languageCode: 'foo', locale: 'foo', scriptCode: false });
-        t.deepEqual(languages.parseLanguageIntoCodes('en-US'), { countryCode: 'us', languageCode: 'en', locale: 'en-US', scriptCode: false });
-        t.deepEqual(languages.parseLanguageIntoCodes('zh-CN'), { countryCode: 'cn', languageCode: 'zh', locale: 'zh-CN', scriptCode: false });
-        t.deepEqual(languages.parseLanguageIntoCodes('zh-Hant'),  { countryCode: false, languageCode: 'zh', locale: 'zh-Hant', scriptCode: 'hant' });
-        t.deepEqual(languages.parseLanguageIntoCodes('zh-Hant-TW'),  { countryCode: 'tw', languageCode: 'zh', locale: 'zh-Hant-TW', scriptCode: 'hant' });
-        t.deepEqual(languages.parseLanguageIntoCodes('zh'), { countryCode: false, languageCode: 'zh', locale: 'zh', scriptCode: false });
-        t.deepEqual(languages.parseLanguageIntoCodes('es-MX'), { countryCode: 'mx', languageCode: 'es', locale: 'es-MX', scriptCode: false });
-        t.deepEqual(languages.parseLanguageIntoCodes('es-ES'), { countryCode: 'es', languageCode: 'es', locale: 'es-ES', scriptCode: false });
-        t.deepEqual(languages.parseLanguageIntoCodes('pt-PT'),  { countryCode: 'pt', languageCode: 'pt', locale: 'pt-PT', scriptCode: false });
-        t.deepEqual(languages.parseLanguageIntoCodes('pt'), { countryCode: false, languageCode: 'pt', locale: 'pt', scriptCode: false });
+        t.deepEqual(languages.parseLanguageIntoCodes('foo'), { countryCode: undefined, languageCode: 'fo', locale: 'fo', scriptCode: undefined });
+        t.deepEqual(languages.parseLanguageIntoCodes('en-US'), { countryCode: 'US', languageCode: 'en', locale: 'en-US', scriptCode: undefined });
+        t.deepEqual(languages.parseLanguageIntoCodes('zh-CN'), { countryCode: 'CN', languageCode: 'zh', locale: 'zh-CN', scriptCode: undefined });
+        t.deepEqual(languages.parseLanguageIntoCodes('zh-Hant'),  { countryCode: undefined, languageCode: 'zh', locale: 'zh-Hant', scriptCode: 'Hant' });
+        t.deepEqual(languages.parseLanguageIntoCodes('zh-Hant-TW'),  { countryCode: 'TW', languageCode: 'zh', locale: 'zh-Hant-TW', scriptCode: 'Hant' });
+        t.deepEqual(languages.parseLanguageIntoCodes('zh'), { countryCode: undefined, languageCode: 'zh', locale: 'zh', scriptCode: undefined });
+        t.deepEqual(languages.parseLanguageIntoCodes('es-MX'), { countryCode: 'MX', languageCode: 'es', locale: 'es-MX', scriptCode: undefined });
+        t.deepEqual(languages.parseLanguageIntoCodes('es-ES'), { countryCode: 'ES', languageCode: 'es', locale: 'es-ES', scriptCode: undefined });
+        t.deepEqual(languages.parseLanguageIntoCodes('pt-PT'),  { countryCode: 'PT', languageCode: 'pt', locale: 'pt-PT', scriptCode: undefined });
+        t.deepEqual(languages.parseLanguageIntoCodes('pt'), { countryCode: undefined, languageCode: 'pt', locale: 'pt', scriptCode: undefined });
         t.end();
     });
     /* eslint-enable */

--- a/test/languages_test.js
+++ b/test/languages_test.js
@@ -35,3 +35,19 @@ tape.test('verify language files structure', function(assert) {
 
     assert.end();
 });
+
+/* eslint-disable */
+tape.test('parseLanguageIntoCodes', function(t) {
+    t.deepEqual(languages.parseLanguageIntoCodes('foo'), { region: undefined, language: 'fo', locale: 'fo', script: undefined });
+    t.deepEqual(languages.parseLanguageIntoCodes('en-US'), { region: 'US', language: 'en', locale: 'en-US', script: undefined });
+    t.deepEqual(languages.parseLanguageIntoCodes('zh-CN'), { region: 'CN', language: 'zh', locale: 'zh-CN', script: undefined });
+    t.deepEqual(languages.parseLanguageIntoCodes('zh-Hant'),  { region: undefined, language: 'zh', locale: 'zh-Hant', script: 'Hant' });
+    t.deepEqual(languages.parseLanguageIntoCodes('zh-Hant-TW'),  { region: 'TW', language: 'zh', locale: 'zh-Hant-TW', script: 'Hant' });
+    t.deepEqual(languages.parseLanguageIntoCodes('zh'), { region: undefined, language: 'zh', locale: 'zh', script: undefined });
+    t.deepEqual(languages.parseLanguageIntoCodes('es-MX'), { region: 'MX', language: 'es', locale: 'es-MX', script: undefined });
+    t.deepEqual(languages.parseLanguageIntoCodes('es-ES'), { region: 'ES', language: 'es', locale: 'es-ES', script: undefined });
+    t.deepEqual(languages.parseLanguageIntoCodes('pt-PT'),  { region: 'PT', language: 'pt', locale: 'pt-PT', script: undefined });
+    t.deepEqual(languages.parseLanguageIntoCodes('pt'), { region: undefined, language: 'pt', locale: 'pt', script: undefined });
+    t.end();
+});
+/* eslint-enable */


### PR DESCRIPTION
This PR adds support for trying to find locales which we currently do not support. This gist of it is, that if a developer provides `es-MX`, we should give them instructions provides by `es`.

This also moves to use `en` when a language is not found.

/cc @mcwhittemore @1ec5 