### PR TITLE
Shorten Russian rotary instructions

### DIFF
--- a/languages/overrides/ru.js
+++ b/languages/overrides/ru.js
@@ -2,7 +2,8 @@
 
 var replaces = [
     ['(развернитесь +на) +\{((way_name)|(rotary_name))\}', '$1 {$2:prepositional}'],
-    ['(на) +\{((way_name)|(rotary_name))\} +с +', '$1 {$2:prepositional} с '],
+    ['(на) +\{((way_name)|(rotary_name))\} +с', '$1 {$2:prepositional} с'],
+    ['(на) +\{((way_name)|(rotary_name))\} +по', '$1 {$2:prepositional} по'],
     ['(в +конце) +\{((way_name)|(rotary_name))\}', '$1 {$2:genitive}'],
     ['(по) +\{((way_name)|(rotary_name))\}', '$1 {$2:dative}'],
     ['(на) +\{((way_name)|(rotary_name))\}', '$1 {$2:accusative}']

--- a/languages/translations/ru.json
+++ b/languages/translations/ru.json
@@ -355,9 +355,9 @@
                     "destination": "На круговой развязке сверните в направлении {destination}"
                 },
                 "name": {
-                    "default": "Продолжите движение по {rotary_name:dative} с круговым движением",
-                    "name": "На {rotary_name:prepositional} с круговым движением сверните на {way_name:accusative}",
-                    "destination": "На {rotary_name:prepositional} с круговым движением сверните в направлении {destination}"
+                    "default": "Продолжите движение по {rotary_name:dative}",
+                    "name": "На {rotary_name:prepositional} сверните на {way_name:accusative}",
+                    "destination": "На {rotary_name:prepositional} сверните в направлении {destination}"
                 },
                 "exit": {
                     "default": "На круговой развязке сверните на {exit_number} съезд",
@@ -365,9 +365,9 @@
                     "destination": "На круговой развязке сверните на {exit_number} съезд в направлении {destination}"
                 },
                 "name_exit": {
-                    "default": "На {rotary_name:prepositional} с круговым движением сверните на {exit_number} съезд",
-                    "name": "На {rotary_name:prepositional} с круговым движением сверните на {exit_number} съезд на {way_name:accusative}",
-                    "destination": "На {rotary_name:prepositional} с круговым движением сверните на {exit_number} съезд в направлении {destination}"
+                    "default": "На {rotary_name:prepositional} сверните на {exit_number} съезд",
+                    "name": "На {rotary_name:prepositional} сверните на {exit_number} съезд на {way_name:accusative}",
+                    "destination": "На {rotary_name:prepositional} сверните на {exit_number} съезд в направлении {destination}"
                 }
             }
         },

--- a/test/fixtures/v5/rotary/name_default.json
+++ b/test/fixtures/v5/rotary/name_default.json
@@ -20,7 +20,7 @@
         "pl": "Wjedź na Rotary Name",
         "pt-BR": "Entre em Rotary Name",
         "ro": "Intrați în Rotary Name",
-        "ru": "Продолжите движение по Rotary Name с круговым движением",
+        "ru": "Продолжите движение по Rotary Name",
         "sv": "Kör in i Rotary Name",
         "tr": "Rotary Name dönel kavşağa gir",
         "uk": "Рухайтесь по Rotary Name",

--- a/test/fixtures/v5/rotary/name_destination.json
+++ b/test/fixtures/v5/rotary/name_destination.json
@@ -21,7 +21,7 @@
         "pl": "Wjedź na Rotary Name i skręć w kierunku Destination 1",
         "pt-BR": "Entre em Rotary Name e saia sentido Destination 1",
         "ro": "Intrați în Rotary Name și ieșiți spre Destination 1",
-        "ru": "На Rotary Name с круговым движением сверните в направлении Destination 1",
+        "ru": "На Rotary Name сверните в направлении Destination 1",
         "sv": "I Rotary Name ta av mot Destination 1",
         "tr": "Rotary Name dönel kavşağa gir ve Destination 1 istikametinde çık",
         "uk": "Рухайтесь по Rotary Name та поверніть в напрямку Destination 1",

--- a/test/fixtures/v5/rotary/name_exit.json
+++ b/test/fixtures/v5/rotary/name_exit.json
@@ -21,7 +21,7 @@
         "pl": "Wjedź na Rotary Name i skręć na Way Name",
         "pt-BR": "Entre em Rotary Name e saia em Way Name",
         "ro": "Intrați în Rotary Name și ieșiți pe Way Name",
-        "ru": "На Rotary Name с круговым движением сверните на Way Name",
+        "ru": "На Rotary Name сверните на Way Name",
         "sv": "I Rotary Name ta av in på Way Name",
         "tr": "Rotary Name dönel kavşağa gir ve Way Name üzerinde çık",
         "uk": "Рухайтесь по Rotary Name та поверніть на Way Name",

--- a/test/fixtures/v5/rotary/name_exit_default.json
+++ b/test/fixtures/v5/rotary/name_exit_default.json
@@ -21,7 +21,7 @@
         "pl": "Wjedź na Rotary Name i wyjedź 2. zjazdem",
         "pt-BR": "Entre em Rotary Name e saia na 2º saída",
         "ro": "Intrați în Rotary Name și mergeți spre ieșirea a 2-a",
-        "ru": "На Rotary Name с круговым движением сверните на второй съезд",
+        "ru": "На Rotary Name сверните на второй съезд",
         "sv": "I Rotary Name ta 2:a avfarten",
         "tr": "Rotary Name dönel kavşağa gir ve ikinci numaralı çıkışa gir",
         "uk": "Рухайтесь по Rotary Name та поверніть у 2й з'їзд",

--- a/test/fixtures/v5/rotary/name_exit_destination.json
+++ b/test/fixtures/v5/rotary/name_exit_destination.json
@@ -22,7 +22,7 @@
         "pl": "Wjedź na Rotary Name i wyjedź 2. zjazdem w kierunku Destination 1",
         "pt-BR": "Entre em Rotary Name e saia na 2º saída sentido Destination 1",
         "ro": "Intrați în Rotary Name și mergeți spre ieșirea a 2-a spre Destination 1",
-        "ru": "На Rotary Name с круговым движением сверните на второй съезд в направлении Destination 1",
+        "ru": "На Rotary Name сверните на второй съезд в направлении Destination 1",
         "sv": "I Rotary Name ta 2:a avfarten mot Destination 1",
         "tr": "Rotary Name dönel kavşağa gir ve Destination 1 istikametindeki ikinci numaralı çıkışa gir",
         "uk": "Рухайтесь по Rotary Name та поверніть у 2й з'їзд в напрямку Destination 1",

--- a/test/fixtures/v5/rotary/name_exit_exit.json
+++ b/test/fixtures/v5/rotary/name_exit_exit.json
@@ -22,7 +22,7 @@
         "pl": "Wjedź na Rotary Name i wyjedź 2. zjazdem na Way Name",
         "pt-BR": "Entre em Rotary Name e saia na 2º saída em Way Name",
         "ro": "Intrați în Rotary Name și mergeți spre ieșirea a 2-a pe Way Name",
-        "ru": "На Rotary Name с круговым движением сверните на второй съезд на Way Name",
+        "ru": "На Rotary Name сверните на второй съезд на Way Name",
         "sv": "I Rotary Name ta 2:a avfarten in på Way Name",
         "tr": "Rotary Name dönel kavşağa gir ve Way Name üzerindeki ikinci numaralı çıkışa gir",
         "uk": "Рухайтесь по Rotary Name та поверніть у 2й з'їзд на Way Name",

--- a/test/fixtures/v5/rotary/name_exit_exit_destination.json
+++ b/test/fixtures/v5/rotary/name_exit_exit_destination.json
@@ -23,7 +23,7 @@
         "pl": "Wjedź na Rotary Name i wyjedź 2. zjazdem w kierunku Destination 1",
         "pt-BR": "Entre em Rotary Name e saia na 2º saída sentido Destination 1",
         "ro": "Intrați în Rotary Name și mergeți spre ieșirea a 2-a spre Destination 1",
-        "ru": "На Rotary Name с круговым движением сверните на второй съезд в направлении Destination 1",
+        "ru": "На Rotary Name сверните на второй съезд в направлении Destination 1",
         "sv": "I Rotary Name ta 2:a avfarten mot Destination 1",
         "tr": "Rotary Name dönel kavşağa gir ve Destination 1 istikametindeki ikinci numaralı çıkışa gir",
         "uk": "Рухайтесь по Rotary Name та поверніть у 2й з'їзд в напрямку Destination 1",

--- a/test/fixtures/v5/rotary/name_exit_name.json
+++ b/test/fixtures/v5/rotary/name_exit_name.json
@@ -21,7 +21,7 @@
         "pl": "Wjedź na Rotary Name i wyjedź 2. zjazdem na Way Name",
         "pt-BR": "Entre em Rotary Name e saia na 2º saída em Way Name",
         "ro": "Intrați în Rotary Name și mergeți spre ieșirea a 2-a pe Way Name",
-        "ru": "На Rotary Name с круговым движением сверните на второй съезд на Way Name",
+        "ru": "На Rotary Name сверните на второй съезд на Way Name",
         "sv": "I Rotary Name ta 2:a avfarten in på Way Name",
         "tr": "Rotary Name dönel kavşağa gir ve Way Name üzerindeki ikinci numaralı çıkışa gir",
         "uk": "Рухайтесь по Rotary Name та поверніть у 2й з'їзд на Way Name",

--- a/test/fixtures/v5/rotary/name_name.json
+++ b/test/fixtures/v5/rotary/name_name.json
@@ -20,7 +20,7 @@
         "pl": "Wjedź na Rotary Name i skręć na Way Name",
         "pt-BR": "Entre em Rotary Name e saia em Way Name",
         "ro": "Intrați în Rotary Name și ieșiți pe Way Name",
-        "ru": "На Rotary Name с круговым движением сверните на Way Name",
+        "ru": "На Rotary Name сверните на Way Name",
         "sv": "I Rotary Name ta av in på Way Name",
         "tr": "Rotary Name dönel kavşağa gir ve Way Name üzerinde çık",
         "uk": "Рухайтесь по Rotary Name та поверніть на Way Name",


### PR DESCRIPTION
Just make Russian rotary instructions some shorter.

This is slightly related with issue #173 "Remove traffic circle names from the roundabout and rotary instructions" - IMHO rotary names should not be removed here but actually these instructions really look too long especially in Russian.