### PR TITLE
0.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
-## master
+## 0.10.0 2017-10-18
 
 - Added a `formatToken` option to `compile`, `getWayName`, and `tokenize` that allows you to manipulate any token value after any grammar or capitalization rules are applied but before the value is inserted into the instruction. [#170](https://github.com/Project-OSRM/osrm-text-instructions/pull/170)
 - Removed the `options` parameter to this module, including the `tokenizedInstruction` hook. Use the `formatToken` option instead. [#170](https://github.com/Project-OSRM/osrm-text-instructions/pull/170)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "OSRM Text Instructions",
   "url": "https://github.com/Project-OSRM/osrm-text-instructions.js",
   "homepage": "http://project-osrm.org",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "main": "./index.js",
   "license": "BSD-2-Clause",
   "bugs": {


### PR DESCRIPTION
- Added a `formatToken` option to `compile`, `getWayName`, and `tokenize` that allows you to manipulate any token value after any grammar or capitalization rules are applied but before the value is inserted into the instruction. [#170](https://github.com/Project-OSRM/osrm-text-instructions/pull/170)
- Removed the `options` parameter to this module, including the `tokenizedInstruction` hook. Use the `formatToken` option instead. [#170](https://github.com/Project-OSRM/osrm-text-instructions/pull/170)
- Added `namedistance` option to the depart instructions and added tests for `namedistance` in depart and continue instructions. Some typo fixes. [#177](https://github.com/Project-OSRM/osrm-text-instructions/pull/177#discussion_r145279715)