### PR TITLE
Update en.json to use traffic circle for all circles

### DIFF
--- a/languages/translations/en.json
+++ b/languages/translations/en.json
@@ -350,9 +350,9 @@
         "rotary": {
             "default": {
                 "default": {
-                    "default": "Enter the rotary",
-                    "name": "Enter the rotary and exit onto {way_name}",
-                    "destination": "Enter the rotary and exit towards {destination}"
+                    "default": "Enter the traffic circle",
+                    "name": "Enter the traffic circle and exit onto {way_name}",
+                    "destination": "Enter the traffic circle and exit towards {destination}"
                 },
                 "name": {
                     "default": "Enter {rotary_name}",
@@ -360,9 +360,9 @@
                     "destination": "Enter {rotary_name} and exit towards {destination}"
                 },
                 "exit": {
-                    "default": "Enter the rotary and take the {exit_number} exit",
-                    "name": "Enter the rotary and take the {exit_number} exit onto {way_name}",
-                    "destination": "Enter the rotary and take the {exit_number} exit towards {destination}"
+                    "default": "Enter the traffic circle and take the {exit_number} exit",
+                    "name": "Enter the traffic circle and take the {exit_number} exit onto {way_name}",
+                    "destination": "Enter the traffic circle and take the {exit_number} exit towards {destination}"
                 },
                 "name_exit": {
                     "default": "Enter {rotary_name} and take the {exit_number} exit",
@@ -374,14 +374,14 @@
         "roundabout": {
             "default": {
                 "exit": {
-                    "default": "Enter the roundabout and take the {exit_number} exit",
-                    "name": "Enter the roundabout and take the {exit_number} exit onto {way_name}",
-                    "destination": "Enter the roundabout and take the {exit_number} exit towards {destination}"
+                    "default": "Enter the traffic circle and take the {exit_number} exit",
+                    "name": "Enter the traffic circle and take the {exit_number} exit onto {way_name}",
+                    "destination": "Enter the traffic circle and take the {exit_number} exit towards {destination}"
                 },
                 "default": {
-                    "default": "Enter the roundabout",
-                    "name": "Enter the roundabout and exit onto {way_name}",
-                    "destination": "Enter the roundabout and exit towards {destination}"
+                    "default": "Enter the traffic circle",
+                    "name": "Enter the traffic circle and exit onto {way_name}",
+                    "destination": "Enter the traffic circle and exit towards {destination}"
                 }
             }
         },

--- a/test/fixtures/v5/rotary/default_default.json
+++ b/test/fixtures/v5/rotary/default_default.json
@@ -8,7 +8,7 @@
     },
     "instructions": {
         "de": "In den Kreisverkehr fahren",
-        "en": "Enter the rotary",
+        "en": "Enter the traffic circle",
         "eo": "Enveturu trafikcirklegon",
         "es": "Entra en la rotonda",
         "es-ES": "Incorpórate en la rotonda",

--- a/test/fixtures/v5/rotary/default_destination.json
+++ b/test/fixtures/v5/rotary/default_destination.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die Ausfahrt Richtung Destination 1 nehmen",
-        "en": "Enter the rotary and exit towards Destination 1",
+        "en": "Enter the traffic circle and exit towards Destination 1",
         "eo": "Enveturu trafikcirklegon kaj elveturu direkte al Destination 1",
         "es": "Entra en la rotonda y sal hacia Destination 1",
         "es-ES": "En la rotonda sal hacia Destination 1",

--- a/test/fixtures/v5/rotary/default_exit.json
+++ b/test/fixtures/v5/rotary/default_exit.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die Ausfahrt auf Way Name nehmen",
-        "en": "Enter the rotary and exit onto Way Name",
+        "en": "Enter the traffic circle and exit onto Way Name",
         "eo": "Enveturu trafikcirklegon kaj elveturu al Way Name",
         "es": "Entra en la rotonda y sal en Way Name",
         "es-ES": "En la rotonda sal por Way Name",

--- a/test/fixtures/v5/rotary/default_exit_destination.json
+++ b/test/fixtures/v5/rotary/default_exit_destination.json
@@ -10,7 +10,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die Ausfahrt Richtung Destination 1 nehmen",
-        "en": "Enter the rotary and exit towards Destination 1",
+        "en": "Enter the traffic circle and exit towards Destination 1",
         "eo": "Enveturu trafikcirklegon kaj elveturu direkte al Destination 1",
         "es": "Entra en la rotonda y sal hacia Destination 1",
         "es-ES": "En la rotonda sal hacia Destination 1",

--- a/test/fixtures/v5/rotary/default_name.json
+++ b/test/fixtures/v5/rotary/default_name.json
@@ -8,7 +8,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die Ausfahrt auf Way Name nehmen",
-        "en": "Enter the rotary and exit onto Way Name",
+        "en": "Enter the traffic circle and exit onto Way Name",
         "eo": "Enveturu trafikcirklegon kaj elveturu al Way Name",
         "es": "Entra en la rotonda y sal en Way Name",
         "es-ES": "En la rotonda sal por Way Name",

--- a/test/fixtures/v5/rotary/exit_10.json
+++ b/test/fixtures/v5/rotary/exit_10.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die zehnte Ausfahrt nehmen",
-        "en": "Enter the rotary and take the 10th exit",
+        "en": "Enter the traffic circle and take the 10th exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 10-a elveturejo",
         "es": "Entra en la rotonda y toma la 10ª salida",
         "es-ES": "En la rotonda toma la 10ª salida",

--- a/test/fixtures/v5/rotary/exit_11.json
+++ b/test/fixtures/v5/rotary/exit_11.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die Ausfahrt nehmen",
-        "en": "Enter the rotary and take the exit",
+        "en": "Enter the traffic circle and take the exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al elveturejo",
         "es": "Entra en la rotonda y toma la salida",
         "es-ES": "En la rotonda toma la salida",

--- a/test/fixtures/v5/rotary/exit_1_default.json
+++ b/test/fixtures/v5/rotary/exit_1_default.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen",
-        "en": "Enter the rotary and take the 1st exit",
+        "en": "Enter the traffic circle and take the 1st exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 1-a elveturejo",
         "es": "Entra en la rotonda y toma la 1ª salida",
         "es-ES": "En la rotonda toma la 1ª salida",

--- a/test/fixtures/v5/rotary/exit_1_destination.json
+++ b/test/fixtures/v5/rotary/exit_1_destination.json
@@ -10,7 +10,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen Richtung Destination 1",
-        "en": "Enter the rotary and take the 1st exit towards Destination 1",
+        "en": "Enter the traffic circle and take the 1st exit towards Destination 1",
         "eo": "Enveturu trafikcirklegon kaj sekve al 1-a elveturejo direkte al Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "es-ES": "En la rotonda toma la 1ª salida hacia Destination 1",

--- a/test/fixtures/v5/rotary/exit_1_exit.json
+++ b/test/fixtures/v5/rotary/exit_1_exit.json
@@ -10,7 +10,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen auf Way Name",
-        "en": "Enter the rotary and take the 1st exit onto Way Name",
+        "en": "Enter the traffic circle and take the 1st exit onto Way Name",
         "eo": "Enveturu trafikcirklegon kaj sekve al 1-a elveturejo al Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
         "es-ES": "En la rotonda toma la 1ª salida por Way Name",

--- a/test/fixtures/v5/rotary/exit_1_exit_destination.json
+++ b/test/fixtures/v5/rotary/exit_1_exit_destination.json
@@ -11,7 +11,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen Richtung Destination 1",
-        "en": "Enter the rotary and take the 1st exit towards Destination 1",
+        "en": "Enter the traffic circle and take the 1st exit towards Destination 1",
         "eo": "Enveturu trafikcirklegon kaj sekve al 1-a elveturejo direkte al Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "es-ES": "En la rotonda toma la 1ª salida hacia Destination 1",

--- a/test/fixtures/v5/rotary/exit_1_name.json
+++ b/test/fixtures/v5/rotary/exit_1_name.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen auf Way Name",
-        "en": "Enter the rotary and take the 1st exit onto Way Name",
+        "en": "Enter the traffic circle and take the 1st exit onto Way Name",
         "eo": "Enveturu trafikcirklegon kaj sekve al 1-a elveturejo al Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
         "es-ES": "En la rotonda toma la 1ª salida por Way Name",

--- a/test/fixtures/v5/rotary/exit_2.json
+++ b/test/fixtures/v5/rotary/exit_2.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die zweite Ausfahrt nehmen",
-        "en": "Enter the rotary and take the 2nd exit",
+        "en": "Enter the traffic circle and take the 2nd exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 2-a elveturejo",
         "es": "Entra en la rotonda y toma la 2ª salida",
         "es-ES": "En la rotonda toma la 2ª salida",

--- a/test/fixtures/v5/rotary/exit_3.json
+++ b/test/fixtures/v5/rotary/exit_3.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die dritte Ausfahrt nehmen",
-        "en": "Enter the rotary and take the 3rd exit",
+        "en": "Enter the traffic circle and take the 3rd exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 3-a elveturejo",
         "es": "Entra en la rotonda y toma la 3ª salida",
         "es-ES": "En la rotonda toma la 3ª salida",

--- a/test/fixtures/v5/rotary/exit_4.json
+++ b/test/fixtures/v5/rotary/exit_4.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die vierte Ausfahrt nehmen",
-        "en": "Enter the rotary and take the 4th exit",
+        "en": "Enter the traffic circle and take the 4th exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 4-a elveturejo",
         "es": "Entra en la rotonda y toma la 4ª salida",
         "es-ES": "En la rotonda toma la 4ª salida",

--- a/test/fixtures/v5/rotary/exit_5.json
+++ b/test/fixtures/v5/rotary/exit_5.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die fünfte Ausfahrt nehmen",
-        "en": "Enter the rotary and take the 5th exit",
+        "en": "Enter the traffic circle and take the 5th exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 5-a elveturejo",
         "es": "Entra en la rotonda y toma la 5ª salida",
         "es-ES": "En la rotonda toma la 5ª salida",

--- a/test/fixtures/v5/rotary/exit_6.json
+++ b/test/fixtures/v5/rotary/exit_6.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die sechste Ausfahrt nehmen",
-        "en": "Enter the rotary and take the 6th exit",
+        "en": "Enter the traffic circle and take the 6th exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 6-a elveturejo",
         "es": "Entra en la rotonda y toma la 6ª salida",
         "es-ES": "En la rotonda toma la 6ª salida",

--- a/test/fixtures/v5/rotary/exit_7.json
+++ b/test/fixtures/v5/rotary/exit_7.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die siebente Ausfahrt nehmen",
-        "en": "Enter the rotary and take the 7th exit",
+        "en": "Enter the traffic circle and take the 7th exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 7-a elveturejo",
         "es": "Entra en la rotonda y toma la 7ª salida",
         "es-ES": "En la rotonda toma la 7ª salida",

--- a/test/fixtures/v5/rotary/exit_8.json
+++ b/test/fixtures/v5/rotary/exit_8.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die achte Ausfahrt nehmen",
-        "en": "Enter the rotary and take the 8th exit",
+        "en": "Enter the traffic circle and take the 8th exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 8-a elveturejo",
         "es": "Entra en la rotonda y toma la 8ª salida",
         "es-ES": "En la rotonda toma la 8ª salida",

--- a/test/fixtures/v5/rotary/exit_9.json
+++ b/test/fixtures/v5/rotary/exit_9.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die neunte Ausfahrt nehmen",
-        "en": "Enter the rotary and take the 9th exit",
+        "en": "Enter the traffic circle and take the 9th exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 9-a elveturejo",
         "es": "Entra en la rotonda y toma la 9ª salida",
         "es-ES": "En la rotonda toma la 9ª salida",

--- a/test/fixtures/v5/roundabout/default_default.json
+++ b/test/fixtures/v5/roundabout/default_default.json
@@ -8,7 +8,7 @@
     },
     "instructions": {
         "de": "In den Kreisverkehr fahren",
-        "en": "Enter the roundabout",
+        "en": "Enter the traffic circle",
         "eo": "Enveturu trafikcirklon",
         "es": "Entra en la rotonda",
         "es-ES": "Entra en la rotonda",

--- a/test/fixtures/v5/roundabout/default_destination.json
+++ b/test/fixtures/v5/roundabout/default_destination.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die Ausfahrt Richtung Destination 1 nehmen",
-        "en": "Enter the roundabout and exit towards Destination 1",
+        "en": "Enter the traffic circle and exit towards Destination 1",
         "eo": "Enveturu trafikcirklon kaj elveturu direkte al Destination 1",
         "es": "Entra en la rotonda y sal hacia Destination 1",
         "es-ES": "Entra en la rotonda y sal hacia Destination 1",

--- a/test/fixtures/v5/roundabout/default_exit.json
+++ b/test/fixtures/v5/roundabout/default_exit.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die Ausfahrt auf Way Name nehmen",
-        "en": "Enter the roundabout and exit onto Way Name",
+        "en": "Enter the traffic circle and exit onto Way Name",
         "eo": "Enveturu trafikcirklon kaj elveturu al Way Name",
         "es": "Entra en la rotonda y sal en Way Name",
         "es-ES": "Entra en la rotonda y sal por Way Name",

--- a/test/fixtures/v5/roundabout/default_exit_destination.json
+++ b/test/fixtures/v5/roundabout/default_exit_destination.json
@@ -10,7 +10,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die Ausfahrt Richtung Destination 1 nehmen",
-        "en": "Enter the roundabout and exit towards Destination 1",
+        "en": "Enter the traffic circle and exit towards Destination 1",
         "eo": "Enveturu trafikcirklon kaj elveturu direkte al Destination 1",
         "es": "Entra en la rotonda y sal hacia Destination 1",
         "es-ES": "Entra en la rotonda y sal hacia Destination 1",

--- a/test/fixtures/v5/roundabout/default_name.json
+++ b/test/fixtures/v5/roundabout/default_name.json
@@ -8,7 +8,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die Ausfahrt auf Way Name nehmen",
-        "en": "Enter the roundabout and exit onto Way Name",
+        "en": "Enter the traffic circle and exit onto Way Name",
         "eo": "Enveturu trafikcirklon kaj elveturu al Way Name",
         "es": "Entra en la rotonda y sal en Way Name",
         "es-ES": "Entra en la rotonda y sal por Way Name",

--- a/test/fixtures/v5/roundabout/exit_default.json
+++ b/test/fixtures/v5/roundabout/exit_default.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen",
-        "en": "Enter the roundabout and take the 1st exit",
+        "en": "Enter the traffic circle and take the 1st exit",
         "eo": "Enveturu trafikcirklon kaj sekve al 1-a elveturejo",
         "es": "Entra en la rotonda y toma la 1ª salida",
         "es-ES": "Entra en la rotonda y toma la 1ª salida",

--- a/test/fixtures/v5/roundabout/exit_destination.json
+++ b/test/fixtures/v5/roundabout/exit_destination.json
@@ -10,7 +10,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen Richtung Destination 1",
-        "en": "Enter the roundabout and take the 1st exit towards Destination 1",
+        "en": "Enter the traffic circle and take the 1st exit towards Destination 1",
         "eo": "Enveturu trafikcirklon kaj sekve al 1-a elveturejo direkte al Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "es-ES": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",

--- a/test/fixtures/v5/roundabout/exit_exit.json
+++ b/test/fixtures/v5/roundabout/exit_exit.json
@@ -10,7 +10,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen auf Way Name",
-        "en": "Enter the roundabout and take the 1st exit onto Way Name",
+        "en": "Enter the traffic circle and take the 1st exit onto Way Name",
         "eo": "Enveturu trafikcirklon kaj sekve al 1-a elveturejo al Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
         "es-ES": "Entra en la rotonda y toma la 1ª salida por Way Name",

--- a/test/fixtures/v5/roundabout/exit_exit_destination.json
+++ b/test/fixtures/v5/roundabout/exit_exit_destination.json
@@ -11,7 +11,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen Richtung Destination 1",
-        "en": "Enter the roundabout and take the 1st exit towards Destination 1",
+        "en": "Enter the traffic circle and take the 1st exit towards Destination 1",
         "eo": "Enveturu trafikcirklon kaj sekve al 1-a elveturejo direkte al Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "es-ES": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",

--- a/test/fixtures/v5/roundabout/exit_name.json
+++ b/test/fixtures/v5/roundabout/exit_name.json
@@ -9,7 +9,7 @@
     },
     "instructions": {
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen auf Way Name",
-        "en": "Enter the roundabout and take the 1st exit onto Way Name",
+        "en": "Enter the traffic circle and take the 1st exit onto Way Name",
         "eo": "Enveturu trafikcirklon kaj sekve al 1-a elveturejo al Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
         "es-ES": "Entra en la rotonda y toma la 1ª salida por Way Name",


### PR DESCRIPTION
I haven't updated the 'roundabout turn' instructions here as I'm not sure 'traffic circle' is the best option in this case.

While 'rotary' and 'roundabout' are more precise, 'traffic circle' is more largely understood, at least in US English.

@1ec5 do you have any thoughts on this or insight into the `roundabout turn` situation?