### PR TITLE
Added new untranslated Swedish strings related to roundabouts and rotary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. For change 
 ## master
 
 - Added a `merge straight` instruction [#183](https://github.com/Project-OSRM/osrm-text-instructions/pull/183)
+- Added new untranslated Swedish strings related to roundabouts and rotary [#186](https://github.com/Project-OSRM/osrm-text-instructions/pull/186)
 
 ## 0.10.4 2017-10-26
 

--- a/languages/translations/sv.json
+++ b/languages/translations/sv.json
@@ -134,7 +134,7 @@
             "default": {
                 "default": "Kör åt {direction}",
                 "name": "Kör åt {direction} på {way_name}",
-                "namedistance": "Head {direction} on {way_name} for {distance}"
+                "namedistance": "Kör {distance} åt {direction} på {way_name}"
             }
         },
         "end of road": {
@@ -364,7 +364,7 @@
             "default": {
                 "default": {
                     "default": "Kör in i rondellen",
-                    "name": "I rondellen ta av in på {way_name}",
+                    "name": "I rondellen ta avfarten in på {way_name}",
                     "destination": "I rondellen ta av mot {destination}"
                 },
                 "name": {
@@ -393,7 +393,7 @@
                 },
                 "default": {
                     "default": "Kör in i rondellen",
-                    "name": "I rondellen ta av mot {way_name}",
+                    "name": "I rondellen ta avfarten in på {way_name}",
                     "destination": "I rondellen ta av mot {destination}"
                 }
             }
@@ -422,46 +422,16 @@
         },
         "exit roundabout": {
             "default": {
-                "default": "Sväng {modifier}",
-                "name": "Sväng {modifier} in på {way_name}",
-                "destination": "Sväng {modifier} mot {destination}"
-            },
-            "left": {
-                "default": "Sväng vänster",
-                "name": "Sväng vänster in på {way_name}",
-                "destination": "Sväng vänster mot {destination}"
-            },
-            "right": {
-                "default": "Sväng höger",
-                "name": "Sväng höger in på {way_name}",
-                "destination": "Sväng höger mot {destination}"
-            },
-            "straight": {
-                "default": "Kör rakt fram",
-                "name": "Kör rakt fram in på {way_name}",
-                "destination": "Kör rakt fram mot {destination}"
+                "default": "Kör ut ur rondellen",
+                "name": "Kör ut ur rondellen in på {way_name}",
+                "destination": "Kör ut ur rondellen mot {destination}"
             }
         },
         "exit rotary": {
             "default": {
-                "default": "Sväng {modifier}",
-                "name": "Sväng {modifier} in på {way_name}",
-                "destination": "Sväng {modifier} mot {destination}"
-            },
-            "left": {
-                "default": "Sväng vänster",
-                "name": "Sväng vänster in på {way_name}",
-                "destination": "Sväng vänster mot {destination}"
-            },
-            "right": {
-                "default": "Sväng höger",
-                "name": "Sväng höger in på {way_name}",
-                "destination": "Sväng höger mot {destination}"
-            },
-            "straight": {
-                "default": "Kör rakt fram",
-                "name": "Kör rakt fram in på {way_name}",
-                "destination": "Kör rakt fram mot {destination}"
+                "default": "Kör ut ur rondellen",
+                "name": "Kör ut ur rondellen in på {way_name}",
+                "destination": "Kör ut ur rondellen mot {destination}"
             }
         },
         "turn": {

--- a/languages/translations/sv.json
+++ b/languages/translations/sv.json
@@ -59,35 +59,35 @@
         "arrive": {
             "default": {
                 "default": "Du är framme vid din {nth} destination",
-                "upcoming": "Du är framme vid din {nth} destination"
+                "upcoming": "Du är snart framme vid din {nth} destination"
             },
             "left": {
                 "default": "Du är framme vid din {nth} destination, till vänster",
-                "upcoming": "Du är framme vid din {nth} destination, till vänster"
+                "upcoming": "Du är snart framme vid din {nth} destination, till vänster"
             },
             "right": {
                 "default": "Du är framme vid din {nth} destination, till höger",
-                "upcoming": "Du är framme vid din {nth} destination, till höger"
+                "upcoming": "Du är snart framme vid din {nth} destination, till höger"
             },
             "sharp left": {
-                "default": "Du är framme vid din {nth} destination, skarpt till vänster",
-                "upcoming": "Du är framme vid din {nth} destination, skarpt till vänster"
+                "default": "Du är framme vid din {nth} destination, till vänster",
+                "upcoming": "Du är snart framme vid din {nth} destination, till vänster"
             },
             "sharp right": {
-                "default": "Du är framme vid din {nth} destination, skarpt till höger",
-                "upcoming": "Du är framme vid din {nth} destination, skarpt till höger"
+                "default": "Du är framme vid din {nth} destination, till höger",
+                "upcoming": "Du är snart framme vid din {nth} destination, till höger"
             },
             "slight right": {
                 "default": "Du är framme vid din {nth} destination, till höger",
-                "upcoming": "Du är framme vid din {nth} destination, till höger"
+                "upcoming": "Du är snart framme vid din {nth} destination, till höger"
             },
             "slight left": {
                 "default": "Du är framme vid din {nth} destination, till vänster",
-                "upcoming": "Du är framme vid din {nth} destination, till vänster"
+                "upcoming": "Du är snart framme vid din {nth} destination, till vänster"
             },
             "straight": {
                 "default": "Du är framme vid din {nth} destination, rakt fram",
-                "upcoming": "Du är framme vid din {nth} destination, rakt fram"
+                "upcoming": "Du är snart framme vid din {nth} destination, rakt fram"
             }
         },
         "continue": {
@@ -189,8 +189,8 @@
         "merge": {
             "default": {
                 "default": "Byt till {modifier} körfält",
-                "name": "Byt till {modifier} körfält in på {way_name}",
-                "destination": "Byt till {modifier} körfält mot {destination}"
+                "name": "Byt till {modifier} körfält, in på {way_name}",
+                "destination": "Byt till {modifier} körfält, mot {destination}"
             },
             "straight": {
                 "default": "Byt till rakt fram körfält",
@@ -199,23 +199,23 @@
             },
             "slight left": {
                 "default": "Byt till vänstra körfältet",
-                "name": "Byt till vänstra körfältet in på {way_name}",
-                "destination": "Byt till vänstra körfältet mot {destination}"
+                "name": "Byt till vänstra körfältet, in på {way_name}",
+                "destination": "Byt till vänstra körfältet, mot {destination}"
             },
             "slight right": {
                 "default": "Byt till högra körfältet",
-                "name": "Byt till högra körfältet in på {way_name}",
-                "destination": "Byt till högra körfältet mot {destination}"
+                "name": "Byt till högra körfältet, in på {way_name}",
+                "destination": "Byt till högra körfältet, mot {destination}"
             },
             "sharp left": {
                 "default": "Byt till vänstra körfältet",
-                "name": "Byt till vänstra körfältet in på {way_name}",
-                "destination": "Byt till vänstra körfältet mot {destination}"
+                "name": "Byt till vänstra körfältet, in på {way_name}",
+                "destination": "Byt till vänstra körfältet, mot {destination}"
             },
             "sharp right": {
                 "default": "Byt till högra körfältet",
-                "name": "Byt till högra körfältet in på {way_name}",
-                "destination": "Byt till högra körfältet mot {destination}"
+                "name": "Byt till högra körfältet, in på {way_name}",
+                "destination": "Byt till högra körfältet, mot {destination}"
             },
             "uturn": {
                 "default": "Gör en U-sväng",
@@ -364,60 +364,60 @@
             "default": {
                 "default": {
                     "default": "Kör in i rondellen",
-                    "name": "I rondellen ta avfarten in på {way_name}",
-                    "destination": "I rondellen ta av mot {destination}"
+                    "name": "I rondellen, ta avfarten in på {way_name}",
+                    "destination": "I rondellen, ta av mot {destination}"
                 },
                 "name": {
                     "default": "Kör in i {rotary_name}",
-                    "name": "I {rotary_name} ta av in på {way_name}",
-                    "destination": "I {rotary_name} ta av mot {destination}"
+                    "name": "I {rotary_name}, ta av in på {way_name}",
+                    "destination": "I {rotary_name}, ta av mot {destination}"
                 },
                 "exit": {
-                    "default": "I rondellen ta {exit_number} avfarten",
-                    "name": "I rondellen ta {exit_number} avfarten in på {way_name}",
-                    "destination": "I rondellen ta {exit_number} avfarten mot {destination}"
+                    "default": "I rondellen, ta {exit_number} avfarten",
+                    "name": "I rondellen, ta {exit_number} avfarten in på {way_name}",
+                    "destination": "I rondellen, ta {exit_number} avfarten mot {destination}"
                 },
                 "name_exit": {
-                    "default": "I {rotary_name} ta {exit_number} avfarten",
-                    "name": "I {rotary_name} ta {exit_number}  avfarten in på {way_name}",
-                    "destination": "I {rotary_name} ta {exit_number} avfarten mot {destination}"
+                    "default": "I {rotary_name}, ta {exit_number} avfarten",
+                    "name": "I {rotary_name}, ta {exit_number}  avfarten in på {way_name}",
+                    "destination": "I {rotary_name}, ta {exit_number} avfarten mot {destination}"
                 }
             }
         },
         "roundabout": {
             "default": {
                 "exit": {
-                    "default": "I rondellen ta {exit_number} avfarten",
-                    "name": "I rondellen ta {exit_number} avfarten in på {way_name}",
-                    "destination": "I rondellen ta {exit_number} avfarten mot {destination}"
+                    "default": "I rondellen, ta {exit_number} avfarten",
+                    "name": "I rondellen, ta {exit_number} avfarten in på {way_name}",
+                    "destination": "I rondellen, ta {exit_number} avfarten mot {destination}"
                 },
                 "default": {
                     "default": "Kör in i rondellen",
-                    "name": "I rondellen ta avfarten in på {way_name}",
-                    "destination": "I rondellen ta av mot {destination}"
+                    "name": "I rondellen, ta avfarten in på {way_name}",
+                    "destination": "I rondellen, ta av mot {destination}"
                 }
             }
         },
         "roundabout turn": {
             "default": {
-                "default": "I rondellen sväng {modifier}",
-                "name": "I rondellen sväng {modifier} in på {way_name}",
-                "destination": "I rondellen sväng {modifier} mot {destination}"
+                "default": "I rondellen, sväng {modifier}",
+                "name": "I rondellen, sväng {modifier} in på {way_name}",
+                "destination": "I rondellen, sväng {modifier} mot {destination}"
             },
             "left": {
-                "default": "I rondellen sväng vänster",
-                "name": "I rondellen sväng vänster in på {way_name}",
-                "destination": "I rondellen sväng vänster mot {destination}"
+                "default": "I rondellen, sväng vänster",
+                "name": "I rondellen, sväng vänster in på {way_name}",
+                "destination": "I rondellen, sväng vänster mot {destination}"
             },
             "right": {
-                "default": "I rondellen sväng höger",
-                "name": "I rondellen sväng höger in på {way_name}",
-                "destination": "I rondellen sväng höger mot {destination}"
+                "default": "I rondellen, sväng höger",
+                "name": "I rondellen, sväng höger in på {way_name}",
+                "destination": "I rondellen, sväng höger mot {destination}"
             },
             "straight": {
-                "default": "I rondellen fortsätt rakt fram",
-                "name": "I rondellen fortsätt rakt fram in på {way_name}",
-                "destination": "I rondellen fortsätt rakt fram mot {destination}"
+                "default": "I rondellen, fortsätt rakt fram",
+                "name": "I rondellen, fortsätt rakt fram in på {way_name}",
+                "destination": "I rondellen, fortsätt rakt fram mot {destination}"
             }
         },
         "exit roundabout": {

--- a/test/fixtures/v5/arrive/sharp_left.json
+++ b/test/fixtures/v5/arrive/sharp_left.json
@@ -20,7 +20,7 @@
         "pt-BR": "Você chegou ao seu destino, à esquerda",
         "ro": "Ați ajuns la destinație, pe stânga",
         "ru": "Вы прибыли в пункт назначения, он находится слева",
-        "sv": "Du är framme vid din destination, skarpt till vänster",
+        "sv": "Du är framme vid din destination, till vänster",
         "tr": " hedefinize ulaştınız, hedefiniz solunuzdadır",
         "uk": "Ви прибули у ваш пункт призначення, він – ліворуч",
         "vi": "Đến nơi ở bên trái",

--- a/test/fixtures/v5/arrive/sharp_right.json
+++ b/test/fixtures/v5/arrive/sharp_right.json
@@ -20,7 +20,7 @@
         "pt-BR": "Você chegou ao seu destino, à direita",
         "ro": "Ați ajuns la destinație, pe dreapta",
         "ru": "Вы прибыли в пункт назначения, он находится справа",
-        "sv": "Du är framme vid din destination, skarpt till höger",
+        "sv": "Du är framme vid din destination, till höger",
         "tr": " hedefinize ulaştınız, hedefiniz sağınızdadır",
         "uk": "Ви прибули у ваш пункт призначення, він – праворуч",
         "vi": "Đến nơi ở bên phải",

--- a/test/fixtures/v5/arrive_waypoint/sharp_left.json
+++ b/test/fixtures/v5/arrive_waypoint/sharp_left.json
@@ -20,7 +20,7 @@
         "pt-BR": "Você chegou ao seu 1º destino, à esquerda",
         "ro": "Ați ajuns la prima destinație, pe stânga",
         "ru": "Вы прибыли в первый пункт назначения, он находится слева",
-        "sv": "Du är framme vid din 1:a destination, skarpt till vänster",
+        "sv": "Du är framme vid din 1:a destination, till vänster",
         "tr": "Birinci hedefinize ulaştınız, hedefiniz solunuzdadır",
         "uk": "Ви прибули у ваш 1й пункт призначення, він – ліворуч",
         "vi": "Đến nơi đầu tiên ở bên trái",

--- a/test/fixtures/v5/arrive_waypoint/sharp_right.json
+++ b/test/fixtures/v5/arrive_waypoint/sharp_right.json
@@ -20,7 +20,7 @@
         "pt-BR": "Você chegou ao seu 1º destino, à direita",
         "ro": "Ați ajuns la prima destinație, pe dreapta",
         "ru": "Вы прибыли в первый пункт назначения, он находится справа",
-        "sv": "Du är framme vid din 1:a destination, skarpt till höger",
+        "sv": "Du är framme vid din 1:a destination, till höger",
         "tr": "Birinci hedefinize ulaştınız, hedefiniz sağınızdadır",
         "uk": "Ви прибули у ваш 1й пункт призначення, він – праворуч",
         "vi": "Đến nơi đầu tiên ở bên phải",

--- a/test/fixtures/v5/arrive_waypoint_last/sharp_left.json
+++ b/test/fixtures/v5/arrive_waypoint_last/sharp_left.json
@@ -20,7 +20,7 @@
         "pt-BR": "Você chegou ao seu destino, à esquerda",
         "ro": "Ați ajuns la destinație, pe stânga",
         "ru": "Вы прибыли в пункт назначения, он находится слева",
-        "sv": "Du är framme vid din destination, skarpt till vänster",
+        "sv": "Du är framme vid din destination, till vänster",
         "tr": " hedefinize ulaştınız, hedefiniz solunuzdadır",
         "uk": "Ви прибули у ваш пункт призначення, він – ліворуч",
         "vi": "Đến nơi ở bên trái",

--- a/test/fixtures/v5/arrive_waypoint_last/sharp_right.json
+++ b/test/fixtures/v5/arrive_waypoint_last/sharp_right.json
@@ -20,7 +20,7 @@
         "pt-BR": "Você chegou ao seu destino, à direita",
         "ro": "Ați ajuns la destinație, pe dreapta",
         "ru": "Вы прибыли в пункт назначения, он находится справа",
-        "sv": "Du är framme vid din destination, skarpt till höger",
+        "sv": "Du är framme vid din destination, till höger",
         "tr": " hedefinize ulaştınız, hedefiniz sağınızdadır",
         "uk": "Ви прибули у ваш пункт призначення, він – праворуч",
         "vi": "Đến nơi ở bên phải",

--- a/test/fixtures/v5/exit_rotary/left_default.json
+++ b/test/fixtures/v5/exit_rotary/left_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Vire à esquerda",
         "ro": "Virați stânga",
         "ru": "Сверните налево",
-        "sv": "Sväng vänster",
+        "sv": "Kör ut ur rondellen",
         "tr": "Sola dön",
         "uk": "Поверніть ліворуч",
         "vi": "Quẹo trái",

--- a/test/fixtures/v5/exit_rotary/left_destination.json
+++ b/test/fixtures/v5/exit_rotary/left_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Vire à esquerda sentido Destination 1",
         "ro": "Virați stânga spre Destination 1",
         "ru": "Сверните налево в направлении Destination 1",
-        "sv": "Sväng vänster mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde sola dön",
         "uk": "Поверніть ліворуч у напрямку Destination 1",
         "vi": "Quẹo trái đến Destination 1",

--- a/test/fixtures/v5/exit_rotary/left_exit.json
+++ b/test/fixtures/v5/exit_rotary/left_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Vire à esquerda em Way Name",
         "ro": "Virați stânga pe Way Name",
         "ru": "Сверните налево на Way Name",
-        "sv": "Sväng vänster in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde sola dön",
         "uk": "Поверніть ліворуч на Way Name",
         "vi": "Quẹo trái vào Way Name",

--- a/test/fixtures/v5/exit_rotary/left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/left_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Vire à esquerda sentido Destination 1",
         "ro": "Virați stânga spre Destination 1",
         "ru": "Сверните налево в направлении Destination 1",
-        "sv": "Sväng vänster mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde sola dön",
         "uk": "Поверніть ліворуч у напрямку Destination 1",
         "vi": "Quẹo trái đến Destination 1",

--- a/test/fixtures/v5/exit_rotary/left_name.json
+++ b/test/fixtures/v5/exit_rotary/left_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Vire à esquerda em Way Name",
         "ro": "Virați stânga pe Way Name",
         "ru": "Сверните налево на Way Name",
-        "sv": "Sväng vänster in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde sola dön",
         "uk": "Поверніть ліворуч на Way Name",
         "vi": "Quẹo trái vào Way Name",

--- a/test/fixtures/v5/exit_rotary/right_default.json
+++ b/test/fixtures/v5/exit_rotary/right_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Vire à direita",
         "ro": "Virați dreapta",
         "ru": "Сверните направо",
-        "sv": "Sväng höger",
+        "sv": "Kör ut ur rondellen",
         "tr": "Sağa dön",
         "uk": "Поверніть праворуч",
         "vi": "Quẹo phải",

--- a/test/fixtures/v5/exit_rotary/right_destination.json
+++ b/test/fixtures/v5/exit_rotary/right_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Vire à direita sentido Destination 1",
         "ro": "Virați dreapta spre Destination 1",
         "ru": "Сверните направо в направлении Destination 1",
-        "sv": "Sväng höger mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde sağa dön",
         "uk": "Поверніть праворуч у напрямку Destination 1",
         "vi": "Quẹo phải đến Destination 1",

--- a/test/fixtures/v5/exit_rotary/right_exit.json
+++ b/test/fixtures/v5/exit_rotary/right_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Vire à direita em Way Name",
         "ro": "Virați dreapta pe Way Name",
         "ru": "Сверните направо на Way Name",
-        "sv": "Sväng höger in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde sağa dön",
         "uk": "Поверніть праворуч на Way Name",
         "vi": "Quẹo phải vào Way Name",

--- a/test/fixtures/v5/exit_rotary/right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/right_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Vire à direita sentido Destination 1",
         "ro": "Virați dreapta spre Destination 1",
         "ru": "Сверните направо в направлении Destination 1",
-        "sv": "Sväng höger mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde sağa dön",
         "uk": "Поверніть праворуч у напрямку Destination 1",
         "vi": "Quẹo phải đến Destination 1",

--- a/test/fixtures/v5/exit_rotary/right_name.json
+++ b/test/fixtures/v5/exit_rotary/right_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Vire à direita em Way Name",
         "ro": "Virați dreapta pe Way Name",
         "ru": "Сверните направо на Way Name",
-        "sv": "Sväng höger in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde sağa dön",
         "uk": "Поверніть праворуч на Way Name",
         "vi": "Quẹo phải vào Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_left_default.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga acentuadamente à esquerda",
         "ro": "Virați brusc stânga",
         "ru": "Двигайтесь налево",
-        "sv": "Sväng vänster",
+        "sv": "Kör ut ur rondellen",
         "tr": "Keskin sol yöne dön",
         "uk": "Рухайтесь різко ліворуч",
         "vi": "Quẹo trái gắt",

--- a/test/fixtures/v5/exit_rotary/sharp_left_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga acentuadamente à esquerda sentido Destination 1",
         "ro": "Virați brusc stânga spre Destination 1",
         "ru": "Двигайтесь налево в направлении Destination 1",
-        "sv": "Sväng vänster mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde keskin sol yöne dön",
         "uk": "Рухайтесь різко ліворуч в напрямку Destination 1",
         "vi": "Quẹo trái gắt đến Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_left_exit.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga acentuadamente à esquerda em Way Name",
         "ro": "Virați brusc stânga pe Way Name",
         "ru": "Двигайтесь налево на Way Name",
-        "sv": "Sväng vänster in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde keskin sol yöne dön",
         "uk": "Рухайтесь різко ліворуч на Way Name",
         "vi": "Quẹo trái gắt vào Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Siga acentuadamente à esquerda sentido Destination 1",
         "ro": "Virați brusc stânga spre Destination 1",
         "ru": "Двигайтесь налево в направлении Destination 1",
-        "sv": "Sväng vänster mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde keskin sol yöne dön",
         "uk": "Рухайтесь різко ліворуч в напрямку Destination 1",
         "vi": "Quẹo trái gắt đến Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_left_name.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga acentuadamente à esquerda em Way Name",
         "ro": "Virați brusc stânga pe Way Name",
         "ru": "Двигайтесь налево на Way Name",
-        "sv": "Sväng vänster in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde keskin sol yöne dön",
         "uk": "Рухайтесь різко ліворуч на Way Name",
         "vi": "Quẹo trái gắt vào Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_right_default.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga acentuadamente à direita",
         "ro": "Virați brusc dreapta",
         "ru": "Двигайтесь направо",
-        "sv": "Sväng höger",
+        "sv": "Kör ut ur rondellen",
         "tr": "Keskin sağ yöne dön",
         "uk": "Рухайтесь різко праворуч",
         "vi": "Quẹo phải gắt",

--- a/test/fixtures/v5/exit_rotary/sharp_right_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga acentuadamente à direita sentido Destination 1",
         "ro": "Virați brusc dreapta spre Destination 1",
         "ru": "Двигайтесь направо в направлении Destination 1",
-        "sv": "Sväng höger mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde keskin sağ yöne dön",
         "uk": "Рухайтесь різко праворуч в напрямку Destination 1",
         "vi": "Quẹo phải gắt đến Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_right_exit.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga acentuadamente à direita em Way Name",
         "ro": "Virați brusc dreapta pe Way Name",
         "ru": "Двигайтесь направо на Way Name",
-        "sv": "Sväng höger in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde keskin sağ yöne dön",
         "uk": "Рухайтесь різко праворуч на Way Name",
         "vi": "Quẹo phải gắt vào Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Siga acentuadamente à direita sentido Destination 1",
         "ro": "Virați brusc dreapta spre Destination 1",
         "ru": "Двигайтесь направо в направлении Destination 1",
-        "sv": "Sväng höger mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde keskin sağ yöne dön",
         "uk": "Рухайтесь різко праворуч в напрямку Destination 1",
         "vi": "Quẹo phải gắt đến Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_right_name.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga acentuadamente à direita em Way Name",
         "ro": "Virați brusc dreapta pe Way Name",
         "ru": "Двигайтесь направо на Way Name",
-        "sv": "Sväng höger in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde keskin sağ yöne dön",
         "uk": "Рухайтесь різко праворуч на Way Name",
         "vi": "Quẹo phải gắt vào Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_left_default.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga ligeiramente à esquerda",
         "ro": "Virați ușor stânga",
         "ru": "Двигайтесь левее",
-        "sv": "Sväng vänster",
+        "sv": "Kör ut ur rondellen",
         "tr": "Hafif sol yöne dön",
         "uk": "Рухайтесь плавно ліворуч",
         "vi": "Quẹo trái nghiêng",

--- a/test/fixtures/v5/exit_rotary/slight_left_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga ligeiramente à esquerda sentido Destination 1",
         "ro": "Virați ușor stânga spre Destination 1",
         "ru": "Двигайтесь левее в направлении Destination 1",
-        "sv": "Sväng vänster mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde hafif sol yöne dön",
         "uk": "Рухайтесь плавно ліворуч в напрямку Destination 1",
         "vi": "Quẹo trái nghiêng đến Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_left_exit.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga ligeiramente à esquerda em Way Name",
         "ro": "Virați ușor stânga pe Way Name",
         "ru": "Двигайтесь левее на Way Name",
-        "sv": "Sväng vänster in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde hafif sol yöne dön",
         "uk": "Рухайтесь плавно ліворуч на Way Name",
         "vi": "Quẹo trái nghiêng vào Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Siga ligeiramente à esquerda sentido Destination 1",
         "ro": "Virați ușor stânga spre Destination 1",
         "ru": "Двигайтесь левее в направлении Destination 1",
-        "sv": "Sväng vänster mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde hafif sol yöne dön",
         "uk": "Рухайтесь плавно ліворуч в напрямку Destination 1",
         "vi": "Quẹo trái nghiêng đến Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_left_name.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga ligeiramente à esquerda em Way Name",
         "ro": "Virați ușor stânga pe Way Name",
         "ru": "Двигайтесь левее на Way Name",
-        "sv": "Sväng vänster in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde hafif sol yöne dön",
         "uk": "Рухайтесь плавно ліворуч на Way Name",
         "vi": "Quẹo trái nghiêng vào Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_right_default.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga ligeiramente à direita",
         "ro": "Virați ușor dreapta",
         "ru": "Двигайтесь правее",
-        "sv": "Sväng höger",
+        "sv": "Kör ut ur rondellen",
         "tr": "Hafif sağ yöne dön",
         "uk": "Рухайтесь плавно праворуч",
         "vi": "Quẹo phải nghiêng",

--- a/test/fixtures/v5/exit_rotary/slight_right_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga ligeiramente à direita sentido Destination 1",
         "ro": "Virați ușor dreapta spre Destination 1",
         "ru": "Двигайтесь правее в направлении Destination 1",
-        "sv": "Sväng höger mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde hafif sağ yöne dön",
         "uk": "Рухайтесь плавно праворуч в напрямку Destination 1",
         "vi": "Quẹo phải nghiêng đến Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_right_exit.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga ligeiramente à direita em Way Name",
         "ro": "Virați ușor dreapta pe Way Name",
         "ru": "Двигайтесь правее на Way Name",
-        "sv": "Sväng höger in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde hafif sağ yöne dön",
         "uk": "Рухайтесь плавно праворуч на Way Name",
         "vi": "Quẹo phải nghiêng vào Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Siga ligeiramente à direita sentido Destination 1",
         "ro": "Virați ușor dreapta spre Destination 1",
         "ru": "Двигайтесь правее в направлении Destination 1",
-        "sv": "Sväng höger mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde hafif sağ yöne dön",
         "uk": "Рухайтесь плавно праворуч в напрямку Destination 1",
         "vi": "Quẹo phải nghiêng đến Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_right_name.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga ligeiramente à direita em Way Name",
         "ro": "Virați ușor dreapta pe Way Name",
         "ru": "Двигайтесь правее на Way Name",
-        "sv": "Sväng höger in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde hafif sağ yöne dön",
         "uk": "Рухайтесь плавно праворуч на Way Name",
         "vi": "Quẹo phải nghiêng vào Way Name",

--- a/test/fixtures/v5/exit_rotary/straight_default.json
+++ b/test/fixtures/v5/exit_rotary/straight_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga reto",
         "ro": "Mergeți înainte",
         "ru": "Двигайтесь прямо",
-        "sv": "Kör rakt fram",
+        "sv": "Kör ut ur rondellen",
         "tr": "Düz git",
         "uk": "Рухайтесь прямо",
         "vi": "Chạy thẳng",

--- a/test/fixtures/v5/exit_rotary/straight_destination.json
+++ b/test/fixtures/v5/exit_rotary/straight_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga reto sentido Destination 1",
         "ro": "Mergeți înainte spre Destination 1",
         "ru": "Двигайтесь в направлении Destination 1",
-        "sv": "Kör rakt fram mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde düz git",
         "uk": "Рухайтесь прямо у напрямку Destination 1",
         "vi": "Chạy thẳng đến Destination 1",

--- a/test/fixtures/v5/exit_rotary/straight_exit.json
+++ b/test/fixtures/v5/exit_rotary/straight_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga reto em Way Name",
         "ro": "Mergeți înainte pe Way Name",
         "ru": "Двигайтесь по Way Name",
-        "sv": "Kör rakt fram in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde düz git",
         "uk": "Рухайтесь прямо по Way Name",
         "vi": "Chạy thẳng vào Way Name",

--- a/test/fixtures/v5/exit_rotary/straight_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/straight_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Siga reto sentido Destination 1",
         "ro": "Mergeți înainte spre Destination 1",
         "ru": "Двигайтесь в направлении Destination 1",
-        "sv": "Kör rakt fram mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde düz git",
         "uk": "Рухайтесь прямо у напрямку Destination 1",
         "vi": "Chạy thẳng đến Destination 1",

--- a/test/fixtures/v5/exit_rotary/straight_name.json
+++ b/test/fixtures/v5/exit_rotary/straight_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga reto em Way Name",
         "ro": "Mergeți înainte pe Way Name",
         "ru": "Двигайтесь по Way Name",
-        "sv": "Kör rakt fram in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde düz git",
         "uk": "Рухайтесь прямо по Way Name",
         "vi": "Chạy thẳng vào Way Name",

--- a/test/fixtures/v5/exit_rotary/uturn_default.json
+++ b/test/fixtures/v5/exit_rotary/uturn_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga retorno",
         "ro": "Virați întoarcere",
         "ru": "Двигайтесь на разворот",
-        "sv": "Sväng U-sväng",
+        "sv": "Kör ut ur rondellen",
         "tr": "U dönüşü yöne dön",
         "uk": "Рухайтесь розворот",
         "vi": "Quẹo ngược",

--- a/test/fixtures/v5/exit_rotary/uturn_destination.json
+++ b/test/fixtures/v5/exit_rotary/uturn_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga retorno sentido Destination 1",
         "ro": "Virați întoarcere spre Destination 1",
         "ru": "Двигайтесь на разворот в направлении Destination 1",
-        "sv": "Sväng U-sväng mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde U dönüşü yöne dön",
         "uk": "Рухайтесь розворот в напрямку Destination 1",
         "vi": "Quẹo ngược đến Destination 1",

--- a/test/fixtures/v5/exit_rotary/uturn_exit.json
+++ b/test/fixtures/v5/exit_rotary/uturn_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga retorno em Way Name",
         "ro": "Virați întoarcere pe Way Name",
         "ru": "Двигайтесь на разворот на Way Name",
-        "sv": "Sväng U-sväng in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde U dönüşü yöne dön",
         "uk": "Рухайтесь розворот на Way Name",
         "vi": "Quẹo ngược vào Way Name",

--- a/test/fixtures/v5/exit_rotary/uturn_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/uturn_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Siga retorno sentido Destination 1",
         "ro": "Virați întoarcere spre Destination 1",
         "ru": "Двигайтесь на разворот в направлении Destination 1",
-        "sv": "Sväng U-sväng mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde U dönüşü yöne dön",
         "uk": "Рухайтесь розворот в напрямку Destination 1",
         "vi": "Quẹo ngược đến Destination 1",

--- a/test/fixtures/v5/exit_rotary/uturn_name.json
+++ b/test/fixtures/v5/exit_rotary/uturn_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga retorno em Way Name",
         "ro": "Virați întoarcere pe Way Name",
         "ru": "Двигайтесь на разворот на Way Name",
-        "sv": "Sväng U-sväng in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde U dönüşü yöne dön",
         "uk": "Рухайтесь розворот на Way Name",
         "vi": "Quẹo ngược vào Way Name",

--- a/test/fixtures/v5/exit_roundabout/left_default.json
+++ b/test/fixtures/v5/exit_roundabout/left_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Vire à esquerda",
         "ro": "Virați stânga",
         "ru": "Сверните налево",
-        "sv": "Sväng vänster",
+        "sv": "Kör ut ur rondellen",
         "tr": "Sola dön",
         "uk": "Поверніть ліворуч",
         "vi": "Quẹo trái",

--- a/test/fixtures/v5/exit_roundabout/left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/left_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Vire à esquerda sentido Destination 1",
         "ro": "Virați stânga spre Destination 1",
         "ru": "Сверните налево в направлении Destination 1",
-        "sv": "Sväng vänster mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde sola dön",
         "uk": "Поверніть ліворуч у напрямку Destination 1",
         "vi": "Quẹo trái đến Destination 1",

--- a/test/fixtures/v5/exit_roundabout/left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/left_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Vire à esquerda em Way Name",
         "ro": "Virați stânga pe Way Name",
         "ru": "Сверните налево на Way Name",
-        "sv": "Sväng vänster in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde sola dön",
         "uk": "Поверніть ліворуч на Way Name",
         "vi": "Quẹo trái vào Way Name",

--- a/test/fixtures/v5/exit_roundabout/left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/left_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Vire à esquerda sentido Destination 1",
         "ro": "Virați stânga spre Destination 1",
         "ru": "Сверните налево в направлении Destination 1",
-        "sv": "Sväng vänster mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde sola dön",
         "uk": "Поверніть ліворуч у напрямку Destination 1",
         "vi": "Quẹo trái đến Destination 1",

--- a/test/fixtures/v5/exit_roundabout/left_name.json
+++ b/test/fixtures/v5/exit_roundabout/left_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Vire à esquerda em Way Name",
         "ro": "Virați stânga pe Way Name",
         "ru": "Сверните налево на Way Name",
-        "sv": "Sväng vänster in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde sola dön",
         "uk": "Поверніть ліворуч на Way Name",
         "vi": "Quẹo trái vào Way Name",

--- a/test/fixtures/v5/exit_roundabout/right_default.json
+++ b/test/fixtures/v5/exit_roundabout/right_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Vire à direita",
         "ro": "Virați dreapta",
         "ru": "Сверните направо",
-        "sv": "Sväng höger",
+        "sv": "Kör ut ur rondellen",
         "tr": "Sağa dön",
         "uk": "Поверніть праворуч",
         "vi": "Quẹo phải",

--- a/test/fixtures/v5/exit_roundabout/right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/right_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Vire à direita sentido Destination 1",
         "ro": "Virați dreapta spre Destination 1",
         "ru": "Сверните направо в направлении Destination 1",
-        "sv": "Sväng höger mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde sağa dön",
         "uk": "Поверніть праворуч у напрямку Destination 1",
         "vi": "Quẹo phải đến Destination 1",

--- a/test/fixtures/v5/exit_roundabout/right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/right_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Vire à direita em Way Name",
         "ro": "Virați dreapta pe Way Name",
         "ru": "Сверните направо на Way Name",
-        "sv": "Sväng höger in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde sağa dön",
         "uk": "Поверніть праворуч на Way Name",
         "vi": "Quẹo phải vào Way Name",

--- a/test/fixtures/v5/exit_roundabout/right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/right_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Vire à direita sentido Destination 1",
         "ro": "Virați dreapta spre Destination 1",
         "ru": "Сверните направо в направлении Destination 1",
-        "sv": "Sväng höger mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde sağa dön",
         "uk": "Поверніть праворуч у напрямку Destination 1",
         "vi": "Quẹo phải đến Destination 1",

--- a/test/fixtures/v5/exit_roundabout/right_name.json
+++ b/test/fixtures/v5/exit_roundabout/right_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Vire à direita em Way Name",
         "ro": "Virați dreapta pe Way Name",
         "ru": "Сверните направо на Way Name",
-        "sv": "Sväng höger in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde sağa dön",
         "uk": "Поверніть праворуч на Way Name",
         "vi": "Quẹo phải vào Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_default.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga acentuadamente à esquerda",
         "ro": "Virați brusc stânga",
         "ru": "Двигайтесь налево",
-        "sv": "Sväng vänster",
+        "sv": "Kör ut ur rondellen",
         "tr": "Keskin sol yöne dön",
         "uk": "Рухайтесь різко ліворуч",
         "vi": "Quẹo trái gắt",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga acentuadamente à esquerda sentido Destination 1",
         "ro": "Virați brusc stânga spre Destination 1",
         "ru": "Двигайтесь налево в направлении Destination 1",
-        "sv": "Sväng vänster mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde keskin sol yöne dön",
         "uk": "Рухайтесь різко ліворуч в напрямку Destination 1",
         "vi": "Quẹo trái gắt đến Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga acentuadamente à esquerda em Way Name",
         "ro": "Virați brusc stânga pe Way Name",
         "ru": "Двигайтесь налево на Way Name",
-        "sv": "Sväng vänster in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde keskin sol yöne dön",
         "uk": "Рухайтесь різко ліворуч на Way Name",
         "vi": "Quẹo trái gắt vào Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Siga acentuadamente à esquerda sentido Destination 1",
         "ro": "Virați brusc stânga spre Destination 1",
         "ru": "Двигайтесь налево в направлении Destination 1",
-        "sv": "Sväng vänster mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde keskin sol yöne dön",
         "uk": "Рухайтесь різко ліворуч в напрямку Destination 1",
         "vi": "Quẹo trái gắt đến Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_name.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga acentuadamente à esquerda em Way Name",
         "ro": "Virați brusc stânga pe Way Name",
         "ru": "Двигайтесь налево на Way Name",
-        "sv": "Sväng vänster in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde keskin sol yöne dön",
         "uk": "Рухайтесь різко ліворуч на Way Name",
         "vi": "Quẹo trái gắt vào Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_default.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga acentuadamente à direita",
         "ro": "Virați brusc dreapta",
         "ru": "Двигайтесь направо",
-        "sv": "Sväng höger",
+        "sv": "Kör ut ur rondellen",
         "tr": "Keskin sağ yöne dön",
         "uk": "Рухайтесь різко праворуч",
         "vi": "Quẹo phải gắt",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga acentuadamente à direita sentido Destination 1",
         "ro": "Virați brusc dreapta spre Destination 1",
         "ru": "Двигайтесь направо в направлении Destination 1",
-        "sv": "Sväng höger mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde keskin sağ yöne dön",
         "uk": "Рухайтесь різко праворуч в напрямку Destination 1",
         "vi": "Quẹo phải gắt đến Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga acentuadamente à direita em Way Name",
         "ro": "Virați brusc dreapta pe Way Name",
         "ru": "Двигайтесь направо на Way Name",
-        "sv": "Sväng höger in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde keskin sağ yöne dön",
         "uk": "Рухайтесь різко праворуч на Way Name",
         "vi": "Quẹo phải gắt vào Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Siga acentuadamente à direita sentido Destination 1",
         "ro": "Virați brusc dreapta spre Destination 1",
         "ru": "Двигайтесь направо в направлении Destination 1",
-        "sv": "Sväng höger mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde keskin sağ yöne dön",
         "uk": "Рухайтесь різко праворуч в напрямку Destination 1",
         "vi": "Quẹo phải gắt đến Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_name.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga acentuadamente à direita em Way Name",
         "ro": "Virați brusc dreapta pe Way Name",
         "ru": "Двигайтесь направо на Way Name",
-        "sv": "Sväng höger in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde keskin sağ yöne dön",
         "uk": "Рухайтесь різко праворуч на Way Name",
         "vi": "Quẹo phải gắt vào Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_left_default.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga ligeiramente à esquerda",
         "ro": "Virați ușor stânga",
         "ru": "Двигайтесь левее",
-        "sv": "Sväng vänster",
+        "sv": "Kör ut ur rondellen",
         "tr": "Hafif sol yöne dön",
         "uk": "Рухайтесь плавно ліворуч",
         "vi": "Quẹo trái nghiêng",

--- a/test/fixtures/v5/exit_roundabout/slight_left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga ligeiramente à esquerda sentido Destination 1",
         "ro": "Virați ușor stânga spre Destination 1",
         "ru": "Двигайтесь левее в направлении Destination 1",
-        "sv": "Sväng vänster mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde hafif sol yöne dön",
         "uk": "Рухайтесь плавно ліворуч в напрямку Destination 1",
         "vi": "Quẹo trái nghiêng đến Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga ligeiramente à esquerda em Way Name",
         "ro": "Virați ușor stânga pe Way Name",
         "ru": "Двигайтесь левее на Way Name",
-        "sv": "Sväng vänster in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde hafif sol yöne dön",
         "uk": "Рухайтесь плавно ліворуч на Way Name",
         "vi": "Quẹo trái nghiêng vào Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Siga ligeiramente à esquerda sentido Destination 1",
         "ro": "Virați ușor stânga spre Destination 1",
         "ru": "Двигайтесь левее в направлении Destination 1",
-        "sv": "Sväng vänster mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde hafif sol yöne dön",
         "uk": "Рухайтесь плавно ліворуч в напрямку Destination 1",
         "vi": "Quẹo trái nghiêng đến Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_left_name.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga ligeiramente à esquerda em Way Name",
         "ro": "Virați ușor stânga pe Way Name",
         "ru": "Двигайтесь левее на Way Name",
-        "sv": "Sväng vänster in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde hafif sol yöne dön",
         "uk": "Рухайтесь плавно ліворуч на Way Name",
         "vi": "Quẹo trái nghiêng vào Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_right_default.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga ligeiramente à direita",
         "ro": "Virați ușor dreapta",
         "ru": "Двигайтесь правее",
-        "sv": "Sväng höger",
+        "sv": "Kör ut ur rondellen",
         "tr": "Hafif sağ yöne dön",
         "uk": "Рухайтесь плавно праворуч",
         "vi": "Quẹo phải nghiêng",

--- a/test/fixtures/v5/exit_roundabout/slight_right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga ligeiramente à direita sentido Destination 1",
         "ro": "Virați ușor dreapta spre Destination 1",
         "ru": "Двигайтесь правее в направлении Destination 1",
-        "sv": "Sväng höger mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde hafif sağ yöne dön",
         "uk": "Рухайтесь плавно праворуч в напрямку Destination 1",
         "vi": "Quẹo phải nghiêng đến Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga ligeiramente à direita em Way Name",
         "ro": "Virați ușor dreapta pe Way Name",
         "ru": "Двигайтесь правее на Way Name",
-        "sv": "Sväng höger in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde hafif sağ yöne dön",
         "uk": "Рухайтесь плавно праворуч на Way Name",
         "vi": "Quẹo phải nghiêng vào Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Siga ligeiramente à direita sentido Destination 1",
         "ro": "Virați ușor dreapta spre Destination 1",
         "ru": "Двигайтесь правее в направлении Destination 1",
-        "sv": "Sväng höger mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde hafif sağ yöne dön",
         "uk": "Рухайтесь плавно праворуч в напрямку Destination 1",
         "vi": "Quẹo phải nghiêng đến Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_right_name.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga ligeiramente à direita em Way Name",
         "ro": "Virați ușor dreapta pe Way Name",
         "ru": "Двигайтесь правее на Way Name",
-        "sv": "Sväng höger in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde hafif sağ yöne dön",
         "uk": "Рухайтесь плавно праворуч на Way Name",
         "vi": "Quẹo phải nghiêng vào Way Name",

--- a/test/fixtures/v5/exit_roundabout/straight_default.json
+++ b/test/fixtures/v5/exit_roundabout/straight_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga reto",
         "ro": "Mergeți înainte",
         "ru": "Двигайтесь прямо",
-        "sv": "Kör rakt fram",
+        "sv": "Kör ut ur rondellen",
         "tr": "Düz git",
         "uk": "Рухайтесь прямо",
         "vi": "Chạy thẳng",

--- a/test/fixtures/v5/exit_roundabout/straight_destination.json
+++ b/test/fixtures/v5/exit_roundabout/straight_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga reto sentido Destination 1",
         "ro": "Mergeți înainte spre Destination 1",
         "ru": "Двигайтесь в направлении Destination 1",
-        "sv": "Kör rakt fram mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde düz git",
         "uk": "Рухайтесь прямо у напрямку Destination 1",
         "vi": "Chạy thẳng đến Destination 1",

--- a/test/fixtures/v5/exit_roundabout/straight_exit.json
+++ b/test/fixtures/v5/exit_roundabout/straight_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga reto em Way Name",
         "ro": "Mergeți înainte pe Way Name",
         "ru": "Двигайтесь по Way Name",
-        "sv": "Kör rakt fram in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde düz git",
         "uk": "Рухайтесь прямо по Way Name",
         "vi": "Chạy thẳng vào Way Name",

--- a/test/fixtures/v5/exit_roundabout/straight_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/straight_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Siga reto sentido Destination 1",
         "ro": "Mergeți înainte spre Destination 1",
         "ru": "Двигайтесь в направлении Destination 1",
-        "sv": "Kör rakt fram mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde düz git",
         "uk": "Рухайтесь прямо у напрямку Destination 1",
         "vi": "Chạy thẳng đến Destination 1",

--- a/test/fixtures/v5/exit_roundabout/straight_name.json
+++ b/test/fixtures/v5/exit_roundabout/straight_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga reto em Way Name",
         "ro": "Mergeți înainte pe Way Name",
         "ru": "Двигайтесь по Way Name",
-        "sv": "Kör rakt fram in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde düz git",
         "uk": "Рухайтесь прямо по Way Name",
         "vi": "Chạy thẳng vào Way Name",

--- a/test/fixtures/v5/exit_roundabout/uturn_default.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga retorno",
         "ro": "Virați întoarcere",
         "ru": "Двигайтесь на разворот",
-        "sv": "Sväng U-sväng",
+        "sv": "Kör ut ur rondellen",
         "tr": "U dönüşü yöne dön",
         "uk": "Рухайтесь розворот",
         "vi": "Quẹo ngược",

--- a/test/fixtures/v5/exit_roundabout/uturn_destination.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga retorno sentido Destination 1",
         "ro": "Virați întoarcere spre Destination 1",
         "ru": "Двигайтесь на разворот в направлении Destination 1",
-        "sv": "Sväng U-sväng mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde U dönüşü yöne dön",
         "uk": "Рухайтесь розворот в напрямку Destination 1",
         "vi": "Quẹo ngược đến Destination 1",

--- a/test/fixtures/v5/exit_roundabout/uturn_exit.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Siga retorno em Way Name",
         "ro": "Virați întoarcere pe Way Name",
         "ru": "Двигайтесь на разворот на Way Name",
-        "sv": "Sväng U-sväng in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde U dönüşü yöne dön",
         "uk": "Рухайтесь розворот на Way Name",
         "vi": "Quẹo ngược vào Way Name",

--- a/test/fixtures/v5/exit_roundabout/uturn_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Siga retorno sentido Destination 1",
         "ro": "Virați întoarcere spre Destination 1",
         "ru": "Двигайтесь на разворот в направлении Destination 1",
-        "sv": "Sväng U-sväng mot Destination 1",
+        "sv": "Kör ut ur rondellen mot Destination 1",
         "tr": "Destination 1 istikametinde U dönüşü yöne dön",
         "uk": "Рухайтесь розворот в напрямку Destination 1",
         "vi": "Quẹo ngược đến Destination 1",

--- a/test/fixtures/v5/exit_roundabout/uturn_name.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Siga retorno em Way Name",
         "ro": "Virați întoarcere pe Way Name",
         "ru": "Двигайтесь на разворот на Way Name",
-        "sv": "Sväng U-sväng in på Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
         "tr": "Way Name üzerinde U dönüşü yöne dön",
         "uk": "Рухайтесь розворот на Way Name",
         "vi": "Quẹo ngược vào Way Name",

--- a/test/fixtures/v5/merge/left_destination.json
+++ b/test/fixtures/v5/merge/left_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre à esquerda em direção à Destination 1",
         "ro": "Intrați în stânga spre Destination 1",
         "ru": "Перестройтесь налево в направлении Destination 1",
-        "sv": "Byt till vänster körfält mot Destination 1",
+        "sv": "Byt till vänster körfält, mot Destination 1",
         "tr": "Destination 1 istikametinde sol yöne gir",
         "uk": "Приєднайтеся до потоку ліворуч у напрямку Destination 1",
         "vi": "Nhập sang trái đến Destination 1",

--- a/test/fixtures/v5/merge/left_exit.json
+++ b/test/fixtures/v5/merge/left_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre à esquerda na Way Name",
         "ro": "Intrați în stânga pe Way Name",
         "ru": "Перестройтесь налево на Way Name",
-        "sv": "Byt till vänster körfält in på Way Name",
+        "sv": "Byt till vänster körfält, in på Way Name",
         "tr": "Way Name üzerinde sol yöne gir",
         "uk": "Приєднайтеся до потоку ліворуч на Way Name",
         "vi": "Nhập sang trái vào Way Name",

--- a/test/fixtures/v5/merge/left_exit_destination.json
+++ b/test/fixtures/v5/merge/left_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Entre à esquerda em direção à Destination 1",
         "ro": "Intrați în stânga spre Destination 1",
         "ru": "Перестройтесь налево в направлении Destination 1",
-        "sv": "Byt till vänster körfält mot Destination 1",
+        "sv": "Byt till vänster körfält, mot Destination 1",
         "tr": "Destination 1 istikametinde sol yöne gir",
         "uk": "Приєднайтеся до потоку ліворуч у напрямку Destination 1",
         "vi": "Nhập sang trái đến Destination 1",

--- a/test/fixtures/v5/merge/left_name.json
+++ b/test/fixtures/v5/merge/left_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Entre à esquerda na Way Name",
         "ro": "Intrați în stânga pe Way Name",
         "ru": "Перестройтесь налево на Way Name",
-        "sv": "Byt till vänster körfält in på Way Name",
+        "sv": "Byt till vänster körfält, in på Way Name",
         "tr": "Way Name üzerinde sol yöne gir",
         "uk": "Приєднайтеся до потоку ліворуч на Way Name",
         "vi": "Nhập sang trái vào Way Name",

--- a/test/fixtures/v5/merge/right_destination.json
+++ b/test/fixtures/v5/merge/right_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre à direita em direção à Destination 1",
         "ro": "Intrați în dreapta spre Destination 1",
         "ru": "Перестройтесь направо в направлении Destination 1",
-        "sv": "Byt till höger körfält mot Destination 1",
+        "sv": "Byt till höger körfält, mot Destination 1",
         "tr": "Destination 1 istikametinde sağ yöne gir",
         "uk": "Приєднайтеся до потоку праворуч у напрямку Destination 1",
         "vi": "Nhập sang phải đến Destination 1",

--- a/test/fixtures/v5/merge/right_exit.json
+++ b/test/fixtures/v5/merge/right_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre à direita na Way Name",
         "ro": "Intrați în dreapta pe Way Name",
         "ru": "Перестройтесь направо на Way Name",
-        "sv": "Byt till höger körfält in på Way Name",
+        "sv": "Byt till höger körfält, in på Way Name",
         "tr": "Way Name üzerinde sağ yöne gir",
         "uk": "Приєднайтеся до потоку праворуч на Way Name",
         "vi": "Nhập sang phải vào Way Name",

--- a/test/fixtures/v5/merge/right_exit_destination.json
+++ b/test/fixtures/v5/merge/right_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Entre à direita em direção à Destination 1",
         "ro": "Intrați în dreapta spre Destination 1",
         "ru": "Перестройтесь направо в направлении Destination 1",
-        "sv": "Byt till höger körfält mot Destination 1",
+        "sv": "Byt till höger körfält, mot Destination 1",
         "tr": "Destination 1 istikametinde sağ yöne gir",
         "uk": "Приєднайтеся до потоку праворуч у напрямку Destination 1",
         "vi": "Nhập sang phải đến Destination 1",

--- a/test/fixtures/v5/merge/right_name.json
+++ b/test/fixtures/v5/merge/right_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Entre à direita na Way Name",
         "ro": "Intrați în dreapta pe Way Name",
         "ru": "Перестройтесь направо на Way Name",
-        "sv": "Byt till höger körfält in på Way Name",
+        "sv": "Byt till höger körfält, in på Way Name",
         "tr": "Way Name üzerinde sağ yöne gir",
         "uk": "Приєднайтеся до потоку праворуч на Way Name",
         "vi": "Nhập sang phải vào Way Name",

--- a/test/fixtures/v5/merge/sharp_left_destination.json
+++ b/test/fixtures/v5/merge/sharp_left_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre à esquerda em direção à Destination 1",
         "ro": "Intrați în stânga spre Destination 1",
         "ru": "Перестраивайтесь левее в направлении Destination 1",
-        "sv": "Byt till vänstra körfältet mot Destination 1",
+        "sv": "Byt till vänstra körfältet, mot Destination 1",
         "tr": "Destination 1 istikametinde sola gir",
         "uk": "Приєднайтеся до потоку ліворуч у напрямку Destination 1",
         "vi": "Nhập sang trái đến Destination 1",

--- a/test/fixtures/v5/merge/sharp_left_exit.json
+++ b/test/fixtures/v5/merge/sharp_left_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre à esquerda na Way Name",
         "ro": "Intrați în stânga pe Way Name",
         "ru": "Перестраивайтесь левее на Way Name",
-        "sv": "Byt till vänstra körfältet in på Way Name",
+        "sv": "Byt till vänstra körfältet, in på Way Name",
         "tr": "Way Name üzerinde sola gir",
         "uk": "Приєднайтеся до потоку ліворуч на Way Name",
         "vi": "Nhập sang trái vào Way Name",

--- a/test/fixtures/v5/merge/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/merge/sharp_left_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Entre à esquerda em direção à Destination 1",
         "ro": "Intrați în stânga spre Destination 1",
         "ru": "Перестраивайтесь левее в направлении Destination 1",
-        "sv": "Byt till vänstra körfältet mot Destination 1",
+        "sv": "Byt till vänstra körfältet, mot Destination 1",
         "tr": "Destination 1 istikametinde sola gir",
         "uk": "Приєднайтеся до потоку ліворуч у напрямку Destination 1",
         "vi": "Nhập sang trái đến Destination 1",

--- a/test/fixtures/v5/merge/sharp_left_name.json
+++ b/test/fixtures/v5/merge/sharp_left_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Entre à esquerda na Way Name",
         "ro": "Intrați în stânga pe Way Name",
         "ru": "Перестраивайтесь левее на Way Name",
-        "sv": "Byt till vänstra körfältet in på Way Name",
+        "sv": "Byt till vänstra körfältet, in på Way Name",
         "tr": "Way Name üzerinde sola gir",
         "uk": "Приєднайтеся до потоку ліворуч на Way Name",
         "vi": "Nhập sang trái vào Way Name",

--- a/test/fixtures/v5/merge/sharp_right_destination.json
+++ b/test/fixtures/v5/merge/sharp_right_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre à direita em direção à Destination 1",
         "ro": "Intrați în dreapta spre Destination 1",
         "ru": "Перестраивайтесь правее в направлении Destination 1",
-        "sv": "Byt till högra körfältet mot Destination 1",
+        "sv": "Byt till högra körfältet, mot Destination 1",
         "tr": "Destination 1 istikametinde sağa gir",
         "uk": "Приєднайтеся до потоку праворуч у напрямку Destination 1",
         "vi": "Nhập sang phải đến Destination 1",

--- a/test/fixtures/v5/merge/sharp_right_exit.json
+++ b/test/fixtures/v5/merge/sharp_right_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre à direita na Way Name",
         "ro": "Intrați în dreapta pe Way Name",
         "ru": "Перестраивайтесь правее на Way Name",
-        "sv": "Byt till högra körfältet in på Way Name",
+        "sv": "Byt till högra körfältet, in på Way Name",
         "tr": "Way Name üzerinde sağa gir",
         "uk": "Приєднайтеся до потоку праворуч на Way Name",
         "vi": "Nhập sang phải vào Way Name",

--- a/test/fixtures/v5/merge/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/merge/sharp_right_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Entre à direita em direção à Destination 1",
         "ro": "Intrați în dreapta spre Destination 1",
         "ru": "Перестраивайтесь правее в направлении Destination 1",
-        "sv": "Byt till högra körfältet mot Destination 1",
+        "sv": "Byt till högra körfältet, mot Destination 1",
         "tr": "Destination 1 istikametinde sağa gir",
         "uk": "Приєднайтеся до потоку праворуч у напрямку Destination 1",
         "vi": "Nhập sang phải đến Destination 1",

--- a/test/fixtures/v5/merge/sharp_right_name.json
+++ b/test/fixtures/v5/merge/sharp_right_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Entre à direita na Way Name",
         "ro": "Intrați în dreapta pe Way Name",
         "ru": "Перестраивайтесь правее на Way Name",
-        "sv": "Byt till högra körfältet in på Way Name",
+        "sv": "Byt till högra körfältet, in på Way Name",
         "tr": "Way Name üzerinde sağa gir",
         "uk": "Приєднайтеся до потоку праворуч на Way Name",
         "vi": "Nhập sang phải vào Way Name",

--- a/test/fixtures/v5/merge/slight_left_destination.json
+++ b/test/fixtures/v5/merge/slight_left_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre à esquerda em direção à Destination 1",
         "ro": "Intrați în stânga spre Destination 1",
         "ru": "Перестройтесь левее в направлении Destination 1",
-        "sv": "Byt till vänstra körfältet mot Destination 1",
+        "sv": "Byt till vänstra körfältet, mot Destination 1",
         "tr": "Destination 1 istikametinde sola gir",
         "uk": "Приєднайтеся до потоку ліворуч у напрямку Destination 1",
         "vi": "Nhập sang trái đến Destination 1",

--- a/test/fixtures/v5/merge/slight_left_exit.json
+++ b/test/fixtures/v5/merge/slight_left_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre à esquerda na Way Name",
         "ro": "Intrați în stânga pe Way Name",
         "ru": "Перестройтесь левее на Way Name",
-        "sv": "Byt till vänstra körfältet in på Way Name",
+        "sv": "Byt till vänstra körfältet, in på Way Name",
         "tr": "Way Name üzerinde sola gir",
         "uk": "Приєднайтеся до потоку ліворуч на Way Name",
         "vi": "Nhập sang trái vào Way Name",

--- a/test/fixtures/v5/merge/slight_left_exit_destination.json
+++ b/test/fixtures/v5/merge/slight_left_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Entre à esquerda em direção à Destination 1",
         "ro": "Intrați în stânga spre Destination 1",
         "ru": "Перестройтесь левее в направлении Destination 1",
-        "sv": "Byt till vänstra körfältet mot Destination 1",
+        "sv": "Byt till vänstra körfältet, mot Destination 1",
         "tr": "Destination 1 istikametinde sola gir",
         "uk": "Приєднайтеся до потоку ліворуч у напрямку Destination 1",
         "vi": "Nhập sang trái đến Destination 1",

--- a/test/fixtures/v5/merge/slight_left_name.json
+++ b/test/fixtures/v5/merge/slight_left_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Entre à esquerda na Way Name",
         "ro": "Intrați în stânga pe Way Name",
         "ru": "Перестройтесь левее на Way Name",
-        "sv": "Byt till vänstra körfältet in på Way Name",
+        "sv": "Byt till vänstra körfältet, in på Way Name",
         "tr": "Way Name üzerinde sola gir",
         "uk": "Приєднайтеся до потоку ліворуч на Way Name",
         "vi": "Nhập sang trái vào Way Name",

--- a/test/fixtures/v5/merge/slight_right_destination.json
+++ b/test/fixtures/v5/merge/slight_right_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre à direita em direção à Destination 1",
         "ro": "Intrați în dreapta spre Destination 1",
         "ru": "Перестройтесь правее в направлении Destination 1",
-        "sv": "Byt till högra körfältet mot Destination 1",
+        "sv": "Byt till högra körfältet, mot Destination 1",
         "tr": "Destination 1 istikametinde sağa gir",
         "uk": "Приєднайтеся до потоку праворуч у напрямку Destination 1",
         "vi": "Nhập sang phải đến Destination 1",

--- a/test/fixtures/v5/merge/slight_right_exit.json
+++ b/test/fixtures/v5/merge/slight_right_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre à direita na Way Name",
         "ro": "Intrați în dreapta pe Way Name",
         "ru": "Перестройтесь правее на Way Name",
-        "sv": "Byt till högra körfältet in på Way Name",
+        "sv": "Byt till högra körfältet, in på Way Name",
         "tr": "Way Name üzerinde sağa gir",
         "uk": "Приєднайтеся до потоку праворуч на Way Name",
         "vi": "Nhập sang phải vào Way Name",

--- a/test/fixtures/v5/merge/slight_right_exit_destination.json
+++ b/test/fixtures/v5/merge/slight_right_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Entre à direita em direção à Destination 1",
         "ro": "Intrați în dreapta spre Destination 1",
         "ru": "Перестройтесь правее в направлении Destination 1",
-        "sv": "Byt till högra körfältet mot Destination 1",
+        "sv": "Byt till högra körfältet, mot Destination 1",
         "tr": "Destination 1 istikametinde sağa gir",
         "uk": "Приєднайтеся до потоку праворуч у напрямку Destination 1",
         "vi": "Nhập sang phải đến Destination 1",

--- a/test/fixtures/v5/merge/slight_right_name.json
+++ b/test/fixtures/v5/merge/slight_right_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Entre à direita na Way Name",
         "ro": "Intrați în dreapta pe Way Name",
         "ru": "Перестройтесь правее на Way Name",
-        "sv": "Byt till högra körfältet in på Way Name",
+        "sv": "Byt till högra körfältet, in på Way Name",
         "tr": "Way Name üzerinde sağa gir",
         "uk": "Приєднайтеся до потоку праворуч на Way Name",
         "vi": "Nhập sang phải vào Way Name",

--- a/test/fixtures/v5/rotary/default_destination.json
+++ b/test/fixtures/v5/rotary/default_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia sentido Destination 1",
         "ro": "Intrați în sensul giratoriu și ieșiți spre Destination 1",
         "ru": "На круговой развязке сверните в направлении Destination 1",
-        "sv": "I rondellen ta av mot Destination 1",
+        "sv": "I rondellen, ta av mot Destination 1",
         "tr": "Dönel kavşağa gir ve Destination 1 istikametinde çık",
         "uk": "Рухайтесь по колу в напрямку Destination 1",
         "vi": "Vào bùng binh và ra để đi Destination 1",

--- a/test/fixtures/v5/rotary/default_exit.json
+++ b/test/fixtures/v5/rotary/default_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia em Way Name",
         "ro": "Intrați în sensul giratoriu și ieșiți pe Way Name",
         "ru": "На круговой развязке сверните на Way Name",
-        "sv": "I rondellen ta av in på Way Name",
+        "sv": "I rondellen ta avfarten in på Way Name",
         "tr": "Dönel kavşağa gir ve Way Name üzerinde çık",
         "uk": "Рухайтесь по колу до Way Name",
         "vi": "Đi vào bùng binh và ra tại Way Name",

--- a/test/fixtures/v5/rotary/default_exit.json
+++ b/test/fixtures/v5/rotary/default_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia em Way Name",
         "ro": "Intrați în sensul giratoriu și ieșiți pe Way Name",
         "ru": "На круговой развязке сверните на Way Name",
-        "sv": "I rondellen ta avfarten in på Way Name",
+        "sv": "I rondellen, ta avfarten in på Way Name",
         "tr": "Dönel kavşağa gir ve Way Name üzerinde çık",
         "uk": "Рухайтесь по колу до Way Name",
         "vi": "Đi vào bùng binh và ra tại Way Name",

--- a/test/fixtures/v5/rotary/default_exit_destination.json
+++ b/test/fixtures/v5/rotary/default_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Entre na rotatória e saia sentido Destination 1",
         "ro": "Intrați în sensul giratoriu și ieșiți spre Destination 1",
         "ru": "На круговой развязке сверните в направлении Destination 1",
-        "sv": "I rondellen ta av mot Destination 1",
+        "sv": "I rondellen, ta av mot Destination 1",
         "tr": "Dönel kavşağa gir ve Destination 1 istikametinde çık",
         "uk": "Рухайтесь по колу в напрямку Destination 1",
         "vi": "Vào bùng binh và ra để đi Destination 1",

--- a/test/fixtures/v5/rotary/default_name.json
+++ b/test/fixtures/v5/rotary/default_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Entre na rotatória e saia em Way Name",
         "ro": "Intrați în sensul giratoriu și ieșiți pe Way Name",
         "ru": "На круговой развязке сверните на Way Name",
-        "sv": "I rondellen ta avfarten in på Way Name",
+        "sv": "I rondellen, ta avfarten in på Way Name",
         "tr": "Dönel kavşağa gir ve Way Name üzerinde çık",
         "uk": "Рухайтесь по колу до Way Name",
         "vi": "Đi vào bùng binh và ra tại Way Name",

--- a/test/fixtures/v5/rotary/default_name.json
+++ b/test/fixtures/v5/rotary/default_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Entre na rotatória e saia em Way Name",
         "ro": "Intrați în sensul giratoriu și ieșiți pe Way Name",
         "ru": "На круговой развязке сверните на Way Name",
-        "sv": "I rondellen ta av in på Way Name",
+        "sv": "I rondellen ta avfarten in på Way Name",
         "tr": "Dönel kavşağa gir ve Way Name üzerinde çık",
         "uk": "Рухайтесь по колу до Way Name",
         "vi": "Đi vào bùng binh và ra tại Way Name",

--- a/test/fixtures/v5/rotary/exit_10.json
+++ b/test/fixtures/v5/rotary/exit_10.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia na 10º saída",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea a 10-a",
         "ru": "На круговой развязке сверните на десятый съезд",
-        "sv": "I rondellen ta 10:e avfarten",
+        "sv": "I rondellen, ta 10:e avfarten",
         "tr": "Dönel kavşağa gir ve onuncu numaralı çıkışa gir",
         "uk": "Рухайтесь по колу та повереніть у 10й з'їзд",
         "vi": "Đi vào bùng binh và ra tại đường thứ 10",

--- a/test/fixtures/v5/rotary/exit_11.json
+++ b/test/fixtures/v5/rotary/exit_11.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia na saída",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea ",
         "ru": "На круговой развязке сверните на съезд",
-        "sv": "I rondellen ta avfarten",
+        "sv": "I rondellen, ta avfarten",
         "tr": "Dönel kavşağa gir ve numaralı çıkışa gir",
         "uk": "Рухайтесь по колу та повереніть у з'їзд",
         "vi": "Đi vào bùng binh và ra tại đường ",

--- a/test/fixtures/v5/rotary/exit_1_default.json
+++ b/test/fixtures/v5/rotary/exit_1_default.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia na 1º saída",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea prima",
         "ru": "На круговой развязке сверните на первый съезд",
-        "sv": "I rondellen ta 1:a avfarten",
+        "sv": "I rondellen, ta 1:a avfarten",
         "tr": "Dönel kavşağa gir ve birinci numaralı çıkışa gir",
         "uk": "Рухайтесь по колу та повереніть у 1й з'їзд",
         "vi": "Đi vào bùng binh và ra tại đường đầu tiên",

--- a/test/fixtures/v5/rotary/exit_1_destination.json
+++ b/test/fixtures/v5/rotary/exit_1_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Entre na rotatória e saia na 1º saída sentido Destination 1",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea prima spre Destination 1",
         "ru": "На круговой развязке сверните на первый съезд в направлении Destination 1",
-        "sv": "I rondellen ta 1:a avfarten mot Destination 1",
+        "sv": "I rondellen, ta 1:a avfarten mot Destination 1",
         "tr": "Dönel kavşağa gir ve Destination 1 istikametindeki birinci numaralı çıkışa gir",
         "uk": "Рухайтесь по колу та поверніть у 1й з'їзд у напрямку Destination 1",
         "vi": "Đi vào bùng binh và ra tại đường đầu tiên đến Destination 1",

--- a/test/fixtures/v5/rotary/exit_1_exit.json
+++ b/test/fixtures/v5/rotary/exit_1_exit.json
@@ -22,7 +22,7 @@
         "pt-BR": "Entre na rotatória e saia na 1º saída em Way Name",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea prima pe Way Name",
         "ru": "На круговой развязке сверните на первый съезд на Way Name",
-        "sv": "I rondellen ta 1:a avfarten in på Way Name",
+        "sv": "I rondellen, ta 1:a avfarten in på Way Name",
         "tr": "Dönel kavşağa gir ve Way Name üzerindeki birinci numaralı çıkışa gir",
         "uk": "Рухайтесь по колу та поверніть у 1й з'їзд на Way Name",
         "vi": "Đi vào bùng binh và ra tại đường đầu tiên tức Way Name",

--- a/test/fixtures/v5/rotary/exit_1_exit_destination.json
+++ b/test/fixtures/v5/rotary/exit_1_exit_destination.json
@@ -23,7 +23,7 @@
         "pt-BR": "Entre na rotatória e saia na 1º saída sentido Destination 1",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea prima spre Destination 1",
         "ru": "На круговой развязке сверните на первый съезд в направлении Destination 1",
-        "sv": "I rondellen ta 1:a avfarten mot Destination 1",
+        "sv": "I rondellen, ta 1:a avfarten mot Destination 1",
         "tr": "Dönel kavşağa gir ve Destination 1 istikametindeki birinci numaralı çıkışa gir",
         "uk": "Рухайтесь по колу та поверніть у 1й з'їзд у напрямку Destination 1",
         "vi": "Đi vào bùng binh và ra tại đường đầu tiên đến Destination 1",

--- a/test/fixtures/v5/rotary/exit_1_name.json
+++ b/test/fixtures/v5/rotary/exit_1_name.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia na 1º saída em Way Name",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea prima pe Way Name",
         "ru": "На круговой развязке сверните на первый съезд на Way Name",
-        "sv": "I rondellen ta 1:a avfarten in på Way Name",
+        "sv": "I rondellen, ta 1:a avfarten in på Way Name",
         "tr": "Dönel kavşağa gir ve Way Name üzerindeki birinci numaralı çıkışa gir",
         "uk": "Рухайтесь по колу та поверніть у 1й з'їзд на Way Name",
         "vi": "Đi vào bùng binh và ra tại đường đầu tiên tức Way Name",

--- a/test/fixtures/v5/rotary/exit_2.json
+++ b/test/fixtures/v5/rotary/exit_2.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia na 2º saída",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea a 2-a",
         "ru": "На круговой развязке сверните на второй съезд",
-        "sv": "I rondellen ta 2:a avfarten",
+        "sv": "I rondellen, ta 2:a avfarten",
         "tr": "Dönel kavşağa gir ve ikinci numaralı çıkışa gir",
         "uk": "Рухайтесь по колу та повереніть у 2й з'їзд",
         "vi": "Đi vào bùng binh và ra tại đường thứ 2",

--- a/test/fixtures/v5/rotary/exit_3.json
+++ b/test/fixtures/v5/rotary/exit_3.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia na 3º saída",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea a 3-a",
         "ru": "На круговой развязке сверните на третий съезд",
-        "sv": "I rondellen ta 3:e avfarten",
+        "sv": "I rondellen, ta 3:e avfarten",
         "tr": "Dönel kavşağa gir ve üçüncü numaralı çıkışa gir",
         "uk": "Рухайтесь по колу та повереніть у 3й з'їзд",
         "vi": "Đi vào bùng binh và ra tại đường thứ 3",

--- a/test/fixtures/v5/rotary/exit_4.json
+++ b/test/fixtures/v5/rotary/exit_4.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia na 4º saída",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea a 4-a",
         "ru": "На круговой развязке сверните на четвёртый съезд",
-        "sv": "I rondellen ta 4:e avfarten",
+        "sv": "I rondellen, ta 4:e avfarten",
         "tr": "Dönel kavşağa gir ve dördüncü numaralı çıkışa gir",
         "uk": "Рухайтесь по колу та повереніть у 4й з'їзд",
         "vi": "Đi vào bùng binh và ra tại đường thứ 4",

--- a/test/fixtures/v5/rotary/exit_5.json
+++ b/test/fixtures/v5/rotary/exit_5.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia na 5º saída",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea a 5-a",
         "ru": "На круговой развязке сверните на пятый съезд",
-        "sv": "I rondellen ta 5:e avfarten",
+        "sv": "I rondellen, ta 5:e avfarten",
         "tr": "Dönel kavşağa gir ve beşinci numaralı çıkışa gir",
         "uk": "Рухайтесь по колу та повереніть у 5й з'їзд",
         "vi": "Đi vào bùng binh và ra tại đường thứ 5",

--- a/test/fixtures/v5/rotary/exit_6.json
+++ b/test/fixtures/v5/rotary/exit_6.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia na 6º saída",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea a 6-a",
         "ru": "На круговой развязке сверните на шестой съезд",
-        "sv": "I rondellen ta 6:e avfarten",
+        "sv": "I rondellen, ta 6:e avfarten",
         "tr": "Dönel kavşağa gir ve altıncı numaralı çıkışa gir",
         "uk": "Рухайтесь по колу та повереніть у 6й з'їзд",
         "vi": "Đi vào bùng binh và ra tại đường thú 6",

--- a/test/fixtures/v5/rotary/exit_7.json
+++ b/test/fixtures/v5/rotary/exit_7.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia na 7º saída",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea a 7-a",
         "ru": "На круговой развязке сверните на седьмой съезд",
-        "sv": "I rondellen ta 7:e avfarten",
+        "sv": "I rondellen, ta 7:e avfarten",
         "tr": "Dönel kavşağa gir ve yedinci numaralı çıkışa gir",
         "uk": "Рухайтесь по колу та повереніть у 7й з'їзд",
         "vi": "Đi vào bùng binh và ra tại đường thứ 7",

--- a/test/fixtures/v5/rotary/exit_8.json
+++ b/test/fixtures/v5/rotary/exit_8.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia na 8º saída",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea a 8-a",
         "ru": "На круговой развязке сверните на восьмой съезд",
-        "sv": "I rondellen ta 8:e avfarten",
+        "sv": "I rondellen, ta 8:e avfarten",
         "tr": "Dönel kavşağa gir ve sekizinci numaralı çıkışa gir",
         "uk": "Рухайтесь по колу та повереніть у 8й з'їзд",
         "vi": "Đi vào bùng binh và ra tại đường thứ 8",

--- a/test/fixtures/v5/rotary/exit_9.json
+++ b/test/fixtures/v5/rotary/exit_9.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia na 9º saída",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea a 9-a",
         "ru": "На круговой развязке сверните на девятый съезд",
-        "sv": "I rondellen ta 9:e avfarten",
+        "sv": "I rondellen, ta 9:e avfarten",
         "tr": "Dönel kavşağa gir ve dokuzuncu numaralı çıkışa gir",
         "uk": "Рухайтесь по колу та повереніть у 9й з'їзд",
         "vi": "Đi vào bùng binh và ra tại đường thứ 9",

--- a/test/fixtures/v5/rotary/name_destination.json
+++ b/test/fixtures/v5/rotary/name_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Entre em Rotary Name e saia sentido Destination 1",
         "ro": "Intrați în Rotary Name și ieșiți spre Destination 1",
         "ru": "На Rotary Name сверните в направлении Destination 1",
-        "sv": "I Rotary Name ta av mot Destination 1",
+        "sv": "I Rotary Name, ta av mot Destination 1",
         "tr": "Rotary Name dönel kavşağa gir ve Destination 1 istikametinde çık",
         "uk": "Рухайтесь по Rotary Name та поверніть в напрямку Destination 1",
         "vi": "Đi và Rotary Name và ra để đi Destination 1",

--- a/test/fixtures/v5/rotary/name_exit.json
+++ b/test/fixtures/v5/rotary/name_exit.json
@@ -22,7 +22,7 @@
         "pt-BR": "Entre em Rotary Name e saia em Way Name",
         "ro": "Intrați în Rotary Name și ieșiți pe Way Name",
         "ru": "На Rotary Name сверните на Way Name",
-        "sv": "I Rotary Name ta av in på Way Name",
+        "sv": "I Rotary Name, ta av in på Way Name",
         "tr": "Rotary Name dönel kavşağa gir ve Way Name üzerinde çık",
         "uk": "Рухайтесь по Rotary Name та поверніть на Way Name",
         "vi": "Đi vào Rotary Name và ra tại Way Name",

--- a/test/fixtures/v5/rotary/name_exit_default.json
+++ b/test/fixtures/v5/rotary/name_exit_default.json
@@ -22,7 +22,7 @@
         "pt-BR": "Entre em Rotary Name e saia na 2º saída",
         "ro": "Intrați în Rotary Name și mergeți spre ieșirea a 2-a",
         "ru": "На Rotary Name сверните на второй съезд",
-        "sv": "I Rotary Name ta 2:a avfarten",
+        "sv": "I Rotary Name, ta 2:a avfarten",
         "tr": "Rotary Name dönel kavşağa gir ve ikinci numaralı çıkışa gir",
         "uk": "Рухайтесь по Rotary Name та поверніть у 2й з'їзд",
         "vi": "Đi vào Rotary Name và ra tại đường thứ 2",

--- a/test/fixtures/v5/rotary/name_exit_destination.json
+++ b/test/fixtures/v5/rotary/name_exit_destination.json
@@ -23,7 +23,7 @@
         "pt-BR": "Entre em Rotary Name e saia na 2º saída sentido Destination 1",
         "ro": "Intrați în Rotary Name și mergeți spre ieșirea a 2-a spre Destination 1",
         "ru": "На Rotary Name сверните на второй съезд в направлении Destination 1",
-        "sv": "I Rotary Name ta 2:a avfarten mot Destination 1",
+        "sv": "I Rotary Name, ta 2:a avfarten mot Destination 1",
         "tr": "Rotary Name dönel kavşağa gir ve Destination 1 istikametindeki ikinci numaralı çıkışa gir",
         "uk": "Рухайтесь по Rotary Name та поверніть у 2й з'їзд в напрямку Destination 1",
         "vi": "Đi vào Rotary Name và ra tại đường thứ 2 đến Destination 1",

--- a/test/fixtures/v5/rotary/name_exit_exit.json
+++ b/test/fixtures/v5/rotary/name_exit_exit.json
@@ -23,7 +23,7 @@
         "pt-BR": "Entre em Rotary Name e saia na 2º saída em Way Name",
         "ro": "Intrați în Rotary Name și mergeți spre ieșirea a 2-a pe Way Name",
         "ru": "На Rotary Name сверните на второй съезд на Way Name",
-        "sv": "I Rotary Name ta 2:a avfarten in på Way Name",
+        "sv": "I Rotary Name, ta 2:a avfarten in på Way Name",
         "tr": "Rotary Name dönel kavşağa gir ve Way Name üzerindeki ikinci numaralı çıkışa gir",
         "uk": "Рухайтесь по Rotary Name та поверніть у 2й з'їзд на Way Name",
         "vi": "Đi vào Rotary Name và ra tại đường thứ 2 tức Way Name",

--- a/test/fixtures/v5/rotary/name_exit_exit_destination.json
+++ b/test/fixtures/v5/rotary/name_exit_exit_destination.json
@@ -24,7 +24,7 @@
         "pt-BR": "Entre em Rotary Name e saia na 2º saída sentido Destination 1",
         "ro": "Intrați în Rotary Name și mergeți spre ieșirea a 2-a spre Destination 1",
         "ru": "На Rotary Name сверните на второй съезд в направлении Destination 1",
-        "sv": "I Rotary Name ta 2:a avfarten mot Destination 1",
+        "sv": "I Rotary Name, ta 2:a avfarten mot Destination 1",
         "tr": "Rotary Name dönel kavşağa gir ve Destination 1 istikametindeki ikinci numaralı çıkışa gir",
         "uk": "Рухайтесь по Rotary Name та поверніть у 2й з'їзд в напрямку Destination 1",
         "vi": "Đi vào Rotary Name và ra tại đường thứ 2 đến Destination 1",

--- a/test/fixtures/v5/rotary/name_exit_name.json
+++ b/test/fixtures/v5/rotary/name_exit_name.json
@@ -22,7 +22,7 @@
         "pt-BR": "Entre em Rotary Name e saia na 2º saída em Way Name",
         "ro": "Intrați în Rotary Name și mergeți spre ieșirea a 2-a pe Way Name",
         "ru": "На Rotary Name сверните на второй съезд на Way Name",
-        "sv": "I Rotary Name ta 2:a avfarten in på Way Name",
+        "sv": "I Rotary Name, ta 2:a avfarten in på Way Name",
         "tr": "Rotary Name dönel kavşağa gir ve Way Name üzerindeki ikinci numaralı çıkışa gir",
         "uk": "Рухайтесь по Rotary Name та поверніть у 2й з'їзд на Way Name",
         "vi": "Đi vào Rotary Name và ra tại đường thứ 2 tức Way Name",

--- a/test/fixtures/v5/rotary/name_name.json
+++ b/test/fixtures/v5/rotary/name_name.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre em Rotary Name e saia em Way Name",
         "ro": "Intrați în Rotary Name și ieșiți pe Way Name",
         "ru": "На Rotary Name сверните на Way Name",
-        "sv": "I Rotary Name ta av in på Way Name",
+        "sv": "I Rotary Name, ta av in på Way Name",
         "tr": "Rotary Name dönel kavşağa gir ve Way Name üzerinde çık",
         "uk": "Рухайтесь по Rotary Name та поверніть на Way Name",
         "vi": "Đi vào Rotary Name và ra tại Way Name",

--- a/test/fixtures/v5/roundabout/default_destination.json
+++ b/test/fixtures/v5/roundabout/default_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia sentido Destination 1",
         "ro": "Intrați în sensul giratoriu și ieșiți spre Destination 1",
         "ru": "На круговой развязке сверните в направлении Destination 1",
-        "sv": "I rondellen ta av mot Destination 1",
+        "sv": "I rondellen, ta av mot Destination 1",
         "tr": "Göbekli kavşağa gir ve Destination 1 istikametinde çık",
         "uk": "Рухайтесь по кільцю в напрямку Destination 1",
         "vi": "Đi vào vòng xuyến và ra để đi Destination 1",

--- a/test/fixtures/v5/roundabout/default_exit.json
+++ b/test/fixtures/v5/roundabout/default_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia em Way Name",
         "ro": "Intrați în sensul giratoriu și ieșiți pe Way Name",
         "ru": "На круговой развязке сверните на Way Name",
-        "sv": "I rondellen ta avfarten in på Way Name",
+        "sv": "I rondellen, ta avfarten in på Way Name",
         "tr": "Göbekli kavşağa gir ve Way Name üzerinde çık",
         "uk": "Рухайтесь по кільцю до Way Name",
         "vi": "Đi vào vòng xuyến và ra tại Way Name",

--- a/test/fixtures/v5/roundabout/default_exit.json
+++ b/test/fixtures/v5/roundabout/default_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia em Way Name",
         "ro": "Intrați în sensul giratoriu și ieșiți pe Way Name",
         "ru": "На круговой развязке сверните на Way Name",
-        "sv": "I rondellen ta av mot Way Name",
+        "sv": "I rondellen ta avfarten in på Way Name",
         "tr": "Göbekli kavşağa gir ve Way Name üzerinde çık",
         "uk": "Рухайтесь по кільцю до Way Name",
         "vi": "Đi vào vòng xuyến và ra tại Way Name",

--- a/test/fixtures/v5/roundabout/default_exit_destination.json
+++ b/test/fixtures/v5/roundabout/default_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Entre na rotatória e saia sentido Destination 1",
         "ro": "Intrați în sensul giratoriu și ieșiți spre Destination 1",
         "ru": "На круговой развязке сверните в направлении Destination 1",
-        "sv": "I rondellen ta av mot Destination 1",
+        "sv": "I rondellen, ta av mot Destination 1",
         "tr": "Göbekli kavşağa gir ve Destination 1 istikametinde çık",
         "uk": "Рухайтесь по кільцю в напрямку Destination 1",
         "vi": "Đi vào vòng xuyến và ra để đi Destination 1",

--- a/test/fixtures/v5/roundabout/default_name.json
+++ b/test/fixtures/v5/roundabout/default_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Entre na rotatória e saia em Way Name",
         "ro": "Intrați în sensul giratoriu și ieșiți pe Way Name",
         "ru": "На круговой развязке сверните на Way Name",
-        "sv": "I rondellen ta av mot Way Name",
+        "sv": "I rondellen ta avfarten in på Way Name",
         "tr": "Göbekli kavşağa gir ve Way Name üzerinde çık",
         "uk": "Рухайтесь по кільцю до Way Name",
         "vi": "Đi vào vòng xuyến và ra tại Way Name",

--- a/test/fixtures/v5/roundabout/default_name.json
+++ b/test/fixtures/v5/roundabout/default_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Entre na rotatória e saia em Way Name",
         "ro": "Intrați în sensul giratoriu și ieșiți pe Way Name",
         "ru": "На круговой развязке сверните на Way Name",
-        "sv": "I rondellen ta avfarten in på Way Name",
+        "sv": "I rondellen, ta avfarten in på Way Name",
         "tr": "Göbekli kavşağa gir ve Way Name üzerinde çık",
         "uk": "Рухайтесь по кільцю до Way Name",
         "vi": "Đi vào vòng xuyến và ra tại Way Name",

--- a/test/fixtures/v5/roundabout/exit_default.json
+++ b/test/fixtures/v5/roundabout/exit_default.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia na 1º saída",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea prima",
         "ru": "На круговой развязке сверните на первый съезд",
-        "sv": "I rondellen ta 1:a avfarten",
+        "sv": "I rondellen, ta 1:a avfarten",
         "tr": "Göbekli kavşağa gir ve birinci numaralı çıkışa gir",
         "uk": "Рухайтесь по кільцю та повереніть у 1й з'їзд",
         "vi": "Đi vào vòng xuyến và ra tại đường đầu tiên",

--- a/test/fixtures/v5/roundabout/exit_destination.json
+++ b/test/fixtures/v5/roundabout/exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Entre na rotatória e saia na 1º saída sentido Destination 1",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea prima spre Destination 1",
         "ru": "На круговой развязке сверните на первый съезд в направлении Destination 1",
-        "sv": "I rondellen ta 1:a avfarten mot Destination 1",
+        "sv": "I rondellen, ta 1:a avfarten mot Destination 1",
         "tr": "Göbekli kavşağa gir ve Destination 1 istikametindeki birinci numaralı çıkışa gir",
         "uk": "Рухайтесь по кільцю та поверніть у 1й з'їзд у напрямку Destination 1",
         "vi": "Đi vào vòng xuyến và ra tại đường đầu tiên đến Destination 1",

--- a/test/fixtures/v5/roundabout/exit_exit.json
+++ b/test/fixtures/v5/roundabout/exit_exit.json
@@ -22,7 +22,7 @@
         "pt-BR": "Entre na rotatória e saia na 1º saída em Way Name",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea prima pe Way Name",
         "ru": "На круговой развязке сверните на первый съезд на Way Name",
-        "sv": "I rondellen ta 1:a avfarten in på Way Name",
+        "sv": "I rondellen, ta 1:a avfarten in på Way Name",
         "tr": "Göbekli kavşağa gir ve Way Name üzerindeki birinci numaralı çıkışa gir",
         "uk": "Рухайтесь по кільцю та поверніть у 1й з'їзд на Way Name",
         "vi": "Đi vào vòng xuyến và ra tại đường đầu tiên tức Way Name",

--- a/test/fixtures/v5/roundabout/exit_exit_destination.json
+++ b/test/fixtures/v5/roundabout/exit_exit_destination.json
@@ -23,7 +23,7 @@
         "pt-BR": "Entre na rotatória e saia na 1º saída sentido Destination 1",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea prima spre Destination 1",
         "ru": "На круговой развязке сверните на первый съезд в направлении Destination 1",
-        "sv": "I rondellen ta 1:a avfarten mot Destination 1",
+        "sv": "I rondellen, ta 1:a avfarten mot Destination 1",
         "tr": "Göbekli kavşağa gir ve Destination 1 istikametindeki birinci numaralı çıkışa gir",
         "uk": "Рухайтесь по кільцю та поверніть у 1й з'їзд у напрямку Destination 1",
         "vi": "Đi vào vòng xuyến và ra tại đường đầu tiên đến Destination 1",

--- a/test/fixtures/v5/roundabout/exit_name.json
+++ b/test/fixtures/v5/roundabout/exit_name.json
@@ -21,7 +21,7 @@
         "pt-BR": "Entre na rotatória e saia na 1º saída em Way Name",
         "ro": "Intrați în sensul giratoriu și mergeți spre ieșirea prima pe Way Name",
         "ru": "На круговой развязке сверните на первый съезд на Way Name",
-        "sv": "I rondellen ta 1:a avfarten in på Way Name",
+        "sv": "I rondellen, ta 1:a avfarten in på Way Name",
         "tr": "Göbekli kavşağa gir ve Way Name üzerindeki birinci numaralı çıkışa gir",
         "uk": "Рухайтесь по кільцю та поверніть у 1й з'їзд на Way Name",
         "vi": "Đi vào vòng xuyến và ra tại đường đầu tiên tức Way Name",

--- a/test/fixtures/v5/roundabout_turn/left_default.json
+++ b/test/fixtures/v5/roundabout_turn/left_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Na rotatória vire à esquerda",
         "ro": "La sensul giratoriu virați stânga",
         "ru": "На круговой развязке сверните налево",
-        "sv": "I rondellen sväng vänster",
+        "sv": "I rondellen, sväng vänster",
         "tr": "Göbekli kavşakta sola dön",
         "uk": "На кільці поверніть ліворуч",
         "vi": "Quẹo trái tại vòng xuyến",

--- a/test/fixtures/v5/roundabout_turn/left_destination.json
+++ b/test/fixtures/v5/roundabout_turn/left_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Na rotatória vire à esquerda sentido Destination 1",
         "ro": "La sensul giratoriu virați stânga spre Destination 1",
         "ru": "На круговой развязке сверните налево в направлении Destination 1",
-        "sv": "I rondellen sväng vänster mot Destination 1",
+        "sv": "I rondellen, sväng vänster mot Destination 1",
         "tr": "Göbekli kavşakta Destination 1 istikametinde sola dön",
         "uk": "На кільці поверніть ліворуч в напрямку Destination 1",
         "vi": "Quẹo trái tại vòng xuyến để đi Destination 1",

--- a/test/fixtures/v5/roundabout_turn/left_exit.json
+++ b/test/fixtures/v5/roundabout_turn/left_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Na rotatória vire à esquerda em Way Name",
         "ro": "La sensul giratoriu virați stânga pe Way Name",
         "ru": "На круговой развязке сверните налево на Way Name",
-        "sv": "I rondellen sväng vänster in på Way Name",
+        "sv": "I rondellen, sväng vänster in på Way Name",
         "tr": "Göbekli kavşakta Way Name üzerinde sola dön",
         "uk": "На кільці поверніть ліворуч на Way Name",
         "vi": "Quẹo trái tại vòng xuyến để vào Way Name",

--- a/test/fixtures/v5/roundabout_turn/left_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/left_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Na rotatória vire à esquerda sentido Destination 1",
         "ro": "La sensul giratoriu virați stânga spre Destination 1",
         "ru": "На круговой развязке сверните налево в направлении Destination 1",
-        "sv": "I rondellen sväng vänster mot Destination 1",
+        "sv": "I rondellen, sväng vänster mot Destination 1",
         "tr": "Göbekli kavşakta Destination 1 istikametinde sola dön",
         "uk": "На кільці поверніть ліворуч в напрямку Destination 1",
         "vi": "Quẹo trái tại vòng xuyến để đi Destination 1",

--- a/test/fixtures/v5/roundabout_turn/left_name.json
+++ b/test/fixtures/v5/roundabout_turn/left_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Na rotatória vire à esquerda em Way Name",
         "ro": "La sensul giratoriu virați stânga pe Way Name",
         "ru": "На круговой развязке сверните налево на Way Name",
-        "sv": "I rondellen sväng vänster in på Way Name",
+        "sv": "I rondellen, sväng vänster in på Way Name",
         "tr": "Göbekli kavşakta Way Name üzerinde sola dön",
         "uk": "На кільці поверніть ліворуч на Way Name",
         "vi": "Quẹo trái tại vòng xuyến để vào Way Name",

--- a/test/fixtures/v5/roundabout_turn/right_default.json
+++ b/test/fixtures/v5/roundabout_turn/right_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Na rotatória vire à direita",
         "ro": "La sensul giratoriu virați dreapta",
         "ru": "На круговой развязке сверните направо",
-        "sv": "I rondellen sväng höger",
+        "sv": "I rondellen, sväng höger",
         "tr": "Göbekli kavşakta sağa dön",
         "uk": "На кільці поверніть праворуч",
         "vi": "Quẹo phải tại vòng xuyến",

--- a/test/fixtures/v5/roundabout_turn/right_destination.json
+++ b/test/fixtures/v5/roundabout_turn/right_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Na rotatória vire à direita sentido Destination 1",
         "ro": "La sensul giratoriu virați dreapta spre Destination 1",
         "ru": "На круговой развязке сверните направо в направлении Destination 1",
-        "sv": "I rondellen sväng höger mot Destination 1",
+        "sv": "I rondellen, sväng höger mot Destination 1",
         "tr": "Göbekli kavşakta Destination 1 üzerinde sağa dön",
         "uk": "На кільці поверніть праворуч в напрямку Destination 1",
         "vi": "Quẹo phải tại vòng xuyến để đi Destination 1",

--- a/test/fixtures/v5/roundabout_turn/right_exit.json
+++ b/test/fixtures/v5/roundabout_turn/right_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Na rotatória vire à direita em Way Name",
         "ro": "La sensul giratoriu virați dreapta pe Way Name",
         "ru": "На круговой развязке сверните направо на Way Name",
-        "sv": "I rondellen sväng höger in på Way Name",
+        "sv": "I rondellen, sväng höger in på Way Name",
         "tr": "Göbekli kavşakta Way Name üzerinde sağa dön",
         "uk": "На кільці поверніть праворуч на Way Name",
         "vi": "Quẹo phải ti vòng xuyến để vào Way Name",

--- a/test/fixtures/v5/roundabout_turn/right_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/right_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Na rotatória vire à direita sentido Destination 1",
         "ro": "La sensul giratoriu virați dreapta spre Destination 1",
         "ru": "На круговой развязке сверните направо в направлении Destination 1",
-        "sv": "I rondellen sväng höger mot Destination 1",
+        "sv": "I rondellen, sväng höger mot Destination 1",
         "tr": "Göbekli kavşakta Destination 1 üzerinde sağa dön",
         "uk": "На кільці поверніть праворуч в напрямку Destination 1",
         "vi": "Quẹo phải tại vòng xuyến để đi Destination 1",

--- a/test/fixtures/v5/roundabout_turn/right_name.json
+++ b/test/fixtures/v5/roundabout_turn/right_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Na rotatória vire à direita em Way Name",
         "ro": "La sensul giratoriu virați dreapta pe Way Name",
         "ru": "На круговой развязке сверните направо на Way Name",
-        "sv": "I rondellen sväng höger in på Way Name",
+        "sv": "I rondellen, sväng höger in på Way Name",
         "tr": "Göbekli kavşakta Way Name üzerinde sağa dön",
         "uk": "На кільці поверніть праворуч на Way Name",
         "vi": "Quẹo phải ti vòng xuyến để vào Way Name",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_default.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Na rotatória, vire acentuadamente à esquerda",
         "ro": "La sensul giratoriu virați brusc stânga",
         "ru": "На круговой развязке двигайтесь налево",
-        "sv": "I rondellen sväng vänster",
+        "sv": "I rondellen, sväng vänster",
         "tr": "Göbekli kavşakta keskin sol yöne dön",
         "uk": "На кільці різко ліворуч",
         "vi": "Đi bên trái gắt tại vòng xuyến",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Na rotatória, vire acentuadamente à esquerda em direção à Destination 1",
         "ro": "La sensul giratoriu virați brusc stânga spre Destination 1",
         "ru": "На круговой развязке двигайтесь налево в направлении Destination 1",
-        "sv": "I rondellen sväng vänster mot Destination 1",
+        "sv": "I rondellen, sväng vänster mot Destination 1",
         "tr": "Destination 1 üzerindeki göbekli kavşakta keskin sol yöne dön",
         "uk": "На кільці різко ліворуч в напрямку Destination 1",
         "vi": "Đi bên trái gắt tại vòng xuyến để đi Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_exit.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Na rotatória, vire acentuadamente à esquerda na Way Name",
         "ro": "La sensul giratoriu virați brusc stânga pe Way Name",
         "ru": "На круговой развязке двигайтесь налево на Way Name",
-        "sv": "I rondellen sväng vänster in på Way Name",
+        "sv": "I rondellen, sväng vänster in på Way Name",
         "tr": "Way Name üzerindeki göbekli kavşakta keskin sol yöne dön",
         "uk": "На кільці різко ліворуч на Way Name",
         "vi": "Đi bên trái gắt tại vòng xuyến để vào Way Name",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Na rotatória, vire acentuadamente à esquerda em direção à Destination 1",
         "ro": "La sensul giratoriu virați brusc stânga spre Destination 1",
         "ru": "На круговой развязке двигайтесь налево в направлении Destination 1",
-        "sv": "I rondellen sväng vänster mot Destination 1",
+        "sv": "I rondellen, sväng vänster mot Destination 1",
         "tr": "Destination 1 üzerindeki göbekli kavşakta keskin sol yöne dön",
         "uk": "На кільці різко ліворуч в напрямку Destination 1",
         "vi": "Đi bên trái gắt tại vòng xuyến để đi Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_name.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Na rotatória, vire acentuadamente à esquerda na Way Name",
         "ro": "La sensul giratoriu virați brusc stânga pe Way Name",
         "ru": "На круговой развязке двигайтесь налево на Way Name",
-        "sv": "I rondellen sväng vänster in på Way Name",
+        "sv": "I rondellen, sväng vänster in på Way Name",
         "tr": "Way Name üzerindeki göbekli kavşakta keskin sol yöne dön",
         "uk": "На кільці різко ліворуч на Way Name",
         "vi": "Đi bên trái gắt tại vòng xuyến để vào Way Name",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_default.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Na rotatória, vire acentuadamente à direita",
         "ro": "La sensul giratoriu virați brusc dreapta",
         "ru": "На круговой развязке двигайтесь направо",
-        "sv": "I rondellen sväng höger",
+        "sv": "I rondellen, sväng höger",
         "tr": "Göbekli kavşakta keskin sağ yöne dön",
         "uk": "На кільці різко праворуч",
         "vi": "Đi bên phải gắt tại vòng xuyến",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Na rotatória, vire acentuadamente à direita em direção à Destination 1",
         "ro": "La sensul giratoriu virați brusc dreapta spre Destination 1",
         "ru": "На круговой развязке двигайтесь направо в направлении Destination 1",
-        "sv": "I rondellen sväng höger mot Destination 1",
+        "sv": "I rondellen, sväng höger mot Destination 1",
         "tr": "Destination 1 üzerindeki göbekli kavşakta keskin sağ yöne dön",
         "uk": "На кільці різко праворуч в напрямку Destination 1",
         "vi": "Đi bên phải gắt tại vòng xuyến để đi Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_exit.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Na rotatória, vire acentuadamente à direita na Way Name",
         "ro": "La sensul giratoriu virați brusc dreapta pe Way Name",
         "ru": "На круговой развязке двигайтесь направо на Way Name",
-        "sv": "I rondellen sväng höger in på Way Name",
+        "sv": "I rondellen, sväng höger in på Way Name",
         "tr": "Way Name üzerindeki göbekli kavşakta keskin sağ yöne dön",
         "uk": "На кільці різко праворуч на Way Name",
         "vi": "Đi bên phải gắt tại vòng xuyến để vào Way Name",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Na rotatória, vire acentuadamente à direita em direção à Destination 1",
         "ro": "La sensul giratoriu virați brusc dreapta spre Destination 1",
         "ru": "На круговой развязке двигайтесь направо в направлении Destination 1",
-        "sv": "I rondellen sväng höger mot Destination 1",
+        "sv": "I rondellen, sväng höger mot Destination 1",
         "tr": "Destination 1 üzerindeki göbekli kavşakta keskin sağ yöne dön",
         "uk": "На кільці різко праворуч в напрямку Destination 1",
         "vi": "Đi bên phải gắt tại vòng xuyến để đi Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_name.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Na rotatória, vire acentuadamente à direita na Way Name",
         "ro": "La sensul giratoriu virați brusc dreapta pe Way Name",
         "ru": "На круговой развязке двигайтесь направо на Way Name",
-        "sv": "I rondellen sväng höger in på Way Name",
+        "sv": "I rondellen, sväng höger in på Way Name",
         "tr": "Way Name üzerindeki göbekli kavşakta keskin sağ yöne dön",
         "uk": "На кільці різко праворуч на Way Name",
         "vi": "Đi bên phải gắt tại vòng xuyến để vào Way Name",

--- a/test/fixtures/v5/roundabout_turn/slight_left_default.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Na rotatória, vire ligeiramente à esquerda",
         "ro": "La sensul giratoriu virați ușor stânga",
         "ru": "На круговой развязке двигайтесь левее",
-        "sv": "I rondellen sväng vänster",
+        "sv": "I rondellen, sväng vänster",
         "tr": "Göbekli kavşakta hafif sol yöne dön",
         "uk": "На кільці плавно ліворуч",
         "vi": "Đi bên trái nghiêng tại vòng xuyến",

--- a/test/fixtures/v5/roundabout_turn/slight_left_destination.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Na rotatória, vire ligeiramente à esquerda em direção à Destination 1",
         "ro": "La sensul giratoriu virați ușor stânga spre Destination 1",
         "ru": "На круговой развязке двигайтесь левее в направлении Destination 1",
-        "sv": "I rondellen sväng vänster mot Destination 1",
+        "sv": "I rondellen, sväng vänster mot Destination 1",
         "tr": "Destination 1 üzerindeki göbekli kavşakta hafif sol yöne dön",
         "uk": "На кільці плавно ліворуч в напрямку Destination 1",
         "vi": "Đi bên trái nghiêng tại vòng xuyến để đi Destination 1",

--- a/test/fixtures/v5/roundabout_turn/slight_left_exit.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Na rotatória, vire ligeiramente à esquerda na Way Name",
         "ro": "La sensul giratoriu virați ușor stânga pe Way Name",
         "ru": "На круговой развязке двигайтесь левее на Way Name",
-        "sv": "I rondellen sväng vänster in på Way Name",
+        "sv": "I rondellen, sväng vänster in på Way Name",
         "tr": "Way Name üzerindeki göbekli kavşakta hafif sol yöne dön",
         "uk": "На кільці плавно ліворуч на Way Name",
         "vi": "Đi bên trái nghiêng tại vòng xuyến để vào Way Name",

--- a/test/fixtures/v5/roundabout_turn/slight_left_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Na rotatória, vire ligeiramente à esquerda em direção à Destination 1",
         "ro": "La sensul giratoriu virați ușor stânga spre Destination 1",
         "ru": "На круговой развязке двигайтесь левее в направлении Destination 1",
-        "sv": "I rondellen sväng vänster mot Destination 1",
+        "sv": "I rondellen, sväng vänster mot Destination 1",
         "tr": "Destination 1 üzerindeki göbekli kavşakta hafif sol yöne dön",
         "uk": "На кільці плавно ліворуч в напрямку Destination 1",
         "vi": "Đi bên trái nghiêng tại vòng xuyến để đi Destination 1",

--- a/test/fixtures/v5/roundabout_turn/slight_left_name.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Na rotatória, vire ligeiramente à esquerda na Way Name",
         "ro": "La sensul giratoriu virați ușor stânga pe Way Name",
         "ru": "На круговой развязке двигайтесь левее на Way Name",
-        "sv": "I rondellen sväng vänster in på Way Name",
+        "sv": "I rondellen, sväng vänster in på Way Name",
         "tr": "Way Name üzerindeki göbekli kavşakta hafif sol yöne dön",
         "uk": "На кільці плавно ліворуч на Way Name",
         "vi": "Đi bên trái nghiêng tại vòng xuyến để vào Way Name",

--- a/test/fixtures/v5/roundabout_turn/slight_right_default.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Na rotatória, vire ligeiramente à direita",
         "ro": "La sensul giratoriu virați ușor dreapta",
         "ru": "На круговой развязке двигайтесь правее",
-        "sv": "I rondellen sväng höger",
+        "sv": "I rondellen, sväng höger",
         "tr": "Göbekli kavşakta hafif sağ yöne dön",
         "uk": "На кільці плавно праворуч",
         "vi": "Đi bên phải nghiêng tại vòng xuyến",

--- a/test/fixtures/v5/roundabout_turn/slight_right_destination.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Na rotatória, vire ligeiramente à direita em direção à Destination 1",
         "ro": "La sensul giratoriu virați ușor dreapta spre Destination 1",
         "ru": "На круговой развязке двигайтесь правее в направлении Destination 1",
-        "sv": "I rondellen sväng höger mot Destination 1",
+        "sv": "I rondellen, sväng höger mot Destination 1",
         "tr": "Destination 1 üzerindeki göbekli kavşakta hafif sağ yöne dön",
         "uk": "На кільці плавно праворуч в напрямку Destination 1",
         "vi": "Đi bên phải nghiêng tại vòng xuyến để đi Destination 1",

--- a/test/fixtures/v5/roundabout_turn/slight_right_exit.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Na rotatória, vire ligeiramente à direita na Way Name",
         "ro": "La sensul giratoriu virați ușor dreapta pe Way Name",
         "ru": "На круговой развязке двигайтесь правее на Way Name",
-        "sv": "I rondellen sväng höger in på Way Name",
+        "sv": "I rondellen, sväng höger in på Way Name",
         "tr": "Way Name üzerindeki göbekli kavşakta hafif sağ yöne dön",
         "uk": "На кільці плавно праворуч на Way Name",
         "vi": "Đi bên phải nghiêng tại vòng xuyến để vào Way Name",

--- a/test/fixtures/v5/roundabout_turn/slight_right_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Na rotatória, vire ligeiramente à direita em direção à Destination 1",
         "ro": "La sensul giratoriu virați ușor dreapta spre Destination 1",
         "ru": "На круговой развязке двигайтесь правее в направлении Destination 1",
-        "sv": "I rondellen sväng höger mot Destination 1",
+        "sv": "I rondellen, sväng höger mot Destination 1",
         "tr": "Destination 1 üzerindeki göbekli kavşakta hafif sağ yöne dön",
         "uk": "На кільці плавно праворуч в напрямку Destination 1",
         "vi": "Đi bên phải nghiêng tại vòng xuyến để đi Destination 1",

--- a/test/fixtures/v5/roundabout_turn/slight_right_name.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Na rotatória, vire ligeiramente à direita na Way Name",
         "ro": "La sensul giratoriu virați ușor dreapta pe Way Name",
         "ru": "На круговой развязке двигайтесь правее на Way Name",
-        "sv": "I rondellen sväng höger in på Way Name",
+        "sv": "I rondellen, sväng höger in på Way Name",
         "tr": "Way Name üzerindeki göbekli kavşakta hafif sağ yöne dön",
         "uk": "На кільці плавно праворуч на Way Name",
         "vi": "Đi bên phải nghiêng tại vòng xuyến để vào Way Name",

--- a/test/fixtures/v5/roundabout_turn/straight_default.json
+++ b/test/fixtures/v5/roundabout_turn/straight_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Na rotatória siga reto",
         "ro": "La sensul giratoriu continuați înainte",
         "ru": "На круговой развязке двигайтесь прямо",
-        "sv": "I rondellen fortsätt rakt fram",
+        "sv": "I rondellen, fortsätt rakt fram",
         "tr": "Göbekli kavşakta düz devam et",
         "uk": "На кільці продовжуйте рухатись прямо",
         "vi": "Chạy thẳng tại vòng xuyến",

--- a/test/fixtures/v5/roundabout_turn/straight_destination.json
+++ b/test/fixtures/v5/roundabout_turn/straight_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Na rotatória siga reto sentido Destination 1",
         "ro": "La sensul giratoriu continuați înainte spre Destination 1",
         "ru": "На круговой развязке двигайтесь в направлении Destination 1",
-        "sv": "I rondellen fortsätt rakt fram mot Destination 1",
+        "sv": "I rondellen, fortsätt rakt fram mot Destination 1",
         "tr": "Göbekli kavşakta Destination 1 istikametinde düz devam et",
         "uk": "На кільці продовжуйте рухатись прямо в напрямку Destination 1",
         "vi": "Chạy thẳng tại vòng xuyến để đi Destination 1",

--- a/test/fixtures/v5/roundabout_turn/straight_exit.json
+++ b/test/fixtures/v5/roundabout_turn/straight_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Na rotatória siga reto em Way Name",
         "ro": "La sensul giratoriu continuați înainte pe Way Name",
         "ru": "На круговой развязке двигайтесь по Way Name",
-        "sv": "I rondellen fortsätt rakt fram in på Way Name",
+        "sv": "I rondellen, fortsätt rakt fram in på Way Name",
         "tr": "Göbekli kavşakta Way Name üzerinde düz devam et",
         "uk": "На кільці продовжуйте рухатись прямо на Way Name",
         "vi": "Chạy thẳng tại vòng xuyến để chạy tiếp trên Way Name",

--- a/test/fixtures/v5/roundabout_turn/straight_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/straight_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Na rotatória siga reto sentido Destination 1",
         "ro": "La sensul giratoriu continuați înainte spre Destination 1",
         "ru": "На круговой развязке двигайтесь в направлении Destination 1",
-        "sv": "I rondellen fortsätt rakt fram mot Destination 1",
+        "sv": "I rondellen, fortsätt rakt fram mot Destination 1",
         "tr": "Göbekli kavşakta Destination 1 istikametinde düz devam et",
         "uk": "На кільці продовжуйте рухатись прямо в напрямку Destination 1",
         "vi": "Chạy thẳng tại vòng xuyến để đi Destination 1",

--- a/test/fixtures/v5/roundabout_turn/straight_name.json
+++ b/test/fixtures/v5/roundabout_turn/straight_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Na rotatória siga reto em Way Name",
         "ro": "La sensul giratoriu continuați înainte pe Way Name",
         "ru": "На круговой развязке двигайтесь по Way Name",
-        "sv": "I rondellen fortsätt rakt fram in på Way Name",
+        "sv": "I rondellen, fortsätt rakt fram in på Way Name",
         "tr": "Göbekli kavşakta Way Name üzerinde düz devam et",
         "uk": "На кільці продовжуйте рухатись прямо на Way Name",
         "vi": "Chạy thẳng tại vòng xuyến để chạy tiếp trên Way Name",

--- a/test/fixtures/v5/roundabout_turn/uturn_default.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_default.json
@@ -20,7 +20,7 @@
         "pt-BR": "Na rotatória, vire retorno",
         "ro": "La sensul giratoriu virați întoarcere",
         "ru": "На круговой развязке двигайтесь на разворот",
-        "sv": "I rondellen sväng U-sväng",
+        "sv": "I rondellen, sväng U-sväng",
         "tr": "Göbekli kavşakta U dönüşü yöne dön",
         "uk": "На кільці розворот",
         "vi": "Đi bên ngược tại vòng xuyến",

--- a/test/fixtures/v5/roundabout_turn/uturn_destination.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_destination.json
@@ -21,7 +21,7 @@
         "pt-BR": "Na rotatória, vire retorno em direção à Destination 1",
         "ro": "La sensul giratoriu virați întoarcere spre Destination 1",
         "ru": "На круговой развязке двигайтесь на разворот в направлении Destination 1",
-        "sv": "I rondellen sväng U-sväng mot Destination 1",
+        "sv": "I rondellen, sväng U-sväng mot Destination 1",
         "tr": "Destination 1 üzerindeki göbekli kavşakta U dönüşü yöne dön",
         "uk": "На кільці розворот в напрямку Destination 1",
         "vi": "Đi bên ngược tại vòng xuyến để đi Destination 1",

--- a/test/fixtures/v5/roundabout_turn/uturn_exit.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_exit.json
@@ -21,7 +21,7 @@
         "pt-BR": "Na rotatória, vire retorno na Way Name",
         "ro": "La sensul giratoriu virați întoarcere pe Way Name",
         "ru": "На круговой развязке двигайтесь на разворот на Way Name",
-        "sv": "I rondellen sväng U-sväng in på Way Name",
+        "sv": "I rondellen, sväng U-sväng in på Way Name",
         "tr": "Way Name üzerindeki göbekli kavşakta U dönüşü yöne dön",
         "uk": "На кільці розворот на Way Name",
         "vi": "Đi bên ngược tại vòng xuyến để vào Way Name",

--- a/test/fixtures/v5/roundabout_turn/uturn_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_exit_destination.json
@@ -22,7 +22,7 @@
         "pt-BR": "Na rotatória, vire retorno em direção à Destination 1",
         "ro": "La sensul giratoriu virați întoarcere spre Destination 1",
         "ru": "На круговой развязке двигайтесь на разворот в направлении Destination 1",
-        "sv": "I rondellen sväng U-sväng mot Destination 1",
+        "sv": "I rondellen, sväng U-sväng mot Destination 1",
         "tr": "Destination 1 üzerindeki göbekli kavşakta U dönüşü yöne dön",
         "uk": "На кільці розворот в напрямку Destination 1",
         "vi": "Đi bên ngược tại vòng xuyến để đi Destination 1",

--- a/test/fixtures/v5/roundabout_turn/uturn_name.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_name.json
@@ -20,7 +20,7 @@
         "pt-BR": "Na rotatória, vire retorno na Way Name",
         "ro": "La sensul giratoriu virați întoarcere pe Way Name",
         "ru": "На круговой развязке двигайтесь на разворот на Way Name",
-        "sv": "I rondellen sväng U-sväng in på Way Name",
+        "sv": "I rondellen, sväng U-sväng in på Way Name",
         "tr": "Way Name üzerindeki göbekli kavşakta U dönüşü yöne dön",
         "uk": "На кільці розворот на Way Name",
         "vi": "Đi bên ngược tại vòng xuyến để vào Way Name",


### PR DESCRIPTION
Added untranslated strings in transifex, pulled them and created the test strings. 

cc @frederoni for review and @1ec5 

Started wondering about the possibility with commas and how they are treated with TTS in Swedish. Like `i rondellen, ta av mot` vs `i rondellen ta av mot`. 
