### PR TITLE
Fix broken links in Readme files

### DIFF
--- a/Grammar.md
+++ b/Grammar.md
@@ -55,7 +55,7 @@ Russian _"Большая Монетная улица"_ street from St Petersburg
 ### Design goals
 
 - __Cross platform__ - uses the same data-driven approach as OSRM Text Instructions
-- __Test suite__ - has [prepared test](test/grammar_tests.js) to check available expressions automatically and has easily extendable language-specific names testing pattern
+- __Test suite__ - has [prepared test](test/grammar_test.js) to check available expressions automatically and has easily extendable language-specific names testing pattern
 - __Customization__ - could be easily extended for other languages with adding new regular expressions blocks into [grammar support](languages/grammar/) folder and modifying `{way_name}` and other variables in translated instructions only with necessary grammatical case labels
 
 ### Notes

--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@ OSRM Text Instructions transforms [OSRM](http://www.project-osrm.org/) route res
 
 OSRM Text Instructions has been translated into [several languages](https://github.com/Project-OSRM/osrm-text-instructions/tree/master/languages/translations/). Please help us add support for the languages you speak [using Transifex](https://www.transifex.com/project-osrm/osrm-text-instructions/).
 
-OSRM Text Instructions could support [grammatical cases](https://github.com/Project-OSRM/osrm-text-instructions/tree/master/Grammar.md) for street names for [some languages](https://github.com/Project-OSRM/osrm-text-instructions/tree/languages/grammar/).
+OSRM Text Instructions could support [grammatical cases](https://github.com/Project-OSRM/osrm-text-instructions/tree/master/Grammar.md) for street names for [some languages](https://github.com/Project-OSRM/osrm-text-instructions/tree/master/languages/grammar/).
 
 Grammatical cases and other translated strings customization after [Transifex](https://www.transifex.com/project-osrm/osrm-text-instructions/) is handled by [override scripts](https://github.com/Project-OSRM/osrm-text-instructions/tree/master/languages/overrides/).
 


### PR DESCRIPTION
# Issue

Some links in Readme.md and Grammar.md to project source files are broken.
This PR fixes them.

