### PR TITLE
Call formatToken on bare refs and names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
+## master
+
+- Fixed issue preventing `formatToken` from being called on refs or names when the way has only a ref or a name. [#193](https://github.com/Project-OSRM/osrm-text-instructions/pull/193)
+
 ## 0.10.6 2017-11-10
 
 - Updated translations in Esperanto, French, Portuguese, Russian, and Spanish. [#189](https://github.com/Project-OSRM/osrm-text-instructions/pull/189)

--- a/index.js
+++ b/index.js
@@ -96,11 +96,11 @@ module.exports = function(version) {
                     ref: ref
                 }, options);
             } else if (name && ref && wayMotorway && (/\d/).test(ref)) {
-                wayName = ref;
+                wayName = options && options.formatToken ? options.formatToken('ref', ref) : ref;
             } else if (!name && ref) {
-                wayName = ref;
+                wayName = options && options.formatToken ? options.formatToken('ref', ref) : ref;
             } else {
-                wayName = name;
+                wayName = options && options.formatToken ? options.formatToken('name', name) : name;
             }
 
             return wayName;

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -158,6 +158,20 @@ tape.test('v5 wayName', function(assert) {
         assert.equal(v5Compiler.getWayName('en', c[0], {classes: ['motorway']}), c[1], `correct way name for motorway test ${i}`);
     });
 
+    [
+        [makeStep('', ''), 'name '],
+        [makeStep('123', 'ABC'), 'name ABC (ref 123)'],
+        [makeStep('123', 'ABC (123)'), 'name ABC (ref 123)'],
+        [makeStep('123; 456', 'ABC (123; 456)'), 'name ABC (ref 123)'],
+        [makeStep('123; 456', 'ABC'), 'name ABC (ref 123)']
+    ].forEach((c, i) => {
+        assert.equal(v5Compiler.getWayName('en', c[0], {
+            formatToken: function(token, value) {
+                return token + ' ' + value;
+            }
+        }), c[1], `correct way name for formatted test ${i}`);
+    });
+
     assert.throws(
         () => { v5Compiler.getWayName(); },
         'throws when no step is passed'


### PR DESCRIPTION
When the step’s way has only a ref or a name, call `formatToken` to give the client the opportunity to manipulate that ref or name, just as it would if the way has both a ref and a name.

/cc @mcwhittemore