### PR TITLE
Consistently choose the first destination ref and destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
+## master
+
+- Fixed inconsistent destinations when a ramp leads to multiple routes towards multiple places. [#197](https://github.com/Project-OSRM/osrm-text-instructions/pull/19y)
+
 ## 0.10.7 2017-12-05
 
 - Fixed issue preventing `formatToken` from being called on refs or names when the way has only a ref or a name. [#193](https://github.com/Project-OSRM/osrm-text-instructions/pull/193)

--- a/index.js
+++ b/index.js
@@ -180,13 +180,23 @@ module.exports = function(version) {
                 instruction = instructionObject.default;
             }
 
+            var destinations = step.destinations && step.destinations.split(': ');
+            var destinationRef = destinations && destinations[0].split(',')[0];
+            var destination = destinations && destinations[1] && destinations[1].split(',')[0];
+            var firstDestination;
+            if (destination && destinationRef) {
+                firstDestination = destinationRef + ': ' + destination;
+            } else {
+                firstDestination = destinationRef || destination || '';
+            }
+
             var nthWaypoint = options && options.legIndex >= 0 && options.legIndex !== options.legCount - 1 ? this.ordinalize(language, options.legIndex + 1) : '';
 
             // Replace tokens
             // NOOP if they don't exist
             var replaceTokens = {
                 'way_name': wayName,
-                'destination': (step.destinations || '').split(',')[0],
+                'destination': firstDestination,
                 'exit': (step.exits || '').split(';')[0],
                 'exit_number': this.ordinalize(language, step.maneuver.exit || 1),
                 'rotary_name': step.rotary_name,

--- a/test/fixtures/v5/other/way_name_destination_refs.json
+++ b/test/fixtures/v5/other/way_name_destination_refs.json
@@ -1,0 +1,29 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "right"
+        },
+        "destinations": "Ref1, Ref2: Destination 1, Destination 2"
+    },
+    "instructions": {
+        "de": "Ausfahrt rechts nehmen Richtung Ref1: Destination 1",
+        "en": "Take the ramp on the right towards Ref1: Destination 1",
+        "eo": "Direktiĝu al enveturejo ĉe dekstre al Ref1: Destination 1",
+        "es": "Tome la salida en la derecha hacia Ref1: Destination 1",
+        "es-ES": "Coge la cuesta abajo de la derecha hacia Ref1: Destination 1",
+        "fr": "Prendre la sortie à droite en direction de Ref1: Destination 1",
+        "id": "Ambil jalan melandai di sebelah kanan menuju Ref1: Destination 1",
+        "it": "Prendi la rampa a destra verso Ref1: Destination 1",
+        "nl": "Neem de afrit rechts richting Ref1: Destination 1",
+        "pl": "Weź zjazd po prawej w kierunku Ref1: Destination 1",
+        "pt-BR": "Pegue a rampa à direita sentido Ref1: Destination 1",
+        "ro": "Urmați rampa pe dreapta spre Ref1: Destination 1",
+        "ru": "Сверните на правый съезд в направлении Ref1: Destination 1",
+        "sv": "Ta avfarten till höger mot Ref1: Destination 1",
+        "tr": "Ref1: Destination 1 istikametine giden sağ bağlantı yoluna geç",
+        "uk": "Рухайтесь на зʼїзд праворуч у напрямку Ref1: Destination 1",
+        "vi": "Đi đường nhánh bên phải về hướng Ref1: Destination 1",
+        "zh-Hans": "通过右边的匝道前往Ref1: Destination 1"
+    }
+}

--- a/test/fixtures_test.js
+++ b/test/fixtures_test.js
@@ -271,6 +271,14 @@ tape.test('verify existence/update fixtures', function(assert) {
             checkOrWrite(baseStep, path.join(basePath, 'way_name_ref_destinations'));
             baseStep = {
                 maneuver: {
+                    type: 'off ramp',
+                    modifier: 'right'
+                },
+                destinations: 'Ref1, Ref2: Destination 1, Destination 2'
+            };
+            checkOrWrite(baseStep, path.join(basePath, 'way_name_destination_refs'));
+            baseStep = {
+                maneuver: {
                     type: 'turn',
                     modifier: 'left'
                 },


### PR DESCRIPTION
The logic for selecting the first destination was too simplistic, failing to account for the `Ref: Destination` format in the `destination` property.

Fixes #135.

/cc @lyzidiamond