### PR TITLE
release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
-## master
+## 0.11.0 2017-12-13
 
 - Fixed inconsistent destinations when a ramp leads to multiple routes towards multiple places. [#197](https://github.com/Project-OSRM/osrm-text-instructions/pull/19y)
 - Removed left/right for off ramps unless it doesn't match driving side. [#199](https://github.com/Project-OSRM/osrm-text-instructions/pull/199)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file. For change 
 
 ## 0.11.0 2017-12-13
 
-- Fixed inconsistent destinations when a ramp leads to multiple routes towards multiple places. [#197](https://github.com/Project-OSRM/osrm-text-instructions/pull/19y)
+- Fixed inconsistent destinations when a ramp leads to multiple routes towards multiple places. [#197](https://github.com/Project-OSRM/osrm-text-instructions/pull/197)
 - Removed left/right for off ramps unless it doesn't match driving side. [#199](https://github.com/Project-OSRM/osrm-text-instructions/pull/199)
 
 ## 0.10.7 2017-12-05

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "OSRM Text Instructions",
   "url": "https://github.com/Project-OSRM/osrm-text-instructions.js",
   "homepage": "http://project-osrm.org",
-  "version": "0.10.7",
+  "version": "0.11.0",
   "main": "./index.js",
   "license": "BSD-2-Clause",
   "bugs": {


### PR DESCRIPTION
need a ✅ to get this out the door! @1ec5 

- Fixed inconsistent destinations when a ramp leads to multiple route……s towards multiple places. [#197](https://github.com/Project-OSRM/osrm-text-instructions/pull/197)

- Removed left/right for off ramps unless it doesn't match driving side. [#199](https://github.com/Project-OSRM/osrm-text-instructions/pull/199)