### PR TITLE
fix instructions to reflect that master is protected

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -108,10 +108,10 @@ To add an own translations:
 
 #### Release
 
-- `git checkout master`
 - Update CHANGELOG.md
 - Bump version in package.json
 - `git commit -a | "vx.y.z"` with Changelog list in commit message
 - `git tag vx.y.z -a` with Changelog list in tag message
-- `git push origin master; git push origin --tags`
+- `git push && git push --tags`
+- get a review and merge to master (master is a protected branch)
 - `npm publish`

--- a/Readme.md
+++ b/Readme.md
@@ -113,5 +113,5 @@ To add an own translations:
 - `git commit -a | "vx.y.z"` with Changelog list in commit message
 - `git tag vx.y.z -a` with Changelog list in tag message
 - `git push && git push --tags`
-- get a review and merge to master (master is a protected branch)
+- open a pull request, get a review, and merge to master (master is a protected branch)
 - `npm publish`


### PR DESCRIPTION
We instruct people to push to master, but master is protected and you can't push to it. This update reflects that change in the readme.

## Tasklist

 - [ ] Update readme
 - [ ] Review & merge

