### PR TITLE
Add Finnish translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
+## master
+
+- Added a Finnish localization. [#239](https://github.com/Project-OSRM/osrm-text-instructions/pull/239)
+
 ## 0.13.0 2018-04-11
 
 - Added a European Portuguese localization. [#229](https://github.com/Project-OSRM/osrm-text-instructions/pull/229)

--- a/languages.js
+++ b/languages.js
@@ -6,6 +6,7 @@ var instructionsEn = require('./languages/translations/en.json');
 var instructionsEo = require('./languages/translations/eo.json');
 var instructionsEs = require('./languages/translations/es.json');
 var instructionsEsEs = require('./languages/translations/es-ES.json');
+var instructionsFi = require('./languages/translations/fi.json');
 var instructionsFr = require('./languages/translations/fr.json');
 var instructionsHe = require('./languages/translations/he.json');
 var instructionsId = require('./languages/translations/id.json');
@@ -51,6 +52,7 @@ var instructions = {
     'eo': instructionsEo,
     'es': instructionsEs,
     'es-ES': instructionsEsEs,
+    'fi': instructionsFi,
     'fr': instructionsFr,
     'he': instructionsHe,
     'id': instructionsId,

--- a/languages/translations/fi.json
+++ b/languages/translations/fi.json
@@ -1,0 +1,493 @@
+{
+    "meta": {
+        "capitalizeFirstLetter": true
+    },
+    "v5": {
+        "constants": {
+            "ordinalize": {
+                "1": "1.",
+                "2": "2.",
+                "3": "3.",
+                "4": "4.",
+                "5": "5.",
+                "6": "6.",
+                "7": "7.",
+                "8": "8.",
+                "9": "9.",
+                "10": "10."
+            },
+            "direction": {
+                "north": "pohjoiseen",
+                "northeast": "koilliseen",
+                "east": "itään",
+                "southeast": "kaakkoon",
+                "south": "etelään",
+                "southwest": "lounaaseen",
+                "west": "länteen",
+                "northwest": "luoteeseen"
+            },
+            "modifier": {
+                "left": "vasemmall(e/a)",
+                "right": "oikeall(e/a)",
+                "sharp left": "jyrkästi vasempaan",
+                "sharp right": "jyrkästi oikeaan",
+                "slight left": "loivasti vasempaan",
+                "slight right": "loivasti oikeaan",
+                "straight": "suoraan eteenpäin",
+                "uturn": "U-käännös"
+            },
+            "lanes": {
+                "xo": "Pysy oikealla",
+                "ox": "Pysy vasemmalla",
+                "xox": "Pysy keskellä",
+                "oxo": "Pysy vasemmalla tai oikealla"
+            }
+        },
+        "modes": {
+            "ferry": {
+                "default": "Aja lautalle",
+                "name": "Aja lautalle {way_name}",
+                "destination": "Aja lautalle, jonka määränpää on {destination}"
+            }
+        },
+        "phrase": {
+            "two linked by distance": "{instruction_one}, sitten {distance} päästä, {instruction_two}",
+            "two linked": "{instruction_one}, sitten {instruction_two}",
+            "one in distance": "{distance} päästä, {instruction_one}",
+            "name and ref": "{name} ({ref})",
+            "exit with number": "{exit}"
+        },
+        "arrive": {
+            "default": {
+                "default": "Olet saapunut {nth} määränpäähäsi",
+                "upcoming": "Saavut {nth} määränpäähäsi",
+                "short": "Olet saapunut",
+                "short-upcoming": "Saavut",
+                "named": "Olet saapunut määränpäähän {waypoint_name}"
+            },
+            "left": {
+                "default": "Olet saapunut {nth} määränpäähäsi, joka on vasemmalla puolellasi",
+                "upcoming": "Saavut {nth} määränpäähäsi, joka on vasemmalla puolellasi",
+                "short": "Olet saapunut",
+                "short-upcoming": "Saavut",
+                "named": "Olet saapunut määränpäähän {waypoint_name}, joka on vasemmalla puolellasi"
+            },
+            "right": {
+                "default": "Olet saapunut {nth} määränpäähäsi, joka on oikealla puolellasi",
+                "upcoming": "Saavut {nth} määränpäähäsi, joka on oikealla puolellasi",
+                "short": "Olet saapunut",
+                "short-upcoming": "Saavut",
+                "named": "Olet saapunut määränpäähän {waypoint_name}, joka on oikealla puolellasi"
+            },
+            "sharp left": {
+                "default": "Olet saapunut {nth} määränpäähäsi, joka on vasemmalla puolellasi",
+                "upcoming": "Saavut {nth} määränpäähäsi, joka on vasemmalla puolellasi",
+                "short": "Olet saapunut",
+                "short-upcoming": "Saavut",
+                "named": "Olet saapunut määränpäähän {waypoint_name}, joka on vasemmalla puolellasi"
+            },
+            "sharp right": {
+                "default": "Olet saapunut {nth} määränpäähäsi, joka on oikealla puolellasi",
+                "upcoming": "Saavut {nth} määränpäähäsi, joka on oikealla puolellasi",
+                "short": "Olet saapunut",
+                "short-upcoming": "Saavut",
+                "named": "Olet saapunut määränpäähän {waypoint_name}, joka on oikealla puolellasi"
+            },
+            "slight right": {
+                "default": "Olet saapunut {nth} määränpäähäsi, joka on oikealla puolellasi",
+                "upcoming": "Saavut {nth} määränpäähäsi, joka on oikealla puolellasi",
+                "short": "Olet saapunut",
+                "short-upcoming": "Saavut",
+                "named": "Olet saapunut määränpäähän {waypoint_name}, joka on oikealla puolellasi"
+            },
+            "slight left": {
+                "default": "Olet saapunut {nth} määränpäähäsi, joka on vasemmalla puolellasi",
+                "upcoming": "Saavut {nth} määränpäähäsi, joka on vasemmalla puolellasi",
+                "short": "Olet saapunut",
+                "short-upcoming": "Saavut",
+                "named": "Olet saapunut määränpäähän {waypoint_name}, joka on vasemmalla puolellasi"
+            },
+            "straight": {
+                "default": "Olet saapunut {nth} määränpäähäsi, joka on suoraan edessäsi",
+                "upcoming": "Saavut {nth} määränpäähäsi, suoraan edessä",
+                "short": "Olet saapunut",
+                "short-upcoming": "Saavut",
+                "named": "Olet saapunut määränpäähän {waypoint_name}, joka on suoraan edessäsi"
+            }
+        },
+        "continue": {
+            "default": {
+                "default": "Käänny {modifier}",
+                "name": "Käänny {modifier} pysyäksesi tiellä {way_name}",
+                "destination": "Käänny {modifier} suuntana {destination}",
+                "exit": "Käänny {modifier} tielle {way_name}"
+            },
+            "straight": {
+                "default": "Jatka suoraan eteenpäin",
+                "name": "Jatka suoraan pysyäksesi tiellä {way_name}",
+                "destination": "Jatka suuntana {destination}",
+                "distance": "Jatka suoraan {distance}",
+                "namedistance": "Jatka tiellä {way_name} {distance}"
+            },
+            "sharp left": {
+                "default": "Jatka jyrkästi vasempaan",
+                "name": "Jatka jyrkästi vasempaan pysyäksesi tiellä {way_name}",
+                "destination": "Jatka jyrkästi vasempaan suuntana {destination}"
+            },
+            "sharp right": {
+                "default": "Jatka jyrkästi oikeaan",
+                "name": "Jatka jyrkästi oikeaan pysyäksesi tiellä {way_name}",
+                "destination": "Jatka jyrkästi oikeaan suuntana {destination}"
+            },
+            "slight left": {
+                "default": "Jatka loivasti vasempaan",
+                "name": "Jatka loivasti vasempaan pysyäksesi tiellä {way_name}",
+                "destination": "Jatka loivasti vasempaan suuntana {destination}"
+            },
+            "slight right": {
+                "default": "Jatka loivasti oikeaan",
+                "name": "Jatka loivasti oikeaan pysyäksesi tiellä {way_name}",
+                "destination": "Jatka loivasti oikeaan suuntana {destination}"
+            },
+            "uturn": {
+                "default": "Tee U-käännös",
+                "name": "Tee U-käännös ja jatka tietä {way_name}",
+                "destination": "Tee U-käännös suuntana {destination}"
+            }
+        },
+        "depart": {
+            "default": {
+                "default": "Aja {direction}",
+                "name": "Aja tietä {way_name} {direction}",
+                "namedistance": "Aja {distance} {direction} tietä {way_name} "
+            }
+        },
+        "end of road": {
+            "default": {
+                "default": "Käänny {modifier}",
+                "name": "Käänny {modifier} tielle {way_name}",
+                "destination": "Käänny {modifier} suuntana {destination}"
+            },
+            "straight": {
+                "default": "Jatka suoraan eteenpäin",
+                "name": "Jatka suoraan eteenpäin tielle {way_name}",
+                "destination": "Jatka suoraan eteenpäin suuntana {destination}"
+            },
+            "uturn": {
+                "default": "Tien päässä tee U-käännös",
+                "name": "Tien päässä tee U-käännös tielle {way_name}",
+                "destination": "Tien päässä tee U-käännös suuntana {destination}"
+            }
+        },
+        "fork": {
+            "default": {
+                "default": "Jatka tienhaarassa {modifier}",
+                "name": "Jatka {modifier} tielle {way_name}",
+                "destination": "Jatka {modifier} suuntana {destination}"
+            },
+            "slight left": {
+                "default": "Pysy vasemmalla tienhaarassa",
+                "name": "Pysy vasemmalla tielle {way_name}",
+                "destination": "Pysy vasemmalla suuntana {destination}"
+            },
+            "slight right": {
+                "default": "Pysy oikealla tienhaarassa",
+                "name": "Pysy oikealla tielle {way_name}",
+                "destination": "Pysy oikealla suuntana {destination}"
+            },
+            "sharp left": {
+                "default": "Käänny tienhaarassa jyrkästi vasempaan",
+                "name": "Käänny tienhaarassa jyrkästi vasempaan tielle {way_name}",
+                "destination": "Käänny tienhaarassa jyrkästi vasempaan suuntana {destination}"
+            },
+            "sharp right": {
+                "default": "Käänny tienhaarassa jyrkästi oikeaan",
+                "name": "Käänny tienhaarassa jyrkästi oikeaan tielle {way_name}",
+                "destination": "Käänny tienhaarassa jyrkästi oikeaan suuntana {destination}"
+            },
+            "uturn": {
+                "default": "Tee U-käännös",
+                "name": "Tee U-käännös tielle {way_name}",
+                "destination": "Tee U-käännös suuntana {destination}"
+            }
+        },
+        "merge": {
+            "default": {
+                "default": "Liity {modifier}",
+                "name": "Liity {modifier}, tielle {way_name}",
+                "destination": "Liity {modifier}, suuntana {destination}"
+            },
+            "straight": {
+                "default": "Liity",
+                "name": "Liity tielle {way_name}",
+                "destination": "Liity suuntana {destination}"
+            },
+            "slight left": {
+                "default": "Liity vasemmalle",
+                "name": "Liity vasemmalle, tielle {way_name}",
+                "destination": "Liity vasemmalle, suuntana {destination}"
+            },
+            "slight right": {
+                "default": "Liity oikealle",
+                "name": "Liity oikealle, tielle {way_name}",
+                "destination": "Liity oikealle, suuntana {destination}"
+            },
+            "sharp left": {
+                "default": "Liity vasemmalle",
+                "name": "Liity vasemmalle, tielle {way_name}",
+                "destination": "Liity vasemmalle, suuntana {destination}"
+            },
+            "sharp right": {
+                "default": "Liity oikealle",
+                "name": "Liity oikealle, tielle {way_name}",
+                "destination": "Liity oikealle, suuntana {destination}"
+            },
+            "uturn": {
+                "default": "Tee U-käännös",
+                "name": "Tee U-käännös tielle {way_name}",
+                "destination": "Tee U-käännös suuntana {destination}"
+            }
+        },
+        "new name": {
+            "default": {
+                "default": "Jatka {modifier}",
+                "name": "Jatka {modifier} tielle {way_name}",
+                "destination": "Jatka {modifier} suuntana {destination}"
+            },
+            "straight": {
+                "default": "Jatka suoraan eteenpäin",
+                "name": "Jatka tielle {way_name}",
+                "destination": "Jatka suuntana {destination}"
+            },
+            "sharp left": {
+                "default": "Käänny jyrkästi vasempaan",
+                "name": "Käänny jyrkästi vasempaan tielle {way_name}",
+                "destination": "Käänny jyrkästi vasempaan suuntana {destination}"
+            },
+            "sharp right": {
+                "default": "Käänny jyrkästi oikeaan",
+                "name": "Käänny jyrkästi oikeaan tielle {way_name}",
+                "destination": "Käänny jyrkästi oikeaan suuntana {destination}"
+            },
+            "slight left": {
+                "default": "Jatka loivasti vasempaan",
+                "name": "Jatka loivasti vasempaan tielle {way_name}",
+                "destination": "Jatka loivasti vasempaan suuntana {destination}"
+            },
+            "slight right": {
+                "default": "Jatka loivasti oikeaan",
+                "name": "Jatka loivasti oikeaan tielle {way_name}",
+                "destination": "Jatka loivasti oikeaan suuntana {destination}"
+            },
+            "uturn": {
+                "default": "Tee U-käännös",
+                "name": "Tee U-käännös tielle {way_name}",
+                "destination": "Tee U-käännös suuntana {destination}"
+            }
+        },
+        "notification": {
+            "default": {
+                "default": "Jatka {modifier}",
+                "name": "Jatka {modifier} tielle {way_name}",
+                "destination": "Jatka {modifier} suuntana {destination}"
+            },
+            "uturn": {
+                "default": "Tee U-käännös",
+                "name": "Tee U-käännös tielle {way_name}",
+                "destination": "Tee U-käännös suuntana {destination}"
+            }
+        },
+        "off ramp": {
+            "default": {
+                "default": "Aja erkanemiskaistalle",
+                "name": "Aja erkanemiskaistaa tielle {way_name}",
+                "destination": "Aja erkanemiskaistalle suuntana {destination}",
+                "exit": "Ota poistuminen {exit}",
+                "exit_destination": "Ota poistuminen {exit}, suuntana {destination}"
+            },
+            "left": {
+                "default": "Aja vasemmalla olevalle erkanemiskaistalle",
+                "name": "Aja vasemmalla olevaa erkanemiskaistaa tielle {way_name}",
+                "destination": "Aja vasemmalla olevalle erkanemiskaistalle suuntana {destination}",
+                "exit": "Ota poistuminen {exit} vasemmalla",
+                "exit_destination": "Ota poistuminen {exit} vasemmalla, suuntana {destination}"
+            },
+            "right": {
+                "default": "Aja oikealla olevalle erkanemiskaistalle",
+                "name": "Aja oikealla olevaa erkanemiskaistaa tielle {way_name}",
+                "destination": "Aja oikealla olevalle erkanemiskaistalle suuntana {destination}",
+                "exit": "Ota poistuminen {exit} oikealla",
+                "exit_destination": "Ota poistuminen {exit} oikealla, suuntana {destination}"
+            },
+            "sharp left": {
+                "default": "Aja vasemmalla olevalle erkanemiskaistalle",
+                "name": "Aja vasemmalla olevaa erkanemiskaistaa tielle {way_name}",
+                "destination": "Aja vasemmalla olevalle erkanemiskaistalle suuntana {destination}",
+                "exit": "Ota poistuminen {exit} vasemmalla",
+                "exit_destination": "Ota poistuminen {exit} vasemmalla, suuntana {destination}"
+            },
+            "sharp right": {
+                "default": "Aja oikealla olevalle erkanemiskaistalle",
+                "name": "Aja oikealla olevaa erkanemiskaistaa tielle {way_name}",
+                "destination": "Aja oikealla olevalle erkanemiskaistalle suuntana {destination}",
+                "exit": "Ota poistuminen {exit} oikealla",
+                "exit_destination": "Ota poistuminen {exit} oikealla, suuntana {destination}"
+            },
+            "slight left": {
+                "default": "Aja vasemmalla olevalle erkanemiskaistalle",
+                "name": "Aja vasemmalla olevaa erkanemiskaistaa tielle {way_name}",
+                "destination": "Aja vasemmalla olevalle erkanemiskaistalle suuntana {destination}",
+                "exit": "Ota poistuminen {exit} vasemmalla",
+                "exit_destination": "Ota poistuminen {exit} vasemmalla, suuntana {destination}"
+            },
+            "slight right": {
+                "default": "Aja oikealla olevalle erkanemiskaistalle",
+                "name": "Aja oikealla olevaa erkanemiskaistaa tielle {way_name}",
+                "destination": "Aja oikealla olevalle erkanemiskaistalle suuntana {destination}",
+                "exit": "Ota poistuminen {exit} oikealla",
+                "exit_destination": "Ota poistuminen {exit} oikealla, suuntana {destination}"
+            }
+        },
+        "on ramp": {
+            "default": {
+                "default": "Aja erkanemiskaistalle",
+                "name": "Aja erkanemiskaistaa tielle {way_name}",
+                "destination": "Aja erkanemiskaistalle suuntana {destination}"
+            },
+            "left": {
+                "default": "Aja vasemmalla olevalle erkanemiskaistalle",
+                "name": "Aja vasemmalla olevaa erkanemiskaistaa tielle {way_name}",
+                "destination": "Aja vasemmalla olevalle erkanemiskaistalle suuntana {destination}"
+            },
+            "right": {
+                "default": "Aja oikealla olevalle erkanemiskaistalle",
+                "name": "Aja oikealla olevaa erkanemiskaistaa tielle {way_name}",
+                "destination": "Aja oikealla olevalle erkanemiskaistalle suuntana {destination}"
+            },
+            "sharp left": {
+                "default": "Aja vasemmalla olevalle erkanemiskaistalle",
+                "name": "Aja vasemmalla olevaa erkanemiskaistaa tielle {way_name}",
+                "destination": "Aja vasemmalla olevalle erkanemiskaistalle suuntana {destination}"
+            },
+            "sharp right": {
+                "default": "Aja oikealla olevalle erkanemiskaistalle",
+                "name": "Aja oikealla olevaa erkanemiskaistaa tielle {way_name}",
+                "destination": "Aja oikealla olevalle erkanemiskaistalle suuntana {destination}"
+            },
+            "slight left": {
+                "default": "Aja vasemmalla olevalle erkanemiskaistalle",
+                "name": "Aja vasemmalla olevaa erkanemiskaistaa tielle {way_name}",
+                "destination": "Aja vasemmalla olevalle erkanemiskaistalle suuntana {destination}"
+            },
+            "slight right": {
+                "default": "Aja oikealla olevalle erkanemiskaistalle",
+                "name": "Aja oikealla olevaa erkanemiskaistaa tielle {way_name}",
+                "destination": "Aja oikealla olevalle erkanemiskaistalle suuntana {destination}"
+            }
+        },
+        "rotary": {
+            "default": {
+                "default": {
+                    "default": "Aja liikenneympyrään",
+                    "name": "Aja liikenneympyrään ja valitse erkanemiskaista tielle {way_name}",
+                    "destination": "Aja liikenneympyrään ja valitse erkanemiskaista suuntana {destination}"
+                },
+                "name": {
+                    "default": "Aja liikenneympyrään {rotary_name}",
+                    "name": "Aja liikenneympyrään {rotary_name} ja valitse erkanemiskaista tielle {way_name}",
+                    "destination": "Aja liikenneympyrään {rotary_name} ja valitse erkanemiskaista suuntana {destination}"
+                },
+                "exit": {
+                    "default": "Aja liikenneympyrään ja valitse {exit_number} erkanemiskaista",
+                    "name": "Aja liikenneympyrään ja valitse {exit_number} erkanemiskaista tielle {way_name}",
+                    "destination": "Aja liikenneympyrään ja valitse {exit_number} erkanemiskaista suuntana {destination}"
+                },
+                "name_exit": {
+                    "default": "Aja liikenneympyrään {rotary_name} ja valitse {exit_number} erkanemiskaista",
+                    "name": "Aja liikenneympyrään {rotary_name} ja valitse {exit_number} erkanemiskaista tielle {way_name}",
+                    "destination": "Aja liikenneympyrään {rotary_name} ja valitse {exit_number} erkanemiskaista suuntana {destination}"
+                }
+            }
+        },
+        "roundabout": {
+            "default": {
+                "exit": {
+                    "default": "Aja liikenneympyrään ja valitse {exit_number} erkanemiskaista",
+                    "name": "Aja liikenneympyrään ja valitse {exit_number} erkanemiskaista tielle {way_name}",
+                    "destination": "Aja liikenneympyrään ja valitse {exit_number} erkanemiskaista suuntana {destination}"
+                },
+                "default": {
+                    "default": "Aja liikenneympyrään",
+                    "name": "Aja liikenneympyrään ja valitse erkanemiskaista tielle {way_name}",
+                    "destination": "Aja liikenneympyrään ja valitse erkanemiskaista suuntana {destination}"
+                }
+            }
+        },
+        "roundabout turn": {
+            "default": {
+                "default": "Käänny {modifier}",
+                "name": "Käänny {modifier} tielle {way_name}",
+                "destination": "Käänny {modifier} suuntana {destination}"
+            },
+            "left": {
+                "default": "Käänny vasempaan",
+                "name": "Käänny vasempaan tielle {way_name}",
+                "destination": "Käänny vasempaan suuntana {destination}"
+            },
+            "right": {
+                "default": "Käänny oikeaan",
+                "name": "Käänny oikeaan tielle {way_name}",
+                "destination": "Käänny oikeaan suuntana {destination}"
+            },
+            "straight": {
+                "default": "Jatka suoraan eteenpäin",
+                "name": "Jatka suoraan eteenpäin tielle {way_name}",
+                "destination": "Jatka suoraan eteenpäin suuntana {destination}"
+            }
+        },
+        "exit roundabout": {
+            "default": {
+                "default": "Poistu liikenneympyrästä",
+                "name": "Poistu liikenneympyrästä tielle {way_name}",
+                "destination": "Poistu liikenneympyrästä suuntana {destination}"
+            }
+        },
+        "exit rotary": {
+            "default": {
+                "default": "Poistu liikenneympyrästä",
+                "name": "Poistu liikenneympyrästä tielle {way_name}",
+                "destination": "Poistu liikenneympyrästä suuntana {destination}"
+            }
+        },
+        "turn": {
+            "default": {
+                "default": "Käänny {modifier}",
+                "name": "Käänny {modifier} tielle {way_name}",
+                "destination": "Käänny {modifier} suuntana {destination}"
+            },
+            "left": {
+                "default": "Käänny vasempaan",
+                "name": "Käänny vasempaan tielle {way_name}",
+                "destination": "Käänny vasempaan suuntana {destination}"
+            },
+            "right": {
+                "default": "Käänny oikeaan",
+                "name": "Käänny oikeaan tielle {way_name}",
+                "destination": "Käänny oikeaan suuntana {destination}"
+            },
+            "straight": {
+                "default": "Aja suoraan eteenpäin",
+                "name": "Aja suoraan eteenpäin tielle {way_name}",
+                "destination": "Aja suoraan eteenpäin suuntana {destination}"
+            }
+        },
+        "use lane": {
+            "no_lanes": {
+                "default": "Jatka suoraan eteenpäin"
+            },
+            "default": {
+                "default": "{lane_instruction}"
+            }
+        }
+    }
+}

--- a/test/fixtures/v5/arrive/left.json
+++ b/test/fixtures/v5/arrive/left.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian celon ĉe maldekstre",
         "es": "Has llegado a tu destino, a la izquierda",
         "es-ES": "Has llegado a tu destino, a la izquierda",
+        "fi": "Olet saapunut määränpäähäsi, joka on vasemmalla puolellasi",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "he": "הגעת אל היעד ה שלך משמאלך",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kiri",

--- a/test/fixtures/v5/arrive/no_modifier.json
+++ b/test/fixtures/v5/arrive/no_modifier.json
@@ -12,6 +12,7 @@
         "eo": "Vi atingis vian celon",
         "es": "Has llegado a tu destino",
         "es-ES": "Has llegado a tu destino",
+        "fi": "Olet saapunut määränpäähäsi",
         "fr": "Vous êtes arrivés à votre destination",
         "he": "הגעת אל היעד ה שלך",
         "id": "Anda telah tiba di tujuan ke-",

--- a/test/fixtures/v5/arrive/right.json
+++ b/test/fixtures/v5/arrive/right.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian celon ĉe dekstre",
         "es": "Has llegado a tu destino, a la derecha",
         "es-ES": "Has llegado a tu destino, a la derecha",
+        "fi": "Olet saapunut määränpäähäsi, joka on oikealla puolellasi",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "he": "הגעת אל היעד ה שלך מימינך",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kanan",

--- a/test/fixtures/v5/arrive/sharp_left.json
+++ b/test/fixtures/v5/arrive/sharp_left.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian celon ĉe maldekstre",
         "es": "Has llegado a tu destino, a la izquierda",
         "es-ES": "Has llegado a tu destino, a la izquierda",
+        "fi": "Olet saapunut määränpäähäsi, joka on vasemmalla puolellasi",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "he": "הגעת אל היעד ה שלך משמאלך",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kiri",

--- a/test/fixtures/v5/arrive/sharp_right.json
+++ b/test/fixtures/v5/arrive/sharp_right.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian celon ĉe dekstre",
         "es": "Has llegado a tu destino, a la derecha",
         "es-ES": "Has llegado a tu destino, a la derecha",
+        "fi": "Olet saapunut määränpäähäsi, joka on oikealla puolellasi",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "he": "הגעת אל היעד ה שלך מימינך",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kanan",

--- a/test/fixtures/v5/arrive/slight_left.json
+++ b/test/fixtures/v5/arrive/slight_left.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian celon ĉe maldekstre",
         "es": "Has llegado a tu destino, a la izquierda",
         "es-ES": "Has llegado a tu destino, a la izquierda",
+        "fi": "Olet saapunut määränpäähäsi, joka on vasemmalla puolellasi",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "he": "הגעת אל היעד ה שלך משמאלך",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kiri",

--- a/test/fixtures/v5/arrive/slight_right.json
+++ b/test/fixtures/v5/arrive/slight_right.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian celon ĉe dekstre",
         "es": "Has llegado a tu destino, a la derecha",
         "es-ES": "Has llegado a tu destino, a la derecha",
+        "fi": "Olet saapunut määränpäähäsi, joka on oikealla puolellasi",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "he": "הגעת אל היעד ה שלך מימינך",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kanan",

--- a/test/fixtures/v5/arrive/straight.json
+++ b/test/fixtures/v5/arrive/straight.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian celon",
         "es": "Has llegado a tu destino, en frente",
         "es-ES": "Has llegado a tu destino, en frente",
+        "fi": "Olet saapunut määränpäähäsi, joka on suoraan edessäsi",
         "fr": "Vous êtes arrivés à votre destination, droit devant",
         "he": "הגעת אל היעד ה שלך, בהמשך",
         "id": "Anda telah tiba di tujuan ke-, lurus saja",

--- a/test/fixtures/v5/arrive/uturn.json
+++ b/test/fixtures/v5/arrive/uturn.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian celon",
         "es": "Has llegado a tu destino",
         "es-ES": "Has llegado a tu destino",
+        "fi": "Olet saapunut määränpäähäsi",
         "fr": "Vous êtes arrivés à votre destination",
         "he": "הגעת אל היעד ה שלך",
         "id": "Anda telah tiba di tujuan ke-",

--- a/test/fixtures/v5/arrive_short/left.json
+++ b/test/fixtures/v5/arrive_short/left.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingis",
         "es": "Has llegado",
         "es-ES": "Has llegado",
+        "fi": "Olet saapunut",
         "fr": "Vous êtes arrivés",
         "he": "הגעת",
         "id": "Anda telah tiba di tujuan ke-{nth}",

--- a/test/fixtures/v5/arrive_short/no_modifier.json
+++ b/test/fixtures/v5/arrive_short/no_modifier.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingis",
         "es": "Has llegado",
         "es-ES": "Has llegado",
+        "fi": "Olet saapunut",
         "fr": "Vous êtes arrivés",
         "he": "הגעת",
         "id": "Anda telah tiba di tujuan ke-{nth}",

--- a/test/fixtures/v5/arrive_short/right.json
+++ b/test/fixtures/v5/arrive_short/right.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingis",
         "es": "Has llegado",
         "es-ES": "Has llegado",
+        "fi": "Olet saapunut",
         "fr": "Vous êtes arrivés",
         "he": "הגעת",
         "id": "Anda telah tiba di tujuan ke-{nth}",

--- a/test/fixtures/v5/arrive_short/sharp left.json
+++ b/test/fixtures/v5/arrive_short/sharp left.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingis",
         "es": "Has llegado",
         "es-ES": "Has llegado",
+        "fi": "Olet saapunut",
         "fr": "Vous êtes arrivés",
         "he": "הגעת",
         "id": "Anda telah tiba di tujuan ke-{nth}",

--- a/test/fixtures/v5/arrive_short/sharp right.json
+++ b/test/fixtures/v5/arrive_short/sharp right.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingis",
         "es": "Has llegado",
         "es-ES": "Has llegado",
+        "fi": "Olet saapunut",
         "fr": "Vous êtes arrivés",
         "he": "הגעת",
         "id": "Anda telah tiba di tujuan ke-{nth}",

--- a/test/fixtures/v5/arrive_short/slight left.json
+++ b/test/fixtures/v5/arrive_short/slight left.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingis",
         "es": "Has llegado",
         "es-ES": "Has llegado",
+        "fi": "Olet saapunut",
         "fr": "Vous êtes arrivés",
         "he": "הגעת",
         "id": "Anda telah tiba di tujuan ke-{nth}",

--- a/test/fixtures/v5/arrive_short/slight right.json
+++ b/test/fixtures/v5/arrive_short/slight right.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingis",
         "es": "Has llegado",
         "es-ES": "Has llegado",
+        "fi": "Olet saapunut",
         "fr": "Vous êtes arrivés",
         "he": "הגעת",
         "id": "Anda telah tiba di tujuan ke-{nth}",

--- a/test/fixtures/v5/arrive_short/straight.json
+++ b/test/fixtures/v5/arrive_short/straight.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingis",
         "es": "Has llegado",
         "es-ES": "Has llegado",
+        "fi": "Olet saapunut",
         "fr": "Vous êtes arrivés",
         "he": "הגעת",
         "id": "Anda telah tiba di tujuan ke-{nth}",

--- a/test/fixtures/v5/arrive_short_upcoming/left.json
+++ b/test/fixtures/v5/arrive_short_upcoming/left.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingos",
         "es": "Vas a llegar",
         "es-ES": "Vas a llegar",
+        "fi": "Saavut",
         "fr": "Vous arriverez",
         "he": "תגיע",
         "id": "Anda telah tiba di tujuan ke-{nth}",

--- a/test/fixtures/v5/arrive_short_upcoming/no_modifier.json
+++ b/test/fixtures/v5/arrive_short_upcoming/no_modifier.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingos",
         "es": "Vas a llegar",
         "es-ES": "Vas a llegar",
+        "fi": "Saavut",
         "fr": "Vous arriverez",
         "he": "תגיע",
         "id": "Anda telah tiba di tujuan ke-{nth}",

--- a/test/fixtures/v5/arrive_short_upcoming/right.json
+++ b/test/fixtures/v5/arrive_short_upcoming/right.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingos",
         "es": "Vas a llegar",
         "es-ES": "Vas a llegar",
+        "fi": "Saavut",
         "fr": "Vous arriverez",
         "he": "תגיע",
         "id": "Anda telah tiba di tujuan ke-{nth}",

--- a/test/fixtures/v5/arrive_short_upcoming/sharp left.json
+++ b/test/fixtures/v5/arrive_short_upcoming/sharp left.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingos",
         "es": "Vas a llegar",
         "es-ES": "Vas a llegar",
+        "fi": "Saavut",
         "fr": "Vous arriverez",
         "he": "תגיע",
         "id": "Anda telah tiba di tujuan ke-{nth}",

--- a/test/fixtures/v5/arrive_short_upcoming/sharp right.json
+++ b/test/fixtures/v5/arrive_short_upcoming/sharp right.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingos",
         "es": "Vas a llegar",
         "es-ES": "Vas a llegar",
+        "fi": "Saavut",
         "fr": "Vous arriverez",
         "he": "תגיע",
         "id": "Anda telah tiba di tujuan ke-{nth}",

--- a/test/fixtures/v5/arrive_short_upcoming/slight left.json
+++ b/test/fixtures/v5/arrive_short_upcoming/slight left.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingos",
         "es": "Vas a llegar",
         "es-ES": "Vas a llegar",
+        "fi": "Saavut",
         "fr": "Vous arriverez",
         "he": "תגיע",
         "id": "Anda telah tiba di tujuan ke-{nth}",

--- a/test/fixtures/v5/arrive_short_upcoming/slight right.json
+++ b/test/fixtures/v5/arrive_short_upcoming/slight right.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingos",
         "es": "Vas a llegar",
         "es-ES": "Vas a llegar",
+        "fi": "Saavut",
         "fr": "Vous arriverez",
         "he": "תגיע",
         "id": "Anda telah tiba di tujuan ke-{nth}",

--- a/test/fixtures/v5/arrive_short_upcoming/straight.json
+++ b/test/fixtures/v5/arrive_short_upcoming/straight.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingos",
         "es": "Vas a llegar",
         "es-ES": "Vas a llegar",
+        "fi": "Saavut",
         "fr": "Vous arriverez",
         "he": "תגיע",
         "id": "Anda telah tiba di tujuan ke-{nth}",

--- a/test/fixtures/v5/arrive_upcoming/left.json
+++ b/test/fixtures/v5/arrive_upcoming/left.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingos vian {nth} celon ĉe maldekstre",
         "es": "Vas a llegar a tu {nth} destino, a la izquierda",
         "es-ES": "Vas a llegar a tu {nth} destino, a la izquierda",
+        "fi": "Saavut {nth} määränpäähäsi, joka on vasemmalla puolellasi",
         "fr": "Vous arriverez à votre {nth} destination, sur la gauche",
         "he": "אתה תגיע אל היעד ה{nth} שלך משמאלך",
         "id": "Anda telah tiba di tujuan ke-{nth}, di sebelah kiri",

--- a/test/fixtures/v5/arrive_upcoming/no_modifier.json
+++ b/test/fixtures/v5/arrive_upcoming/no_modifier.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingos vian {nth} celon",
         "es": "Vas a llegar a tu {nth} destino",
         "es-ES": "Vas a llegar a tu {nth} destino",
+        "fi": "Saavut {nth} määränpäähäsi",
         "fr": "Vous arriverez à votre {nth} destination",
         "he": "אתה תגיע אל היעד ה{nth} שלך",
         "id": "Anda telah tiba di tujuan ke-{nth}",

--- a/test/fixtures/v5/arrive_upcoming/right.json
+++ b/test/fixtures/v5/arrive_upcoming/right.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingos vian {nth} celon ĉe dekstre",
         "es": "Vas a llegar a tu {nth} destino, a la derecha",
         "es-ES": "Vas a llegar a tu {nth} destino, a la derecha",
+        "fi": "Saavut {nth} määränpäähäsi, joka on oikealla puolellasi",
         "fr": "Vous arriverez à votre {nth} destination, sur la droite",
         "he": "אתה תגיע אל היעד ה{nth} שלך מימינך",
         "id": "Anda telah tiba di tujuan ke-{nth}, di sebelah kanan",

--- a/test/fixtures/v5/arrive_upcoming/sharp left.json
+++ b/test/fixtures/v5/arrive_upcoming/sharp left.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingos vian {nth} celon ĉe maldekstre",
         "es": "Vas a llegar a tu {nth} destino, a la izquierda",
         "es-ES": "Vas a llegar a tu {nth} destino, a la izquierda",
+        "fi": "Saavut {nth} määränpäähäsi, joka on vasemmalla puolellasi",
         "fr": "Vous arriverez à votre {nth} destination, sur la gauche",
         "he": "אתה תגיע אל היעד ה{nth} שלך משמאלך",
         "id": "Anda telah tiba di tujuan ke-{nth}, di sebelah kiri",

--- a/test/fixtures/v5/arrive_upcoming/sharp right.json
+++ b/test/fixtures/v5/arrive_upcoming/sharp right.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingos vian {nth} celon ĉe dekstre",
         "es": "Vas a llegar a tu {nth} destino, a la derecha",
         "es-ES": "Vas a llegar a tu {nth} destino, a la derecha",
+        "fi": "Saavut {nth} määränpäähäsi, joka on oikealla puolellasi",
         "fr": "Vous arriverez à votre {nth} destination, sur la droite",
         "he": "אתה תגיע אל היעד ה{nth} שלך מימינך",
         "id": "Anda telah tiba di tujuan ke-{nth}, di sebelah kanan",

--- a/test/fixtures/v5/arrive_upcoming/slight left.json
+++ b/test/fixtures/v5/arrive_upcoming/slight left.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingos vian {nth} celon ĉe maldekstre",
         "es": "Vas a llegar a tu {nth} destino, a la izquierda",
         "es-ES": "Vas a llegar a tu {nth} destino, a la izquierda",
+        "fi": "Saavut {nth} määränpäähäsi, joka on vasemmalla puolellasi",
         "fr": "Vous arriverez à votre {nth} destination, sur la gauche",
         "he": "אתה תגיע אל היעד ה{nth} שלך משמאלך",
         "id": "Anda telah tiba di tujuan ke-{nth}, di sebelah kiri",

--- a/test/fixtures/v5/arrive_upcoming/slight right.json
+++ b/test/fixtures/v5/arrive_upcoming/slight right.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingos vian {nth} celon ĉe dekstre",
         "es": "Vas a llegar a tu {nth} destino, a la derecha",
         "es-ES": "Vas a llegar a tu {nth} destino, a la derecha",
+        "fi": "Saavut {nth} määränpäähäsi, joka on oikealla puolellasi",
         "fr": "Vous arriverez à votre {nth} destination, sur la droite",
         "he": "אתה תגיע אל היעד ה{nth} שלך מימינך",
         "id": "Anda telah tiba di tujuan ke-{nth}, di sebelah kanan",

--- a/test/fixtures/v5/arrive_upcoming/straight.json
+++ b/test/fixtures/v5/arrive_upcoming/straight.json
@@ -6,6 +6,7 @@
         "eo": "Vi atingos vian {nth} celon rekte",
         "es": "Vas a llegar a tu {nth} destino, en frente",
         "es-ES": "Vas a llegar a tu {nth} destino, en frente",
+        "fi": "Saavut {nth} määränpäähäsi, suoraan edessä",
         "fr": "Vous arriverez à votre {nth} destination, droit devant",
         "he": "אתה תגיע אל היעד ה{nth} שלך, בהמשך",
         "id": "Anda telah tiba di tujuan ke-{nth}, lurus saja",

--- a/test/fixtures/v5/arrive_waypoint/left.json
+++ b/test/fixtures/v5/arrive_waypoint/left.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian 1. celon ĉe maldekstre",
         "es": "Has llegado a tu 1ª destino, a la izquierda",
         "es-ES": "Has llegado a tu 1ª destino, a la izquierda",
+        "fi": "Olet saapunut 1. määränpäähäsi, joka on vasemmalla puolellasi",
         "fr": "Vous êtes arrivés à votre première destination, sur la gauche",
         "he": "הגעת אל היעד הראשונה שלך משמאלך",
         "id": "Anda telah tiba di tujuan ke-1, di sebelah kiri",

--- a/test/fixtures/v5/arrive_waypoint/no_modifier.json
+++ b/test/fixtures/v5/arrive_waypoint/no_modifier.json
@@ -12,6 +12,7 @@
         "eo": "Vi atingis vian 1. celon",
         "es": "Has llegado a tu 1ª destino",
         "es-ES": "Has llegado a tu 1ª destino",
+        "fi": "Olet saapunut 1. määränpäähäsi",
         "fr": "Vous êtes arrivés à votre première destination",
         "he": "הגעת אל היעד הראשונה שלך",
         "id": "Anda telah tiba di tujuan ke-1",

--- a/test/fixtures/v5/arrive_waypoint/right.json
+++ b/test/fixtures/v5/arrive_waypoint/right.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian 1. celon ĉe dekstre",
         "es": "Has llegado a tu 1ª destino, a la derecha",
         "es-ES": "Has llegado a tu 1ª destino, a la derecha",
+        "fi": "Olet saapunut 1. määränpäähäsi, joka on oikealla puolellasi",
         "fr": "Vous êtes arrivés à votre première destination, sur la droite",
         "he": "הגעת אל היעד הראשונה שלך מימינך",
         "id": "Anda telah tiba di tujuan ke-1, di sebelah kanan",

--- a/test/fixtures/v5/arrive_waypoint/sharp_left.json
+++ b/test/fixtures/v5/arrive_waypoint/sharp_left.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian 1. celon ĉe maldekstre",
         "es": "Has llegado a tu 1ª destino, a la izquierda",
         "es-ES": "Has llegado a tu 1ª destino, a la izquierda",
+        "fi": "Olet saapunut 1. määränpäähäsi, joka on vasemmalla puolellasi",
         "fr": "Vous êtes arrivés à votre première destination, sur la gauche",
         "he": "הגעת אל היעד הראשונה שלך משמאלך",
         "id": "Anda telah tiba di tujuan ke-1, di sebelah kiri",

--- a/test/fixtures/v5/arrive_waypoint/sharp_right.json
+++ b/test/fixtures/v5/arrive_waypoint/sharp_right.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian 1. celon ĉe dekstre",
         "es": "Has llegado a tu 1ª destino, a la derecha",
         "es-ES": "Has llegado a tu 1ª destino, a la derecha",
+        "fi": "Olet saapunut 1. määränpäähäsi, joka on oikealla puolellasi",
         "fr": "Vous êtes arrivés à votre première destination, sur la droite",
         "he": "הגעת אל היעד הראשונה שלך מימינך",
         "id": "Anda telah tiba di tujuan ke-1, di sebelah kanan",

--- a/test/fixtures/v5/arrive_waypoint/slight_left.json
+++ b/test/fixtures/v5/arrive_waypoint/slight_left.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian 1. celon ĉe maldekstre",
         "es": "Has llegado a tu 1ª destino, a la izquierda",
         "es-ES": "Has llegado a tu 1ª destino, a la izquierda",
+        "fi": "Olet saapunut 1. määränpäähäsi, joka on vasemmalla puolellasi",
         "fr": "Vous êtes arrivés à votre première destination, sur la gauche",
         "he": "הגעת אל היעד הראשונה שלך משמאלך",
         "id": "Anda telah tiba di tujuan ke-1, di sebelah kiri",

--- a/test/fixtures/v5/arrive_waypoint/slight_right.json
+++ b/test/fixtures/v5/arrive_waypoint/slight_right.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian 1. celon ĉe dekstre",
         "es": "Has llegado a tu 1ª destino, a la derecha",
         "es-ES": "Has llegado a tu 1ª destino, a la derecha",
+        "fi": "Olet saapunut 1. määränpäähäsi, joka on oikealla puolellasi",
         "fr": "Vous êtes arrivés à votre première destination, sur la droite",
         "he": "הגעת אל היעד הראשונה שלך מימינך",
         "id": "Anda telah tiba di tujuan ke-1, di sebelah kanan",

--- a/test/fixtures/v5/arrive_waypoint/straight.json
+++ b/test/fixtures/v5/arrive_waypoint/straight.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian 1. celon",
         "es": "Has llegado a tu 1ª destino, en frente",
         "es-ES": "Has llegado a tu 1ª destino, en frente",
+        "fi": "Olet saapunut 1. määränpäähäsi, joka on suoraan edessäsi",
         "fr": "Vous êtes arrivés à votre première destination, droit devant",
         "he": "הגעת אל היעד הראשונה שלך, בהמשך",
         "id": "Anda telah tiba di tujuan ke-1, lurus saja",

--- a/test/fixtures/v5/arrive_waypoint/uturn.json
+++ b/test/fixtures/v5/arrive_waypoint/uturn.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian 1. celon",
         "es": "Has llegado a tu 1ª destino",
         "es-ES": "Has llegado a tu 1ª destino",
+        "fi": "Olet saapunut 1. määränpäähäsi",
         "fr": "Vous êtes arrivés à votre première destination",
         "he": "הגעת אל היעד הראשונה שלך",
         "id": "Anda telah tiba di tujuan ke-1",

--- a/test/fixtures/v5/arrive_waypoint_last/left.json
+++ b/test/fixtures/v5/arrive_waypoint_last/left.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian celon ĉe maldekstre",
         "es": "Has llegado a tu destino, a la izquierda",
         "es-ES": "Has llegado a tu destino, a la izquierda",
+        "fi": "Olet saapunut määränpäähäsi, joka on vasemmalla puolellasi",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "he": "הגעת אל היעד ה שלך משמאלך",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kiri",

--- a/test/fixtures/v5/arrive_waypoint_last/no_modifier.json
+++ b/test/fixtures/v5/arrive_waypoint_last/no_modifier.json
@@ -12,6 +12,7 @@
         "eo": "Vi atingis vian celon",
         "es": "Has llegado a tu destino",
         "es-ES": "Has llegado a tu destino",
+        "fi": "Olet saapunut määränpäähäsi",
         "fr": "Vous êtes arrivés à votre destination",
         "he": "הגעת אל היעד ה שלך",
         "id": "Anda telah tiba di tujuan ke-",

--- a/test/fixtures/v5/arrive_waypoint_last/right.json
+++ b/test/fixtures/v5/arrive_waypoint_last/right.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian celon ĉe dekstre",
         "es": "Has llegado a tu destino, a la derecha",
         "es-ES": "Has llegado a tu destino, a la derecha",
+        "fi": "Olet saapunut määränpäähäsi, joka on oikealla puolellasi",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "he": "הגעת אל היעד ה שלך מימינך",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kanan",

--- a/test/fixtures/v5/arrive_waypoint_last/sharp_left.json
+++ b/test/fixtures/v5/arrive_waypoint_last/sharp_left.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian celon ĉe maldekstre",
         "es": "Has llegado a tu destino, a la izquierda",
         "es-ES": "Has llegado a tu destino, a la izquierda",
+        "fi": "Olet saapunut määränpäähäsi, joka on vasemmalla puolellasi",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "he": "הגעת אל היעד ה שלך משמאלך",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kiri",

--- a/test/fixtures/v5/arrive_waypoint_last/sharp_right.json
+++ b/test/fixtures/v5/arrive_waypoint_last/sharp_right.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian celon ĉe dekstre",
         "es": "Has llegado a tu destino, a la derecha",
         "es-ES": "Has llegado a tu destino, a la derecha",
+        "fi": "Olet saapunut määränpäähäsi, joka on oikealla puolellasi",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "he": "הגעת אל היעד ה שלך מימינך",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kanan",

--- a/test/fixtures/v5/arrive_waypoint_last/slight_left.json
+++ b/test/fixtures/v5/arrive_waypoint_last/slight_left.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian celon ĉe maldekstre",
         "es": "Has llegado a tu destino, a la izquierda",
         "es-ES": "Has llegado a tu destino, a la izquierda",
+        "fi": "Olet saapunut määränpäähäsi, joka on vasemmalla puolellasi",
         "fr": "Vous êtes arrivés à votre destination, sur la gauche",
         "he": "הגעת אל היעד ה שלך משמאלך",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kiri",

--- a/test/fixtures/v5/arrive_waypoint_last/slight_right.json
+++ b/test/fixtures/v5/arrive_waypoint_last/slight_right.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian celon ĉe dekstre",
         "es": "Has llegado a tu destino, a la derecha",
         "es-ES": "Has llegado a tu destino, a la derecha",
+        "fi": "Olet saapunut määränpäähäsi, joka on oikealla puolellasi",
         "fr": "Vous êtes arrivés à votre destination, sur la droite",
         "he": "הגעת אל היעד ה שלך מימינך",
         "id": "Anda telah tiba di tujuan ke-, di sebelah kanan",

--- a/test/fixtures/v5/arrive_waypoint_last/straight.json
+++ b/test/fixtures/v5/arrive_waypoint_last/straight.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian celon",
         "es": "Has llegado a tu destino, en frente",
         "es-ES": "Has llegado a tu destino, en frente",
+        "fi": "Olet saapunut määränpäähäsi, joka on suoraan edessäsi",
         "fr": "Vous êtes arrivés à votre destination, droit devant",
         "he": "הגעת אל היעד ה שלך, בהמשך",
         "id": "Anda telah tiba di tujuan ke-, lurus saja",

--- a/test/fixtures/v5/arrive_waypoint_last/uturn.json
+++ b/test/fixtures/v5/arrive_waypoint_last/uturn.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis vian celon",
         "es": "Has llegado a tu destino",
         "es-ES": "Has llegado a tu destino",
+        "fi": "Olet saapunut määränpäähäsi",
         "fr": "Vous êtes arrivés à votre destination",
         "he": "הגעת אל היעד ה שלך",
         "id": "Anda telah tiba di tujuan ke-",

--- a/test/fixtures/v5/arrive_waypoint_name/left.json
+++ b/test/fixtures/v5/arrive_waypoint_name/left.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis Somewhere ĉe maldekstre",
         "es": "Has llegado a Somewhere, a la izquierda",
         "es-ES": "Has llegado a Somewhere, a la izquierda",
+        "fi": "Olet saapunut määränpäähän Somewhere, joka on vasemmalla puolellasi",
         "fr": "Vous êtes arrivés à Somewhere, sur la gauche",
         "he": "הגעת אל Somewhere שלך משמאלך",
         "id": "Anda telah tiba di Somewhere, di sebelah kiri",

--- a/test/fixtures/v5/arrive_waypoint_name/no_modifier.json
+++ b/test/fixtures/v5/arrive_waypoint_name/no_modifier.json
@@ -12,6 +12,7 @@
         "eo": "Vi atingis Somewhere",
         "es": "Has llegado a Somewhere",
         "es-ES": "Has llegado a Somewhere",
+        "fi": "Olet saapunut määränpäähän Somewhere",
         "fr": "Vous êtes arrivés à Somewhere",
         "he": "הגעת אל Somewhere",
         "id": "Anda telah tiba di Somewhere",

--- a/test/fixtures/v5/arrive_waypoint_name/right.json
+++ b/test/fixtures/v5/arrive_waypoint_name/right.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis Somewhere ĉe dekstre",
         "es": "Has llegado a Somewhere, a la derecha",
         "es-ES": "Has llegado a Somewhere, a la derecha",
+        "fi": "Olet saapunut määränpäähän Somewhere, joka on oikealla puolellasi",
         "fr": "Vous êtes arrivés à Somewhere, sur la droite",
         "he": "הגעת אל Somewhere שלך מימינך",
         "id": "Anda telah tiba di Somewhere, di sebelah kanan",

--- a/test/fixtures/v5/arrive_waypoint_name/sharp_left.json
+++ b/test/fixtures/v5/arrive_waypoint_name/sharp_left.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis Somewhere ĉe maldekstre",
         "es": "Has llegado a Somewhere, a la izquierda",
         "es-ES": "Has llegado a Somewhere, a la izquierda",
+        "fi": "Olet saapunut määränpäähän Somewhere, joka on vasemmalla puolellasi",
         "fr": "Vous êtes arrivés à Somewhere, sur la gauche",
         "he": "הגעת אל Somewhere שלך משמאלך",
         "id": "Anda telah tiba di Somewhere, di sebelah kiri",

--- a/test/fixtures/v5/arrive_waypoint_name/sharp_right.json
+++ b/test/fixtures/v5/arrive_waypoint_name/sharp_right.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis Somewhere ĉe dekstre",
         "es": "Has llegado a Somewhere, a la derecha",
         "es-ES": "Has llegado a Somewhere, a la derecha",
+        "fi": "Olet saapunut määränpäähän Somewhere, joka on oikealla puolellasi",
         "fr": "Vous êtes arrivés à Somewhere, sur la droite",
         "he": "הגעת אל Somewhere שלך מימינך",
         "id": "Anda telah tiba di Somewhere, di sebelah kanan",

--- a/test/fixtures/v5/arrive_waypoint_name/slight_left.json
+++ b/test/fixtures/v5/arrive_waypoint_name/slight_left.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis Somewhere ĉe maldekstre",
         "es": "Has llegado a Somewhere, a la izquierda",
         "es-ES": "Has llegado a Somewhere, a la izquierda",
+        "fi": "Olet saapunut määränpäähän Somewhere, joka on vasemmalla puolellasi",
         "fr": "Vous êtes arrivés à Somewhere, sur la gauche",
         "he": "הגעת אל Somewhere שלך משמאלך",
         "id": "Anda telah tiba di Somewhere, di sebelah kiri",

--- a/test/fixtures/v5/arrive_waypoint_name/slight_right.json
+++ b/test/fixtures/v5/arrive_waypoint_name/slight_right.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis Somewhere ĉe dekstre",
         "es": "Has llegado a Somewhere, a la derecha",
         "es-ES": "Has llegado a Somewhere, a la derecha",
+        "fi": "Olet saapunut määränpäähän Somewhere, joka on oikealla puolellasi",
         "fr": "Vous êtes arrivés à Somewhere, sur la droite",
         "he": "הגעת אל Somewhere שלך מימינך",
         "id": "Anda telah tiba di Somewhere, di sebelah kanan",

--- a/test/fixtures/v5/arrive_waypoint_name/straight.json
+++ b/test/fixtures/v5/arrive_waypoint_name/straight.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis Somewhere",
         "es": "Has llegado a Somewhere, en frente",
         "es-ES": "Has llegado a Somewhere, en frente",
+        "fi": "Olet saapunut määränpäähän Somewhere, joka on suoraan edessäsi",
         "fr": "Vous êtes arrivés à Somewhere, droit devant",
         "he": "הגעת אל Somewhere, בהמשך",
         "id": "Anda telah tiba di Somewhere, lurus saja",

--- a/test/fixtures/v5/arrive_waypoint_name/uturn.json
+++ b/test/fixtures/v5/arrive_waypoint_name/uturn.json
@@ -13,6 +13,7 @@
         "eo": "Vi atingis Somewhere",
         "es": "Has llegado a Somewhere",
         "es-ES": "Has llegado a Somewhere",
+        "fi": "Olet saapunut määränpäähän Somewhere",
         "fr": "Vous êtes arrivés à Somewhere",
         "he": "הגעת אל Somewhere",
         "id": "Anda telah tiba di Somewhere",

--- a/test/fixtures/v5/continue/left_default.json
+++ b/test/fixtures/v5/continue/left_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstren",
         "es": "Gira a izquierda",
         "es-ES": "Gire a la izquierda",
+        "fi": "Käänny vasemmall(e/a)",
         "fr": "Tourner à gauche",
         "he": "פנה שמאלה",
         "id": "Belok kiri",

--- a/test/fixtures/v5/continue/left_destination.json
+++ b/test/fixtures/v5/continue/left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu maldekstren direkte al Destination 1",
         "es": "Gira a izquierda hacia Destination 1",
         "es-ES": "Gire a la izquierda hacia Destination 1",
+        "fi": "Käänny vasemmall(e/a) suuntana Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "he": "פנה שמאלה לכיוון Destination 1",
         "id": "Belok kiri menuju Destination 1",

--- a/test/fixtures/v5/continue/left_exit.json
+++ b/test/fixtures/v5/continue/left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu maldekstren direkte al Way Name",
         "es": "Gira a izquierda en Way Name",
         "es-ES": "Gire a la izquierda en Way Name",
+        "fi": "Käänny vasemmall(e/a) tielle Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "he": "פנה שמאלה על Way Name",
         "id": "Belok kiri ke Way Name",

--- a/test/fixtures/v5/continue/left_exit_destination.json
+++ b/test/fixtures/v5/continue/left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu maldekstren direkte al Destination 1",
         "es": "Gira a izquierda hacia Destination 1",
         "es-ES": "Gire a la izquierda hacia Destination 1",
+        "fi": "Käänny vasemmall(e/a) suuntana Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "he": "פנה שמאלה לכיוון Destination 1",
         "id": "Belok kiri menuju Destination 1",

--- a/test/fixtures/v5/continue/left_name.json
+++ b/test/fixtures/v5/continue/left_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstren al Way Name",
         "es": "Cruza a laizquierda en Way Name",
         "es-ES": "Cruce a la izquierda en Way Name",
+        "fi": "Käänny vasemmall(e/a) pysyäksesi tiellä Way Name",
         "fr": "Tourner à gauche pour rester Way Name",
         "he": "פנה שמאלה כדי להישאר בWay Name",
         "id": "Terus kiri ke Way Name",

--- a/test/fixtures/v5/continue/right_default.json
+++ b/test/fixtures/v5/continue/right_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstren",
         "es": "Gira a derecha",
         "es-ES": "Gire a la derecha",
+        "fi": "Käänny oikeall(e/a)",
         "fr": "Tourner à droite",
         "he": "פנה ימינה",
         "id": "Belok kanan",

--- a/test/fixtures/v5/continue/right_destination.json
+++ b/test/fixtures/v5/continue/right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu dekstren direkte al Destination 1",
         "es": "Gira a derecha hacia Destination 1",
         "es-ES": "Gire a la derecha hacia Destination 1",
+        "fi": "Käänny oikeall(e/a) suuntana Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "he": "פנה ימינה לכיוון Destination 1",
         "id": "Belok kanan menuju Destination 1",

--- a/test/fixtures/v5/continue/right_exit.json
+++ b/test/fixtures/v5/continue/right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu dekstren direkte al Way Name",
         "es": "Gira a derecha en Way Name",
         "es-ES": "Gire a la derecha en Way Name",
+        "fi": "Käänny oikeall(e/a) tielle Way Name",
         "fr": "Tourner à droite sur Way Name",
         "he": "פנה ימינה על Way Name",
         "id": "Belok kanan ke Way Name",

--- a/test/fixtures/v5/continue/right_exit_destination.json
+++ b/test/fixtures/v5/continue/right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu dekstren direkte al Destination 1",
         "es": "Gira a derecha hacia Destination 1",
         "es-ES": "Gire a la derecha hacia Destination 1",
+        "fi": "Käänny oikeall(e/a) suuntana Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "he": "פנה ימינה לכיוון Destination 1",
         "id": "Belok kanan menuju Destination 1",

--- a/test/fixtures/v5/continue/right_name.json
+++ b/test/fixtures/v5/continue/right_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstren al Way Name",
         "es": "Cruza a laderecha en Way Name",
         "es-ES": "Cruce a la derecha en Way Name",
+        "fi": "Käänny oikeall(e/a) pysyäksesi tiellä Way Name",
         "fr": "Tourner à droite pour rester Way Name",
         "he": "פנה ימינה כדי להישאר בWay Name",
         "id": "Terus kanan ke Way Name",

--- a/test/fixtures/v5/continue/sharp_left_default.json
+++ b/test/fixtures/v5/continue/sharp_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ege maldekstren",
         "es": "Gira a la izquierda",
         "es-ES": "Gire a la izquierda",
+        "fi": "Jatka jyrkästi vasempaan",
         "fr": "Braquer à gauche",
         "he": "פנה בחדות שמאלה",
         "id": "Belok kiri tajam",

--- a/test/fixtures/v5/continue/sharp_left_destination.json
+++ b/test/fixtures/v5/continue/sharp_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu ege maldekstren direkte al Destination 1",
         "es": "Gira a la izquierda hacia Destination 1",
         "es-ES": "Gire a la izquierda hacia Destination 1",
+        "fi": "Jatka jyrkästi vasempaan suuntana Destination 1",
         "fr": "Braquer à gauche en direction de Destination 1",
         "he": "פנה בחדות שמאלה לכיוון Destination 1",
         "id": "Belok kiri tajam menuju Destination 1",

--- a/test/fixtures/v5/continue/sharp_left_exit.json
+++ b/test/fixtures/v5/continue/sharp_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu ege maldekstren al Way Name",
         "es": "Gira a la izquierda en Way Name",
         "es-ES": "Gire a la izquierda en Way Name",
+        "fi": "Jatka jyrkästi vasempaan pysyäksesi tiellä Way Name",
         "fr": "Braquer à gauche pour rester sur Way Name",
         "he": "פנה בחדות שמאלה כדי להישאר על Way Name",
         "id": "Make a sharp left to stay on Way Name",

--- a/test/fixtures/v5/continue/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/continue/sharp_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu ege maldekstren direkte al Destination 1",
         "es": "Gira a la izquierda hacia Destination 1",
         "es-ES": "Gire a la izquierda hacia Destination 1",
+        "fi": "Jatka jyrkästi vasempaan suuntana Destination 1",
         "fr": "Braquer à gauche en direction de Destination 1",
         "he": "פנה בחדות שמאלה לכיוון Destination 1",
         "id": "Belok kiri tajam menuju Destination 1",

--- a/test/fixtures/v5/continue/sharp_left_name.json
+++ b/test/fixtures/v5/continue/sharp_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ege maldekstren al Way Name",
         "es": "Gira a la izquierda en Way Name",
         "es-ES": "Gire a la izquierda en Way Name",
+        "fi": "Jatka jyrkästi vasempaan pysyäksesi tiellä Way Name",
         "fr": "Braquer à gauche pour rester sur Way Name",
         "he": "פנה בחדות שמאלה כדי להישאר על Way Name",
         "id": "Make a sharp left to stay on Way Name",

--- a/test/fixtures/v5/continue/sharp_right_default.json
+++ b/test/fixtures/v5/continue/sharp_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ege dekstren",
         "es": "Gira a la derecha",
         "es-ES": "Gire a la derecha",
+        "fi": "Jatka jyrkästi oikeaan",
         "fr": "Braquer à droite",
         "he": "פנה בחדות ימינה",
         "id": "Belok kanan tajam",

--- a/test/fixtures/v5/continue/sharp_right_destination.json
+++ b/test/fixtures/v5/continue/sharp_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu ege dekstren direkte al Destination 1",
         "es": "Gira a la derecha hacia Destination 1",
         "es-ES": "Gire a la derecha hacia Destination 1",
+        "fi": "Jatka jyrkästi oikeaan suuntana Destination 1",
         "fr": "Braquer à droite en direction de Destination 1",
         "he": "פנה בחדות ימינה לכיוון Destination 1",
         "id": "Belok kanan tajam menuju Destination 1",

--- a/test/fixtures/v5/continue/sharp_right_exit.json
+++ b/test/fixtures/v5/continue/sharp_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu ege dekstren al Way Name",
         "es": "Gira a la derecha en Way Name",
         "es-ES": "Gire a la derecha en Way Name",
+        "fi": "Jatka jyrkästi oikeaan pysyäksesi tiellä Way Name",
         "fr": "Braquer à droite pour rester sur Way Name",
         "he": "פנה בחדות ימינה כדי להישאר על Way Name",
         "id": "Make a sharp right to stay on Way Name",

--- a/test/fixtures/v5/continue/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/continue/sharp_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu ege dekstren direkte al Destination 1",
         "es": "Gira a la derecha hacia Destination 1",
         "es-ES": "Gire a la derecha hacia Destination 1",
+        "fi": "Jatka jyrkästi oikeaan suuntana Destination 1",
         "fr": "Braquer à droite en direction de Destination 1",
         "he": "פנה בחדות ימינה לכיוון Destination 1",
         "id": "Belok kanan tajam menuju Destination 1",

--- a/test/fixtures/v5/continue/sharp_right_name.json
+++ b/test/fixtures/v5/continue/sharp_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ege dekstren al Way Name",
         "es": "Gira a la derecha en Way Name",
         "es-ES": "Gire a la derecha en Way Name",
+        "fi": "Jatka jyrkästi oikeaan pysyäksesi tiellä Way Name",
         "fr": "Braquer à droite pour rester sur Way Name",
         "he": "פנה בחדות ימינה כדי להישאר על Way Name",
         "id": "Make a sharp right to stay on Way Name",

--- a/test/fixtures/v5/continue/slight_left_default.json
+++ b/test/fixtures/v5/continue/slight_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ete maldekstren",
         "es": "Gira a la izquierda",
         "es-ES": "Gire a la izquierda",
+        "fi": "Jatka loivasti vasempaan",
         "fr": "S’aligner légèrement à gauche",
         "he": "פנה קלות שמאלה",
         "id": "Tetap agak di kiri",

--- a/test/fixtures/v5/continue/slight_left_destination.json
+++ b/test/fixtures/v5/continue/slight_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu ete maldekstren direkte al Destination 1",
         "es": "Gira a la izquierda hacia Destination 1",
         "es-ES": "Gire a la izquierda hacia Destination 1",
+        "fi": "Jatka loivasti vasempaan suuntana Destination 1",
         "fr": "S’aligner légèrement à gauche en direction de Destination 1",
         "he": "פנה קלות שמאלה לכיוון Destination 1",
         "id": "Tetap agak di kiri menuju Destination 1",

--- a/test/fixtures/v5/continue/slight_left_exit.json
+++ b/test/fixtures/v5/continue/slight_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu ete maldekstren al Way Name",
         "es": "Dobla levemente a la izquierda en Way Name",
         "es-ES": "Doble levemente a la izquierda en Way Name",
+        "fi": "Jatka loivasti vasempaan pysyäksesi tiellä Way Name",
         "fr": "S’aligner légèrement à gauche pour rester sur Way Name",
         "he": "פנה קלות שמאלה כדי להישאר על Way Name",
         "id": "Tetap agak di kiri ke Way Name",

--- a/test/fixtures/v5/continue/slight_left_exit_destination.json
+++ b/test/fixtures/v5/continue/slight_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu ete maldekstren direkte al Destination 1",
         "es": "Gira a la izquierda hacia Destination 1",
         "es-ES": "Gire a la izquierda hacia Destination 1",
+        "fi": "Jatka loivasti vasempaan suuntana Destination 1",
         "fr": "S’aligner légèrement à gauche en direction de Destination 1",
         "he": "פנה קלות שמאלה לכיוון Destination 1",
         "id": "Tetap agak di kiri menuju Destination 1",

--- a/test/fixtures/v5/continue/slight_left_name.json
+++ b/test/fixtures/v5/continue/slight_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ete maldekstren al Way Name",
         "es": "Dobla levemente a la izquierda en Way Name",
         "es-ES": "Doble levemente a la izquierda en Way Name",
+        "fi": "Jatka loivasti vasempaan pysyäksesi tiellä Way Name",
         "fr": "S’aligner légèrement à gauche pour rester sur Way Name",
         "he": "פנה קלות שמאלה כדי להישאר על Way Name",
         "id": "Tetap agak di kiri ke Way Name",

--- a/test/fixtures/v5/continue/slight_right_default.json
+++ b/test/fixtures/v5/continue/slight_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ete dekstren",
         "es": "Gira a la izquierda",
         "es-ES": "Gire a la izquierda",
+        "fi": "Jatka loivasti oikeaan",
         "fr": "S’aligner légèrement à droite",
         "he": "פנה קלות ימינה",
         "id": "Tetap agak di kanan",

--- a/test/fixtures/v5/continue/slight_right_destination.json
+++ b/test/fixtures/v5/continue/slight_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu ete dekstren direkte al Destination 1",
         "es": "Gira a la izquierda hacia Destination 1",
         "es-ES": "Gire a la izquierda hacia Destination 1",
+        "fi": "Jatka loivasti oikeaan suuntana Destination 1",
         "fr": "S’aligner légèrement à droite en direction de Destination 1",
         "he": "פנה קלות ימינה לכיוון Destination 1",
         "id": "Tetap agak di kanan menuju Destination 1",

--- a/test/fixtures/v5/continue/slight_right_exit.json
+++ b/test/fixtures/v5/continue/slight_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu ete dekstren al Way Name",
         "es": "Dobla levemente a la derecha en Way Name",
         "es-ES": "Doble levemente a la derecha en Way Name",
+        "fi": "Jatka loivasti oikeaan pysyäksesi tiellä Way Name",
         "fr": "S’aligner légèrement à droite pour rester sur Way Name",
         "he": "פנה קלות ימינה כדי להישאר על Way Name",
         "id": "Tetap agak di kanan ke Way Name",

--- a/test/fixtures/v5/continue/slight_right_exit_destination.json
+++ b/test/fixtures/v5/continue/slight_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu ete dekstren direkte al Destination 1",
         "es": "Gira a la izquierda hacia Destination 1",
         "es-ES": "Gire a la izquierda hacia Destination 1",
+        "fi": "Jatka loivasti oikeaan suuntana Destination 1",
         "fr": "S’aligner légèrement à droite en direction de Destination 1",
         "he": "פנה קלות ימינה לכיוון Destination 1",
         "id": "Tetap agak di kanan menuju Destination 1",

--- a/test/fixtures/v5/continue/slight_right_name.json
+++ b/test/fixtures/v5/continue/slight_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ete dekstren al Way Name",
         "es": "Dobla levemente a la derecha en Way Name",
         "es-ES": "Doble levemente a la derecha en Way Name",
+        "fi": "Jatka loivasti oikeaan pysyäksesi tiellä Way Name",
         "fr": "S’aligner légèrement à droite pour rester sur Way Name",
         "he": "פנה קלות ימינה כדי להישאר על Way Name",
         "id": "Tetap agak di kanan ke Way Name",

--- a/test/fixtures/v5/continue/straight_default.json
+++ b/test/fixtures/v5/continue/straight_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu rekten",
         "es": "Continúa recto",
         "es-ES": "Continúa recto",
+        "fi": "Jatka suoraan eteenpäin",
         "fr": "Continuer tout droit",
         "he": "המשך ישר",
         "id": "Lurus terus",

--- a/test/fixtures/v5/continue/straight_destination.json
+++ b/test/fixtures/v5/continue/straight_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu rekten direkte al Destination 1",
         "es": "Continúa hacia Destination 1",
         "es-ES": "Continúa hacia Destination 1",
+        "fi": "Jatka suuntana Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "he": "המשך לכיוון Destination 1",
         "id": "Terus menuju Destination 1",

--- a/test/fixtures/v5/continue/straight_exit.json
+++ b/test/fixtures/v5/continue/straight_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu rekten al Way Name",
         "es": "Continúa en Way Name",
         "es-ES": "Continúa en Way Name",
+        "fi": "Jatka suoraan pysyäksesi tiellä Way Name",
         "fr": "Continuer tout droit pour rester sur Way Name",
         "he": "המשך ישר כדי להישאר על Way Name",
         "id": "Terus ke Way Name",

--- a/test/fixtures/v5/continue/straight_exit_destination.json
+++ b/test/fixtures/v5/continue/straight_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu rekten direkte al Destination 1",
         "es": "Continúa hacia Destination 1",
         "es-ES": "Continúa hacia Destination 1",
+        "fi": "Jatka suuntana Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "he": "המשך לכיוון Destination 1",
         "id": "Terus menuju Destination 1",

--- a/test/fixtures/v5/continue/straight_name.json
+++ b/test/fixtures/v5/continue/straight_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu rekten al Way Name",
         "es": "Continúa en Way Name",
         "es-ES": "Continúa en Way Name",
+        "fi": "Jatka suoraan pysyäksesi tiellä Way Name",
         "fr": "Continuer tout droit pour rester sur Way Name",
         "he": "המשך ישר כדי להישאר על Way Name",
         "id": "Terus ke Way Name",

--- a/test/fixtures/v5/continue/uturn_default.json
+++ b/test/fixtures/v5/continue/uturn_default.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu malantaŭen",
         "es": "Haz un cambio de sentido",
         "es-ES": "Haz un cambio de sentido",
+        "fi": "Tee U-käännös",
         "fr": "Faire demi-tour",
         "he": "פנה פניית פרסה",
         "id": "Putar balik",

--- a/test/fixtures/v5/continue/uturn_destination.json
+++ b/test/fixtures/v5/continue/uturn_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu malantaŭen direkte al Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
         "es-ES": "Haz un cambio de sentido hacia Destination 1",
+        "fi": "Tee U-käännös suuntana Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "he": "פנה פניית פרסה לכיוון Destination 1",
         "id": "Putar balik menuju Destination 1",

--- a/test/fixtures/v5/continue/uturn_exit.json
+++ b/test/fixtures/v5/continue/uturn_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu malantaŭen al Way Name",
         "es": "Haz un cambio de sentido y continúa en Way Name",
         "es-ES": "Haz un cambio de sentido y continúa en Way Name",
+        "fi": "Tee U-käännös ja jatka tietä Way Name",
         "fr": "Faire demi-tour et continuer sur Way Name",
         "he": "פנה פניית פרסה והמשך על Way Name",
         "id": "Putar balik ke arah Way Name",

--- a/test/fixtures/v5/continue/uturn_exit_destination.json
+++ b/test/fixtures/v5/continue/uturn_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu malantaŭen direkte al Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
         "es-ES": "Haz un cambio de sentido hacia Destination 1",
+        "fi": "Tee U-käännös suuntana Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "he": "פנה פניית פרסה לכיוון Destination 1",
         "id": "Putar balik menuju Destination 1",

--- a/test/fixtures/v5/continue/uturn_name.json
+++ b/test/fixtures/v5/continue/uturn_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu malantaŭen al Way Name",
         "es": "Haz un cambio de sentido y continúa en Way Name",
         "es-ES": "Haz un cambio de sentido y continúa en Way Name",
+        "fi": "Tee U-käännös ja jatka tietä Way Name",
         "fr": "Faire demi-tour et continuer sur Way Name",
         "he": "פנה פניית פרסה והמשך על Way Name",
         "id": "Putar balik ke arah Way Name",

--- a/test/fixtures/v5/depart/east_110.json
+++ b/test/fixtures/v5/depart/east_110.json
@@ -13,6 +13,7 @@
         "eo": "Direktiĝu orienten",
         "es": "Ve a este",
         "es-ES": "Dirígete al este",
+        "fi": "Aja itään",
         "fr": "Rouler vers l’est",
         "he": "התכוונן מזרח",
         "id": "Arah timur",

--- a/test/fixtures/v5/depart/east_70.json
+++ b/test/fixtures/v5/depart/east_70.json
@@ -13,6 +13,7 @@
         "eo": "Direktiĝu orienten",
         "es": "Ve a este",
         "es-ES": "Dirígete al este",
+        "fi": "Aja itään",
         "fr": "Rouler vers l’est",
         "he": "התכוונן מזרח",
         "id": "Arah timur",

--- a/test/fixtures/v5/depart/modifier_default.json
+++ b/test/fixtures/v5/depart/modifier_default.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu norden",
         "es": "Ve a norte",
         "es-ES": "Dirígete al norte",
+        "fi": "Aja pohjoiseen",
         "fr": "Rouler vers le nord",
         "he": "התכוונן צפון",
         "id": "Arah utara",

--- a/test/fixtures/v5/depart/modifier_destination.json
+++ b/test/fixtures/v5/depart/modifier_destination.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu norden al Way Name",
         "es": "Ve a norte en Way Name",
         "es-ES": "Dirígete al norte por Way Name",
+        "fi": "Aja tietä Way Name pohjoiseen",
         "fr": "Rouler vers le nord sur Way Name",
         "he": "התכוונן צפון על Way Name",
         "id": "Arah utara di Way Name",

--- a/test/fixtures/v5/depart/modifier_exit.json
+++ b/test/fixtures/v5/depart/modifier_exit.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu norden al Way Name",
         "es": "Ve a norte en Way Name",
         "es-ES": "Dirígete al norte por Way Name",
+        "fi": "Aja tietä Way Name pohjoiseen",
         "fr": "Rouler vers le nord sur Way Name",
         "he": "התכוונן צפון על Way Name",
         "id": "Arah utara di Way Name",

--- a/test/fixtures/v5/depart/modifier_exit_destination.json
+++ b/test/fixtures/v5/depart/modifier_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Direktiĝu norden al Way Name",
         "es": "Ve a norte en Way Name",
         "es-ES": "Dirígete al norte por Way Name",
+        "fi": "Aja tietä Way Name pohjoiseen",
         "fr": "Rouler vers le nord sur Way Name",
         "he": "התכוונן צפון על Way Name",
         "id": "Arah utara di Way Name",

--- a/test/fixtures/v5/depart/modifier_name.json
+++ b/test/fixtures/v5/depart/modifier_name.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu norden al Way Name",
         "es": "Ve a norte en Way Name",
         "es-ES": "Dirígete al norte por Way Name",
+        "fi": "Aja tietä Way Name pohjoiseen",
         "fr": "Rouler vers le nord sur Way Name",
         "he": "התכוונן צפון על Way Name",
         "id": "Arah utara di Way Name",

--- a/test/fixtures/v5/depart/north_20.json
+++ b/test/fixtures/v5/depart/north_20.json
@@ -13,6 +13,7 @@
         "eo": "Direktiĝu norden",
         "es": "Ve a norte",
         "es-ES": "Dirígete al norte",
+        "fi": "Aja pohjoiseen",
         "fr": "Rouler vers le nord",
         "he": "התכוונן צפון",
         "id": "Arah utara",

--- a/test/fixtures/v5/depart/north_340.json
+++ b/test/fixtures/v5/depart/north_340.json
@@ -13,6 +13,7 @@
         "eo": "Direktiĝu norden",
         "es": "Ve a norte",
         "es-ES": "Dirígete al norte",
+        "fi": "Aja pohjoiseen",
         "fr": "Rouler vers le nord",
         "he": "התכוונן צפון",
         "id": "Arah utara",

--- a/test/fixtures/v5/depart/northeast_21.json
+++ b/test/fixtures/v5/depart/northeast_21.json
@@ -13,6 +13,7 @@
         "eo": "Direktiĝu nord-orienten",
         "es": "Ve a noreste",
         "es-ES": "Dirígete al noreste",
+        "fi": "Aja koilliseen",
         "fr": "Rouler vers le nord-est",
         "he": "התכוונן צפון מזרח",
         "id": "Arah timur laut",

--- a/test/fixtures/v5/depart/northeast_69.json
+++ b/test/fixtures/v5/depart/northeast_69.json
@@ -13,6 +13,7 @@
         "eo": "Direktiĝu nord-orienten",
         "es": "Ve a noreste",
         "es-ES": "Dirígete al noreste",
+        "fi": "Aja koilliseen",
         "fr": "Rouler vers le nord-est",
         "he": "התכוונן צפון מזרח",
         "id": "Arah timur laut",

--- a/test/fixtures/v5/depart/northwest_291.json
+++ b/test/fixtures/v5/depart/northwest_291.json
@@ -13,6 +13,7 @@
         "eo": "Direktiĝu nord-okcidenten",
         "es": "Ve a noroeste",
         "es-ES": "Dirígete al noroeste",
+        "fi": "Aja luoteeseen",
         "fr": "Rouler vers le nord-ouest",
         "he": "התכוונן צפון מערב",
         "id": "Arah barat laut",

--- a/test/fixtures/v5/depart/northwest_339.json
+++ b/test/fixtures/v5/depart/northwest_339.json
@@ -13,6 +13,7 @@
         "eo": "Direktiĝu nord-okcidenten",
         "es": "Ve a noroeste",
         "es-ES": "Dirígete al noroeste",
+        "fi": "Aja luoteeseen",
         "fr": "Rouler vers le nord-ouest",
         "he": "התכוונן צפון מערב",
         "id": "Arah barat laut",

--- a/test/fixtures/v5/depart/south_160.json
+++ b/test/fixtures/v5/depart/south_160.json
@@ -13,6 +13,7 @@
         "eo": "Direktiĝu suden",
         "es": "Ve a sur",
         "es-ES": "Dirígete al sur",
+        "fi": "Aja etelään",
         "fr": "Rouler vers le sud",
         "he": "התכוונן דרום",
         "id": "Arah selatan",

--- a/test/fixtures/v5/depart/south_200.json
+++ b/test/fixtures/v5/depart/south_200.json
@@ -13,6 +13,7 @@
         "eo": "Direktiĝu suden",
         "es": "Ve a sur",
         "es-ES": "Dirígete al sur",
+        "fi": "Aja etelään",
         "fr": "Rouler vers le sud",
         "he": "התכוונן דרום",
         "id": "Arah selatan",

--- a/test/fixtures/v5/depart/southeast_111.json
+++ b/test/fixtures/v5/depart/southeast_111.json
@@ -13,6 +13,7 @@
         "eo": "Direktiĝu sud-orienten",
         "es": "Ve a sureste",
         "es-ES": "Dirígete al sureste",
+        "fi": "Aja kaakkoon",
         "fr": "Rouler vers le sud-est",
         "he": "התכוונן דרום מזרח",
         "id": "Arah tenggara",

--- a/test/fixtures/v5/depart/southeast_159.json
+++ b/test/fixtures/v5/depart/southeast_159.json
@@ -13,6 +13,7 @@
         "eo": "Direktiĝu sud-orienten",
         "es": "Ve a sureste",
         "es-ES": "Dirígete al sureste",
+        "fi": "Aja kaakkoon",
         "fr": "Rouler vers le sud-est",
         "he": "התכוונן דרום מזרח",
         "id": "Arah tenggara",

--- a/test/fixtures/v5/depart/southwest_201.json
+++ b/test/fixtures/v5/depart/southwest_201.json
@@ -13,6 +13,7 @@
         "eo": "Direktiĝu sud-okcidenten",
         "es": "Ve a suroeste",
         "es-ES": "Dirígete al suroeste",
+        "fi": "Aja lounaaseen",
         "fr": "Rouler vers le sud-ouest",
         "he": "התכוונן דרום מערב",
         "id": "Arah barat daya",

--- a/test/fixtures/v5/depart/southwest_249.json
+++ b/test/fixtures/v5/depart/southwest_249.json
@@ -13,6 +13,7 @@
         "eo": "Direktiĝu sud-okcidenten",
         "es": "Ve a suroeste",
         "es-ES": "Dirígete al suroeste",
+        "fi": "Aja lounaaseen",
         "fr": "Rouler vers le sud-ouest",
         "he": "התכוונן דרום מערב",
         "id": "Arah barat daya",

--- a/test/fixtures/v5/depart/west_250.json
+++ b/test/fixtures/v5/depart/west_250.json
@@ -13,6 +13,7 @@
         "eo": "Direktiĝu okcidenten",
         "es": "Ve a oeste",
         "es-ES": "Dirígete al oeste",
+        "fi": "Aja länteen",
         "fr": "Rouler vers l’ouest",
         "he": "התכוונן מערב",
         "id": "Arah barat",

--- a/test/fixtures/v5/depart/west_290.json
+++ b/test/fixtures/v5/depart/west_290.json
@@ -13,6 +13,7 @@
         "eo": "Direktiĝu okcidenten",
         "es": "Ve a oeste",
         "es-ES": "Dirígete al oeste",
+        "fi": "Aja länteen",
         "fr": "Rouler vers l’ouest",
         "he": "התכוונן מערב",
         "id": "Arah barat",

--- a/test/fixtures/v5/end_of_road/left_default.json
+++ b/test/fixtures/v5/end_of_road/left_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstren",
         "es": "Gira a izquierda",
         "es-ES": "Al final de la calle gira a la izquierda",
+        "fi": "Käänny vasemmall(e/a)",
         "fr": "Tourner à gauche",
         "he": "פנה שמאלה",
         "id": "Belok kiri",

--- a/test/fixtures/v5/end_of_road/left_destination.json
+++ b/test/fixtures/v5/end_of_road/left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu maldekstren direkte al Destination 1",
         "es": "Gira a izquierda hacia Destination 1",
         "es-ES": "Al final de la calle gira a la izquierda hacia Destination 1",
+        "fi": "Käänny vasemmall(e/a) suuntana Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "he": "פנה שמאלה לכיוון Destination 1",
         "id": "Belok kiri menuju Destination 1",

--- a/test/fixtures/v5/end_of_road/left_exit.json
+++ b/test/fixtures/v5/end_of_road/left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu maldekstren direkte al Way Name",
         "es": "Gira a izquierda en Way Name",
         "es-ES": "Al final de la calle gira a la izquierda por Way Name",
+        "fi": "Käänny vasemmall(e/a) tielle Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "he": "פנה שמאלה על Way Name",
         "id": "Belok kiri ke Way Name",

--- a/test/fixtures/v5/end_of_road/left_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu maldekstren direkte al Destination 1",
         "es": "Gira a izquierda hacia Destination 1",
         "es-ES": "Al final de la calle gira a la izquierda hacia Destination 1",
+        "fi": "Käänny vasemmall(e/a) suuntana Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "he": "פנה שמאלה לכיוון Destination 1",
         "id": "Belok kiri menuju Destination 1",

--- a/test/fixtures/v5/end_of_road/left_name.json
+++ b/test/fixtures/v5/end_of_road/left_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstren direkte al Way Name",
         "es": "Gira a izquierda en Way Name",
         "es-ES": "Al final de la calle gira a la izquierda por Way Name",
+        "fi": "Käänny vasemmall(e/a) tielle Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "he": "פנה שמאלה על Way Name",
         "id": "Belok kiri ke Way Name",

--- a/test/fixtures/v5/end_of_road/right_default.json
+++ b/test/fixtures/v5/end_of_road/right_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstren",
         "es": "Gira a derecha",
         "es-ES": "Al final de la calle gira a la derecha",
+        "fi": "Käänny oikeall(e/a)",
         "fr": "Tourner à droite",
         "he": "פנה ימינה",
         "id": "Belok kanan",

--- a/test/fixtures/v5/end_of_road/right_destination.json
+++ b/test/fixtures/v5/end_of_road/right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu dekstren direkte al Destination 1",
         "es": "Gira a derecha hacia Destination 1",
         "es-ES": "Al final de la calle gira a la derecha hacia Destination 1",
+        "fi": "Käänny oikeall(e/a) suuntana Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "he": "פנה ימינה לכיוון Destination 1",
         "id": "Belok kanan menuju Destination 1",

--- a/test/fixtures/v5/end_of_road/right_exit.json
+++ b/test/fixtures/v5/end_of_road/right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu dekstren direkte al Way Name",
         "es": "Gira a derecha en Way Name",
         "es-ES": "Al final de la calle gira a la derecha por Way Name",
+        "fi": "Käänny oikeall(e/a) tielle Way Name",
         "fr": "Tourner à droite sur Way Name",
         "he": "פנה ימינה על Way Name",
         "id": "Belok kanan ke Way Name",

--- a/test/fixtures/v5/end_of_road/right_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu dekstren direkte al Destination 1",
         "es": "Gira a derecha hacia Destination 1",
         "es-ES": "Al final de la calle gira a la derecha hacia Destination 1",
+        "fi": "Käänny oikeall(e/a) suuntana Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "he": "פנה ימינה לכיוון Destination 1",
         "id": "Belok kanan menuju Destination 1",

--- a/test/fixtures/v5/end_of_road/right_name.json
+++ b/test/fixtures/v5/end_of_road/right_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstren direkte al Way Name",
         "es": "Gira a derecha en Way Name",
         "es-ES": "Al final de la calle gira a la derecha por Way Name",
+        "fi": "Käänny oikeall(e/a) tielle Way Name",
         "fr": "Tourner à droite sur Way Name",
         "he": "פנה ימינה על Way Name",
         "id": "Belok kanan ke Way Name",

--- a/test/fixtures/v5/end_of_road/sharp_left_default.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstregen",
         "es": "Gira a cerrada a la izquierda",
         "es-ES": "Al final de la calle gira cerrada a la izquierda",
+        "fi": "Käänny jyrkästi vasempaan",
         "fr": "Tourner franchement à gauche",
         "he": "פנה חדה שמאלה",
         "id": "Belok tajam kiri",

--- a/test/fixtures/v5/end_of_road/sharp_left_destination.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu maldekstregen direkte al Destination 1",
         "es": "Gira a cerrada a la izquierda hacia Destination 1",
         "es-ES": "Al final de la calle gira cerrada a la izquierda hacia Destination 1",
+        "fi": "Käänny jyrkästi vasempaan suuntana Destination 1",
         "fr": "Tourner franchement à gauche en direction de Destination 1",
         "he": "פנה חדה שמאלה לכיוון Destination 1",
         "id": "Belok tajam kiri menuju Destination 1",

--- a/test/fixtures/v5/end_of_road/sharp_left_exit.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu maldekstregen direkte al Way Name",
         "es": "Gira a cerrada a la izquierda en Way Name",
         "es-ES": "Al final de la calle gira cerrada a la izquierda por Way Name",
+        "fi": "Käänny jyrkästi vasempaan tielle Way Name",
         "fr": "Tourner franchement à gauche sur Way Name",
         "he": "פנה חדה שמאלה על Way Name",
         "id": "Belok tajam kiri ke Way Name",

--- a/test/fixtures/v5/end_of_road/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu maldekstregen direkte al Destination 1",
         "es": "Gira a cerrada a la izquierda hacia Destination 1",
         "es-ES": "Al final de la calle gira cerrada a la izquierda hacia Destination 1",
+        "fi": "Käänny jyrkästi vasempaan suuntana Destination 1",
         "fr": "Tourner franchement à gauche en direction de Destination 1",
         "he": "פנה חדה שמאלה לכיוון Destination 1",
         "id": "Belok tajam kiri menuju Destination 1",

--- a/test/fixtures/v5/end_of_road/sharp_left_name.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstregen direkte al Way Name",
         "es": "Gira a cerrada a la izquierda en Way Name",
         "es-ES": "Al final de la calle gira cerrada a la izquierda por Way Name",
+        "fi": "Käänny jyrkästi vasempaan tielle Way Name",
         "fr": "Tourner franchement à gauche sur Way Name",
         "he": "פנה חדה שמאלה על Way Name",
         "id": "Belok tajam kiri ke Way Name",

--- a/test/fixtures/v5/end_of_road/sharp_right_default.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstregen",
         "es": "Gira a cerrada a la derecha",
         "es-ES": "Al final de la calle gira cerrada a la derecha",
+        "fi": "Käänny jyrkästi oikeaan",
         "fr": "Tourner franchement à droite",
         "he": "פנה חדה ימינה",
         "id": "Belok tajam kanan",

--- a/test/fixtures/v5/end_of_road/sharp_right_destination.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu dekstregen direkte al Destination 1",
         "es": "Gira a cerrada a la derecha hacia Destination 1",
         "es-ES": "Al final de la calle gira cerrada a la derecha hacia Destination 1",
+        "fi": "Käänny jyrkästi oikeaan suuntana Destination 1",
         "fr": "Tourner franchement à droite en direction de Destination 1",
         "he": "פנה חדה ימינה לכיוון Destination 1",
         "id": "Belok tajam kanan menuju Destination 1",

--- a/test/fixtures/v5/end_of_road/sharp_right_exit.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu dekstregen direkte al Way Name",
         "es": "Gira a cerrada a la derecha en Way Name",
         "es-ES": "Al final de la calle gira cerrada a la derecha por Way Name",
+        "fi": "Käänny jyrkästi oikeaan tielle Way Name",
         "fr": "Tourner franchement à droite sur Way Name",
         "he": "פנה חדה ימינה על Way Name",
         "id": "Belok tajam kanan ke Way Name",

--- a/test/fixtures/v5/end_of_road/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu dekstregen direkte al Destination 1",
         "es": "Gira a cerrada a la derecha hacia Destination 1",
         "es-ES": "Al final de la calle gira cerrada a la derecha hacia Destination 1",
+        "fi": "Käänny jyrkästi oikeaan suuntana Destination 1",
         "fr": "Tourner franchement à droite en direction de Destination 1",
         "he": "פנה חדה ימינה לכיוון Destination 1",
         "id": "Belok tajam kanan menuju Destination 1",

--- a/test/fixtures/v5/end_of_road/sharp_right_name.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstregen direkte al Way Name",
         "es": "Gira a cerrada a la derecha en Way Name",
         "es-ES": "Al final de la calle gira cerrada a la derecha por Way Name",
+        "fi": "Käänny jyrkästi oikeaan tielle Way Name",
         "fr": "Tourner franchement à droite sur Way Name",
         "he": "פנה חדה ימינה על Way Name",
         "id": "Belok tajam kanan ke Way Name",

--- a/test/fixtures/v5/end_of_road/slight_left_default.json
+++ b/test/fixtures/v5/end_of_road/slight_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstreten",
         "es": "Gira a levemente a la izquierda",
         "es-ES": "Al final de la calle gira ligeramente a la izquierda",
+        "fi": "Käänny loivasti vasempaan",
         "fr": "Tourner légèrement à gauche",
         "he": "פנה קלה שמאלה",
         "id": "Belok agak ke kiri",

--- a/test/fixtures/v5/end_of_road/slight_left_destination.json
+++ b/test/fixtures/v5/end_of_road/slight_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu maldekstreten direkte al Destination 1",
         "es": "Gira a levemente a la izquierda hacia Destination 1",
         "es-ES": "Al final de la calle gira ligeramente a la izquierda hacia Destination 1",
+        "fi": "Käänny loivasti vasempaan suuntana Destination 1",
         "fr": "Tourner légèrement à gauche en direction de Destination 1",
         "he": "פנה קלה שמאלה לכיוון Destination 1",
         "id": "Belok agak ke kiri menuju Destination 1",

--- a/test/fixtures/v5/end_of_road/slight_left_exit.json
+++ b/test/fixtures/v5/end_of_road/slight_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu maldekstreten direkte al Way Name",
         "es": "Gira a levemente a la izquierda en Way Name",
         "es-ES": "Al final de la calle gira ligeramente a la izquierda por Way Name",
+        "fi": "Käänny loivasti vasempaan tielle Way Name",
         "fr": "Tourner légèrement à gauche sur Way Name",
         "he": "פנה קלה שמאלה על Way Name",
         "id": "Belok agak ke kiri ke Way Name",

--- a/test/fixtures/v5/end_of_road/slight_left_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/slight_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu maldekstreten direkte al Destination 1",
         "es": "Gira a levemente a la izquierda hacia Destination 1",
         "es-ES": "Al final de la calle gira ligeramente a la izquierda hacia Destination 1",
+        "fi": "Käänny loivasti vasempaan suuntana Destination 1",
         "fr": "Tourner légèrement à gauche en direction de Destination 1",
         "he": "פנה קלה שמאלה לכיוון Destination 1",
         "id": "Belok agak ke kiri menuju Destination 1",

--- a/test/fixtures/v5/end_of_road/slight_left_name.json
+++ b/test/fixtures/v5/end_of_road/slight_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstreten direkte al Way Name",
         "es": "Gira a levemente a la izquierda en Way Name",
         "es-ES": "Al final de la calle gira ligeramente a la izquierda por Way Name",
+        "fi": "Käänny loivasti vasempaan tielle Way Name",
         "fr": "Tourner légèrement à gauche sur Way Name",
         "he": "פנה קלה שמאלה על Way Name",
         "id": "Belok agak ke kiri ke Way Name",

--- a/test/fixtures/v5/end_of_road/slight_right_default.json
+++ b/test/fixtures/v5/end_of_road/slight_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstreten",
         "es": "Gira a levemente a la derecha",
         "es-ES": "Al final de la calle gira ligeramente a la derecha",
+        "fi": "Käänny loivasti oikeaan",
         "fr": "Tourner légèrement à droite",
         "he": "פנה קלה ימינה",
         "id": "Belok agak ke kanan",

--- a/test/fixtures/v5/end_of_road/slight_right_destination.json
+++ b/test/fixtures/v5/end_of_road/slight_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu dekstreten direkte al Destination 1",
         "es": "Gira a levemente a la derecha hacia Destination 1",
         "es-ES": "Al final de la calle gira ligeramente a la derecha hacia Destination 1",
+        "fi": "Käänny loivasti oikeaan suuntana Destination 1",
         "fr": "Tourner légèrement à droite en direction de Destination 1",
         "he": "פנה קלה ימינה לכיוון Destination 1",
         "id": "Belok agak ke kanan menuju Destination 1",

--- a/test/fixtures/v5/end_of_road/slight_right_exit.json
+++ b/test/fixtures/v5/end_of_road/slight_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu dekstreten direkte al Way Name",
         "es": "Gira a levemente a la derecha en Way Name",
         "es-ES": "Al final de la calle gira ligeramente a la derecha por Way Name",
+        "fi": "Käänny loivasti oikeaan tielle Way Name",
         "fr": "Tourner légèrement à droite sur Way Name",
         "he": "פנה קלה ימינה על Way Name",
         "id": "Belok agak ke kanan ke Way Name",

--- a/test/fixtures/v5/end_of_road/slight_right_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/slight_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu dekstreten direkte al Destination 1",
         "es": "Gira a levemente a la derecha hacia Destination 1",
         "es-ES": "Al final de la calle gira ligeramente a la derecha hacia Destination 1",
+        "fi": "Käänny loivasti oikeaan suuntana Destination 1",
         "fr": "Tourner légèrement à droite en direction de Destination 1",
         "he": "פנה קלה ימינה לכיוון Destination 1",
         "id": "Belok agak ke kanan menuju Destination 1",

--- a/test/fixtures/v5/end_of_road/slight_right_name.json
+++ b/test/fixtures/v5/end_of_road/slight_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstreten direkte al Way Name",
         "es": "Gira a levemente a la derecha en Way Name",
         "es-ES": "Al final de la calle gira ligeramente a la derecha por Way Name",
+        "fi": "Käänny loivasti oikeaan tielle Way Name",
         "fr": "Tourner légèrement à droite sur Way Name",
         "he": "פנה קלה ימינה על Way Name",
         "id": "Belok agak ke kanan ke Way Name",

--- a/test/fixtures/v5/end_of_road/straight_default.json
+++ b/test/fixtures/v5/end_of_road/straight_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu rekten",
         "es": "Continúa recto",
         "es-ES": "Al final de la calle continúa recto",
+        "fi": "Jatka suoraan eteenpäin",
         "fr": "Continuer tout droit",
         "he": "המשך ישר",
         "id": "Lurus terus",

--- a/test/fixtures/v5/end_of_road/straight_destination.json
+++ b/test/fixtures/v5/end_of_road/straight_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu rekten direkte al Destination 1",
         "es": "Continúa recto hacia Destination 1",
         "es-ES": "Al final de la calle continúa recto hacia Destination 1",
+        "fi": "Jatka suoraan eteenpäin suuntana Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "he": "המשך ישר לכיוון Destination 1",
         "id": "Tetap lurus menuju Destination 1",

--- a/test/fixtures/v5/end_of_road/straight_exit.json
+++ b/test/fixtures/v5/end_of_road/straight_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu rekten al Way Name",
         "es": "Continúa recto en Way Name",
         "es-ES": "Al final de la calle continúa recto por Way Name",
+        "fi": "Jatka suoraan eteenpäin tielle Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "he": "המשך ישר על Way Name",
         "id": "Tetap lurus ke Way Name ",

--- a/test/fixtures/v5/end_of_road/straight_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/straight_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu rekten direkte al Destination 1",
         "es": "Continúa recto hacia Destination 1",
         "es-ES": "Al final de la calle continúa recto hacia Destination 1",
+        "fi": "Jatka suoraan eteenpäin suuntana Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "he": "המשך ישר לכיוון Destination 1",
         "id": "Tetap lurus menuju Destination 1",

--- a/test/fixtures/v5/end_of_road/straight_name.json
+++ b/test/fixtures/v5/end_of_road/straight_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu rekten al Way Name",
         "es": "Continúa recto en Way Name",
         "es-ES": "Al final de la calle continúa recto por Way Name",
+        "fi": "Jatka suoraan eteenpäin tielle Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "he": "המשך ישר על Way Name",
         "id": "Tetap lurus ke Way Name ",

--- a/test/fixtures/v5/end_of_road/uturn_default.json
+++ b/test/fixtures/v5/end_of_road/uturn_default.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu malantaŭen ĉe fino de la vojo",
         "es": "Haz un cambio de sentido al final de la via",
         "es-ES": "Al final de la calle haz un cambio de sentido",
+        "fi": "Tien päässä tee U-käännös",
         "fr": "Faire demi-tour à la fin de la route",
         "he": "פנה פניית פרסה בסוף הדרך",
         "id": "Putar balik di akhir jalan",

--- a/test/fixtures/v5/end_of_road/uturn_destination.json
+++ b/test/fixtures/v5/end_of_road/uturn_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu malantaŭen direkte al Destination 1 ĉe fino de la vojo",
         "es": "Haz un cambio de sentido hacia Destination 1 al final de la via",
         "es-ES": "Al final de la calle haz un cambio de sentido hacia Destination 1",
+        "fi": "Tien päässä tee U-käännös suuntana Destination 1",
         "fr": "Faire demi-tour à la fin de la route en direction de Destination 1",
         "he": "פנה פניית פרסה לכיוון Destination 1 בסוף הדרך",
         "id": "Putar balik menuju Destination 1 di akhir jalan",

--- a/test/fixtures/v5/end_of_road/uturn_exit.json
+++ b/test/fixtures/v5/end_of_road/uturn_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu malantaŭen al Way Name ĉe fino de la vojo",
         "es": "Haz un cambio de sentido en Way Name al final de la via",
         "es-ES": "Al final de la calle haz un cambio de sentido en Way Name",
+        "fi": "Tien päässä tee U-käännös tielle Way Name",
         "fr": "Faire demi-tour à la fin de la route Way Name",
         "he": "פנה פניית פרסה על Way Name בסוף הדרך",
         "id": "Putar balik di Way Name di akhir jalan",

--- a/test/fixtures/v5/end_of_road/uturn_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/uturn_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu malantaŭen direkte al Destination 1 ĉe fino de la vojo",
         "es": "Haz un cambio de sentido hacia Destination 1 al final de la via",
         "es-ES": "Al final de la calle haz un cambio de sentido hacia Destination 1",
+        "fi": "Tien päässä tee U-käännös suuntana Destination 1",
         "fr": "Faire demi-tour à la fin de la route en direction de Destination 1",
         "he": "פנה פניית פרסה לכיוון Destination 1 בסוף הדרך",
         "id": "Putar balik menuju Destination 1 di akhir jalan",

--- a/test/fixtures/v5/end_of_road/uturn_name.json
+++ b/test/fixtures/v5/end_of_road/uturn_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu malantaŭen al Way Name ĉe fino de la vojo",
         "es": "Haz un cambio de sentido en Way Name al final de la via",
         "es-ES": "Al final de la calle haz un cambio de sentido en Way Name",
+        "fi": "Tien päässä tee U-käännös tielle Way Name",
         "fr": "Faire demi-tour à la fin de la route Way Name",
         "he": "פנה פניית פרסה על Way Name בסוף הדרך",
         "id": "Putar balik di Way Name di akhir jalan",

--- a/test/fixtures/v5/exit_rotary/left_default.json
+++ b/test/fixtures/v5/exit_rotary/left_default.json
@@ -14,6 +14,7 @@
         "eo": "Eliru trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",
+        "fi": "Poistu liikenneympyrästä",
         "fr": "Sortir du rond-point",
         "he": "צא ממעגל התנועה",
         "id": "Belok kiri",

--- a/test/fixtures/v5/exit_rotary/left_destination.json
+++ b/test/fixtures/v5/exit_rotary/left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Belok kiri menuju Destination 1",

--- a/test/fixtures/v5/exit_rotary/left_exit.json
+++ b/test/fixtures/v5/exit_rotary/left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Belok kiri ke Way Name",

--- a/test/fixtures/v5/exit_rotary/left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Belok kiri menuju Destination 1",

--- a/test/fixtures/v5/exit_rotary/left_name.json
+++ b/test/fixtures/v5/exit_rotary/left_name.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Belok kiri ke Way Name",

--- a/test/fixtures/v5/exit_rotary/right_default.json
+++ b/test/fixtures/v5/exit_rotary/right_default.json
@@ -14,6 +14,7 @@
         "eo": "Eliru trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",
+        "fi": "Poistu liikenneympyrästä",
         "fr": "Sortir du rond-point",
         "he": "צא ממעגל התנועה",
         "id": "Belok kanan",

--- a/test/fixtures/v5/exit_rotary/right_destination.json
+++ b/test/fixtures/v5/exit_rotary/right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Belok kanan menuju Destination 1",

--- a/test/fixtures/v5/exit_rotary/right_exit.json
+++ b/test/fixtures/v5/exit_rotary/right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Belok kanan ke Way Name",

--- a/test/fixtures/v5/exit_rotary/right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Belok kanan menuju Destination 1",

--- a/test/fixtures/v5/exit_rotary/right_name.json
+++ b/test/fixtures/v5/exit_rotary/right_name.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Belok kanan ke Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_left_default.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Eliru trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",
+        "fi": "Poistu liikenneympyrästä",
         "fr": "Sortir du rond-point",
         "he": "צא ממעגל התנועה",
         "id": "Lakukan tajam kiri",

--- a/test/fixtures/v5/exit_rotary/sharp_left_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan tajam kiri menuju Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_left_exit.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan tajam kiri ke arah Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan tajam kiri menuju Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_left_name.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan tajam kiri ke arah Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_right_default.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Eliru trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",
+        "fi": "Poistu liikenneympyrästä",
         "fr": "Sortir du rond-point",
         "he": "צא ממעגל התנועה",
         "id": "Lakukan tajam kanan",

--- a/test/fixtures/v5/exit_rotary/sharp_right_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan tajam kanan menuju Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_right_exit.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan tajam kanan ke arah Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan tajam kanan menuju Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_right_name.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan tajam kanan ke arah Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_left_default.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Eliru trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",
+        "fi": "Poistu liikenneympyrästä",
         "fr": "Sortir du rond-point",
         "he": "צא ממעגל התנועה",
         "id": "Lakukan agak ke kiri",

--- a/test/fixtures/v5/exit_rotary/slight_left_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan agak ke kiri menuju Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_left_exit.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan agak ke kiri ke arah Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan agak ke kiri menuju Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_left_name.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan agak ke kiri ke arah Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_right_default.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Eliru trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",
+        "fi": "Poistu liikenneympyrästä",
         "fr": "Sortir du rond-point",
         "he": "צא ממעגל התנועה",
         "id": "Lakukan agak ke kanan",

--- a/test/fixtures/v5/exit_rotary/slight_right_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan agak ke kanan menuju Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_right_exit.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan agak ke kanan ke arah Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan agak ke kanan menuju Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_right_name.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan agak ke kanan ke arah Way Name",

--- a/test/fixtures/v5/exit_rotary/straight_default.json
+++ b/test/fixtures/v5/exit_rotary/straight_default.json
@@ -14,6 +14,7 @@
         "eo": "Eliru trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",
+        "fi": "Poistu liikenneympyrästä",
         "fr": "Sortir du rond-point",
         "he": "צא ממעגל התנועה",
         "id": "Lurus",

--- a/test/fixtures/v5/exit_rotary/straight_destination.json
+++ b/test/fixtures/v5/exit_rotary/straight_destination.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lurus menuju Destination 1",

--- a/test/fixtures/v5/exit_rotary/straight_exit.json
+++ b/test/fixtures/v5/exit_rotary/straight_exit.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lurus arah Way Name",

--- a/test/fixtures/v5/exit_rotary/straight_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/straight_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lurus menuju Destination 1",

--- a/test/fixtures/v5/exit_rotary/straight_name.json
+++ b/test/fixtures/v5/exit_rotary/straight_name.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lurus arah Way Name",

--- a/test/fixtures/v5/exit_rotary/uturn_default.json
+++ b/test/fixtures/v5/exit_rotary/uturn_default.json
@@ -14,6 +14,7 @@
         "eo": "Eliru trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",
+        "fi": "Poistu liikenneympyrästä",
         "fr": "Sortir du rond-point",
         "he": "צא ממעגל התנועה",
         "id": "Lakukan putar balik",

--- a/test/fixtures/v5/exit_rotary/uturn_destination.json
+++ b/test/fixtures/v5/exit_rotary/uturn_destination.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan putar balik menuju Destination 1",

--- a/test/fixtures/v5/exit_rotary/uturn_exit.json
+++ b/test/fixtures/v5/exit_rotary/uturn_exit.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan putar balik ke arah Way Name",

--- a/test/fixtures/v5/exit_rotary/uturn_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/uturn_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan putar balik menuju Destination 1",

--- a/test/fixtures/v5/exit_rotary/uturn_name.json
+++ b/test/fixtures/v5/exit_rotary/uturn_name.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan putar balik ke arah Way Name",

--- a/test/fixtures/v5/exit_roundabout/left_default.json
+++ b/test/fixtures/v5/exit_roundabout/left_default.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",
+        "fi": "Poistu liikenneympyrästä",
         "fr": "Sortir du rond-point",
         "he": "צא ממעגל התנועה",
         "id": "Belok kiri",

--- a/test/fixtures/v5/exit_roundabout/left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Belok kiri menuju Destination 1",

--- a/test/fixtures/v5/exit_roundabout/left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Belok kiri ke Way Name",

--- a/test/fixtures/v5/exit_roundabout/left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Belok kiri menuju Destination 1",

--- a/test/fixtures/v5/exit_roundabout/left_name.json
+++ b/test/fixtures/v5/exit_roundabout/left_name.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Belok kiri ke Way Name",

--- a/test/fixtures/v5/exit_roundabout/right_default.json
+++ b/test/fixtures/v5/exit_roundabout/right_default.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",
+        "fi": "Poistu liikenneympyrästä",
         "fr": "Sortir du rond-point",
         "he": "צא ממעגל התנועה",
         "id": "Belok kanan",

--- a/test/fixtures/v5/exit_roundabout/right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Belok kanan menuju Destination 1",

--- a/test/fixtures/v5/exit_roundabout/right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Belok kanan ke Way Name",

--- a/test/fixtures/v5/exit_roundabout/right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Belok kanan menuju Destination 1",

--- a/test/fixtures/v5/exit_roundabout/right_name.json
+++ b/test/fixtures/v5/exit_roundabout/right_name.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Belok kanan ke Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_default.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",
+        "fi": "Poistu liikenneympyrästä",
         "fr": "Sortir du rond-point",
         "he": "צא ממעגל התנועה",
         "id": "Lakukan tajam kiri",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan tajam kiri menuju Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan tajam kiri ke arah Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan tajam kiri menuju Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_name.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan tajam kiri ke arah Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_default.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",
+        "fi": "Poistu liikenneympyrästä",
         "fr": "Sortir du rond-point",
         "he": "צא ממעגל התנועה",
         "id": "Lakukan tajam kanan",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan tajam kanan menuju Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan tajam kanan ke arah Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan tajam kanan menuju Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_name.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan tajam kanan ke arah Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_left_default.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",
+        "fi": "Poistu liikenneympyrästä",
         "fr": "Sortir du rond-point",
         "he": "צא ממעגל התנועה",
         "id": "Lakukan agak ke kiri",

--- a/test/fixtures/v5/exit_roundabout/slight_left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan agak ke kiri menuju Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan agak ke kiri ke arah Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan agak ke kiri menuju Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_left_name.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan agak ke kiri ke arah Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_right_default.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",
+        "fi": "Poistu liikenneympyrästä",
         "fr": "Sortir du rond-point",
         "he": "צא ממעגל התנועה",
         "id": "Lakukan agak ke kanan",

--- a/test/fixtures/v5/exit_roundabout/slight_right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan agak ke kanan menuju Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan agak ke kanan ke arah Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan agak ke kanan menuju Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_right_name.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan agak ke kanan ke arah Way Name",

--- a/test/fixtures/v5/exit_roundabout/straight_default.json
+++ b/test/fixtures/v5/exit_roundabout/straight_default.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",
+        "fi": "Poistu liikenneympyrästä",
         "fr": "Sortir du rond-point",
         "he": "צא ממעגל התנועה",
         "id": "Lurus terus",

--- a/test/fixtures/v5/exit_roundabout/straight_destination.json
+++ b/test/fixtures/v5/exit_roundabout/straight_destination.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Tetap lurus menuju Destination 1",

--- a/test/fixtures/v5/exit_roundabout/straight_exit.json
+++ b/test/fixtures/v5/exit_roundabout/straight_exit.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Tetap lurus ke Way Name ",

--- a/test/fixtures/v5/exit_roundabout/straight_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/straight_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Tetap lurus menuju Destination 1",

--- a/test/fixtures/v5/exit_roundabout/straight_name.json
+++ b/test/fixtures/v5/exit_roundabout/straight_name.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Tetap lurus ke Way Name ",

--- a/test/fixtures/v5/exit_roundabout/uturn_default.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_default.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",
+        "fi": "Poistu liikenneympyrästä",
         "fr": "Sortir du rond-point",
         "he": "צא ממעגל התנועה",
         "id": "Lakukan putar balik",

--- a/test/fixtures/v5/exit_roundabout/uturn_destination.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_destination.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan putar balik menuju Destination 1",

--- a/test/fixtures/v5/exit_roundabout/uturn_exit.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_exit.json
@@ -15,6 +15,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan putar balik ke arah Way Name",

--- a/test/fixtures/v5/exit_roundabout/uturn_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",
+        "fi": "Poistu liikenneympyrästä suuntana Destination 1",
         "fr": "Sortir du rond-point en direction de Destination 1",
         "he": "צא ממעגל התנועה לכיוון Destination 1",
         "id": "Lakukan putar balik menuju Destination 1",

--- a/test/fixtures/v5/exit_roundabout/uturn_name.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_name.json
@@ -14,6 +14,7 @@
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
         "fr": "Sortir du rond-point sur Way Name",
         "he": "צא ממעגל התנועה לWay Name",
         "id": "Lakukan putar balik ke arah Way Name",

--- a/test/fixtures/v5/fork/left_default.json
+++ b/test/fixtures/v5/fork/left_default.json
@@ -14,6 +14,7 @@
         "eo": "Daŭru maldekstren ĉe la vojforko",
         "es": "Mantente izquierda en el cruza",
         "es-ES": "Mantente a la izquierda en el cruce",
+        "fi": "Jatka tienhaarassa vasemmall(e/a)",
         "fr": "Rester à gauche à l’embranchement",
         "he": "היצמד שמאלה בהתפצלות",
         "id": "Tetap kiri di pertigaan",

--- a/test/fixtures/v5/fork/left_destination.json
+++ b/test/fixtures/v5/fork/left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Pluu maldekstren direkte al Destination 1",
         "es": "Mantente izquierda hacia Destination 1",
         "es-ES": "Mantente a la izquierda hacia Destination 1",
+        "fi": "Jatka vasemmall(e/a) suuntana Destination 1",
         "fr": "Rester à gauche à l’embranchement en direction de Destination 1",
         "he": "היצמד שמאלה לכיוון Destination 1",
         "id": "Tetap kiri di pertigaan menuju Destination 1",

--- a/test/fixtures/v5/fork/left_exit.json
+++ b/test/fixtures/v5/fork/left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Pluu maldekstren al Way Name",
         "es": "Mantente izquierda en Way Name",
         "es-ES": "Mantente a la izquierda por Way Name",
+        "fi": "Jatka vasemmall(e/a) tielle Way Name",
         "fr": "Rester à gauche à l’embranchement sur Way Name",
         "he": "היצמד שמאלה על Way Name",
         "id": "Tetap kiri di pertigaan ke Way Name",

--- a/test/fixtures/v5/fork/left_exit_destination.json
+++ b/test/fixtures/v5/fork/left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Pluu maldekstren direkte al Destination 1",
         "es": "Mantente izquierda hacia Destination 1",
         "es-ES": "Mantente a la izquierda hacia Destination 1",
+        "fi": "Jatka vasemmall(e/a) suuntana Destination 1",
         "fr": "Rester à gauche à l’embranchement en direction de Destination 1",
         "he": "היצמד שמאלה לכיוון Destination 1",
         "id": "Tetap kiri di pertigaan menuju Destination 1",

--- a/test/fixtures/v5/fork/left_name.json
+++ b/test/fixtures/v5/fork/left_name.json
@@ -14,6 +14,7 @@
         "eo": "Pluu maldekstren al Way Name",
         "es": "Mantente izquierda en Way Name",
         "es-ES": "Mantente a la izquierda por Way Name",
+        "fi": "Jatka vasemmall(e/a) tielle Way Name",
         "fr": "Rester à gauche à l’embranchement sur Way Name",
         "he": "היצמד שמאלה על Way Name",
         "id": "Tetap kiri di pertigaan ke Way Name",

--- a/test/fixtures/v5/fork/right_default.json
+++ b/test/fixtures/v5/fork/right_default.json
@@ -14,6 +14,7 @@
         "eo": "Daŭru dekstren ĉe la vojforko",
         "es": "Mantente derecha en el cruza",
         "es-ES": "Mantente a la derecha en el cruce",
+        "fi": "Jatka tienhaarassa oikeall(e/a)",
         "fr": "Rester à droite à l’embranchement",
         "he": "היצמד ימינה בהתפצלות",
         "id": "Tetap kanan di pertigaan",

--- a/test/fixtures/v5/fork/right_destination.json
+++ b/test/fixtures/v5/fork/right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Pluu dekstren direkte al Destination 1",
         "es": "Mantente derecha hacia Destination 1",
         "es-ES": "Mantente a la derecha hacia Destination 1",
+        "fi": "Jatka oikeall(e/a) suuntana Destination 1",
         "fr": "Rester à droite à l’embranchement en direction de Destination 1",
         "he": "היצמד ימינה לכיוון Destination 1",
         "id": "Tetap kanan di pertigaan menuju Destination 1",

--- a/test/fixtures/v5/fork/right_exit.json
+++ b/test/fixtures/v5/fork/right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Pluu dekstren al Way Name",
         "es": "Mantente derecha en Way Name",
         "es-ES": "Mantente a la derecha por Way Name",
+        "fi": "Jatka oikeall(e/a) tielle Way Name",
         "fr": "Rester à droite à l’embranchement sur Way Name",
         "he": "היצמד ימינה על Way Name",
         "id": "Tetap kanan di pertigaan ke Way Name",

--- a/test/fixtures/v5/fork/right_exit_destination.json
+++ b/test/fixtures/v5/fork/right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Pluu dekstren direkte al Destination 1",
         "es": "Mantente derecha hacia Destination 1",
         "es-ES": "Mantente a la derecha hacia Destination 1",
+        "fi": "Jatka oikeall(e/a) suuntana Destination 1",
         "fr": "Rester à droite à l’embranchement en direction de Destination 1",
         "he": "היצמד ימינה לכיוון Destination 1",
         "id": "Tetap kanan di pertigaan menuju Destination 1",

--- a/test/fixtures/v5/fork/right_name.json
+++ b/test/fixtures/v5/fork/right_name.json
@@ -14,6 +14,7 @@
         "eo": "Pluu dekstren al Way Name",
         "es": "Mantente derecha en Way Name",
         "es-ES": "Mantente a la derecha por Way Name",
+        "fi": "Jatka oikeall(e/a) tielle Way Name",
         "fr": "Rester à droite à l’embranchement sur Way Name",
         "he": "היצמד ימינה על Way Name",
         "id": "Tetap kanan di pertigaan ke Way Name",

--- a/test/fixtures/v5/fork/sharp_left_default.json
+++ b/test/fixtures/v5/fork/sharp_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Ege maldekstren ĉe la vojforko",
         "es": "Gira a la izquierda en el cruza",
         "es-ES": "Gira la izquierda en el cruce",
+        "fi": "Käänny tienhaarassa jyrkästi vasempaan",
         "fr": "Prendre franchement à gauche à l’embranchement",
         "he": "פנה בחדות שמאלה בהתפצלות",
         "id": "Belok kiri pada pertigaan",

--- a/test/fixtures/v5/fork/sharp_left_destination.json
+++ b/test/fixtures/v5/fork/sharp_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu ege maldekstren direkte al Destination 1",
         "es": "Gira a la izquierda hacia Destination 1",
         "es-ES": "Gira a la izquierda hacia Destination 1",
+        "fi": "Käänny tienhaarassa jyrkästi vasempaan suuntana Destination 1",
         "fr": "Prendre franchement à gauche en direction de Destination 1",
         "he": "פנה בחדות שמאלה לכיוון Destination 1",
         "id": "Belok kiri tajam menuju Destination 1",

--- a/test/fixtures/v5/fork/sharp_left_exit.json
+++ b/test/fixtures/v5/fork/sharp_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu ege maldekstren al Way Name",
         "es": "Gira a la izquierda en Way Name",
         "es-ES": "Gira a la izquierda por Way Name",
+        "fi": "Käänny tienhaarassa jyrkästi vasempaan tielle Way Name",
         "fr": "Prendre franchement à gauche sur Way Name",
         "he": "פנה בחדות שמאלה על Way Name",
         "id": "Belok kiri tajam ke arah Way Name",

--- a/test/fixtures/v5/fork/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/fork/sharp_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu ege maldekstren direkte al Destination 1",
         "es": "Gira a la izquierda hacia Destination 1",
         "es-ES": "Gira a la izquierda hacia Destination 1",
+        "fi": "Käänny tienhaarassa jyrkästi vasempaan suuntana Destination 1",
         "fr": "Prendre franchement à gauche en direction de Destination 1",
         "he": "פנה בחדות שמאלה לכיוון Destination 1",
         "id": "Belok kiri tajam menuju Destination 1",

--- a/test/fixtures/v5/fork/sharp_left_name.json
+++ b/test/fixtures/v5/fork/sharp_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ege maldekstren al Way Name",
         "es": "Gira a la izquierda en Way Name",
         "es-ES": "Gira a la izquierda por Way Name",
+        "fi": "Käänny tienhaarassa jyrkästi vasempaan tielle Way Name",
         "fr": "Prendre franchement à gauche sur Way Name",
         "he": "פנה בחדות שמאלה על Way Name",
         "id": "Belok kiri tajam ke arah Way Name",

--- a/test/fixtures/v5/fork/sharp_right_default.json
+++ b/test/fixtures/v5/fork/sharp_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Ege dekstren ĉe la vojforko",
         "es": "Gira a la derecha en el cruza",
         "es-ES": "Gira a la derecha en el cruce",
+        "fi": "Käänny tienhaarassa jyrkästi oikeaan",
         "fr": "Prendre franchement à droite à l’embranchement",
         "he": "פנה בחדות ימינה בהתפצלות",
         "id": "Belok kanan pada pertigaan",

--- a/test/fixtures/v5/fork/sharp_right_destination.json
+++ b/test/fixtures/v5/fork/sharp_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu ege dekstren direkte al Destination 1",
         "es": "Gira a la derecha hacia Destination 1",
         "es-ES": "Gira a la derecha hacia Destination 1",
+        "fi": "Käänny tienhaarassa jyrkästi oikeaan suuntana Destination 1",
         "fr": "Prendre franchement à droite en direction de Destination 1",
         "he": "פנה בחדות ימינה לכיוון Destination 1",
         "id": "Belok kanan tajam menuju Destination 1",

--- a/test/fixtures/v5/fork/sharp_right_exit.json
+++ b/test/fixtures/v5/fork/sharp_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu ege dekstren al Way Name",
         "es": "Gira a la derecha en Way Name",
         "es-ES": "Gira a la derecha por Way Name",
+        "fi": "Käänny tienhaarassa jyrkästi oikeaan tielle Way Name",
         "fr": "Prendre franchement à droite sur Way Name",
         "he": "פנה בחדות ימינה על Way Name",
         "id": "Belok kanan tajam ke arah Way Name",

--- a/test/fixtures/v5/fork/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/fork/sharp_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu ege dekstren direkte al Destination 1",
         "es": "Gira a la derecha hacia Destination 1",
         "es-ES": "Gira a la derecha hacia Destination 1",
+        "fi": "Käänny tienhaarassa jyrkästi oikeaan suuntana Destination 1",
         "fr": "Prendre franchement à droite en direction de Destination 1",
         "he": "פנה בחדות ימינה לכיוון Destination 1",
         "id": "Belok kanan tajam menuju Destination 1",

--- a/test/fixtures/v5/fork/sharp_right_name.json
+++ b/test/fixtures/v5/fork/sharp_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ege dekstren al Way Name",
         "es": "Gira a la derecha en Way Name",
         "es-ES": "Gira a la derecha por Way Name",
+        "fi": "Käänny tienhaarassa jyrkästi oikeaan tielle Way Name",
         "fr": "Prendre franchement à droite sur Way Name",
         "he": "פנה בחדות ימינה על Way Name",
         "id": "Belok kanan tajam ke arah Way Name",

--- a/test/fixtures/v5/fork/slight_left_default.json
+++ b/test/fixtures/v5/fork/slight_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Maldekstren ĉe la vojforko",
         "es": "Mantente a la izquierda en el cruza",
         "es-ES": "Mantente a la izquierda en el cruce",
+        "fi": "Pysy vasemmalla tienhaarassa",
         "fr": "Rester à gauche à l’embranchement",
         "he": "היצמד לשמאל בהתפצלות",
         "id": "Tetap di kiri pada pertigaan",

--- a/test/fixtures/v5/fork/slight_left_destination.json
+++ b/test/fixtures/v5/fork/slight_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Pluu maldekstren direkte al Destination 1",
         "es": "Mantente a la izquierda hacia Destination 1",
         "es-ES": "Mantente a la izquierda hacia Destination 1",
+        "fi": "Pysy vasemmalla suuntana Destination 1",
         "fr": "Rester à gauche à l’embranchement en direction de Destination 1",
         "he": "היצמד לשמאל לכיוון Destination 1",
         "id": "Tetap di kiri pada pertigaan menuju Destination 1",

--- a/test/fixtures/v5/fork/slight_left_exit.json
+++ b/test/fixtures/v5/fork/slight_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Pluu maldekstren al Way Name",
         "es": "Mantente a la izquierda en Way Name",
         "es-ES": "Mantente a la izquierda por Way Name",
+        "fi": "Pysy vasemmalla tielle Way Name",
         "fr": "Rester à gauche à l’embranchement sur Way Name",
         "he": "היצמד לשמאל על Way Name",
         "id": "Tetap di kiri pada pertigaan ke arah Way Name",

--- a/test/fixtures/v5/fork/slight_left_exit_destination.json
+++ b/test/fixtures/v5/fork/slight_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Pluu maldekstren direkte al Destination 1",
         "es": "Mantente a la izquierda hacia Destination 1",
         "es-ES": "Mantente a la izquierda hacia Destination 1",
+        "fi": "Pysy vasemmalla suuntana Destination 1",
         "fr": "Rester à gauche à l’embranchement en direction de Destination 1",
         "he": "היצמד לשמאל לכיוון Destination 1",
         "id": "Tetap di kiri pada pertigaan menuju Destination 1",

--- a/test/fixtures/v5/fork/slight_left_name.json
+++ b/test/fixtures/v5/fork/slight_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Pluu maldekstren al Way Name",
         "es": "Mantente a la izquierda en Way Name",
         "es-ES": "Mantente a la izquierda por Way Name",
+        "fi": "Pysy vasemmalla tielle Way Name",
         "fr": "Rester à gauche à l’embranchement sur Way Name",
         "he": "היצמד לשמאל על Way Name",
         "id": "Tetap di kiri pada pertigaan ke arah Way Name",

--- a/test/fixtures/v5/fork/slight_right_default.json
+++ b/test/fixtures/v5/fork/slight_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Dekstren ĉe la vojforko",
         "es": "Mantente a la derecha en el cruza",
         "es-ES": "Mantente a la derecha en el cruce",
+        "fi": "Pysy oikealla tienhaarassa",
         "fr": "Rester à droite à l’embranchement",
         "he": "היצמד ימינה בהתפצלות",
         "id": "Tetap di kanan pada pertigaan",

--- a/test/fixtures/v5/fork/slight_right_destination.json
+++ b/test/fixtures/v5/fork/slight_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Pluu dekstren direkte al Destination 1",
         "es": "Mantente a la derecha hacia Destination 1",
         "es-ES": "Mantente a la derecha hacia Destination 1",
+        "fi": "Pysy oikealla suuntana Destination 1",
         "fr": "Rester à droite à l’embranchement en direction de Destination 1",
         "he": "היצמד לימין לכיוון Destination 1",
         "id": "Tetap di kanan pada pertigaan menuju Destination 1",

--- a/test/fixtures/v5/fork/slight_right_exit.json
+++ b/test/fixtures/v5/fork/slight_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Pluu dekstren al Way Name",
         "es": "Mantente a la derecha en Way Name",
         "es-ES": "Mantente a la derecha por Way Name",
+        "fi": "Pysy oikealla tielle Way Name",
         "fr": "Rester à droite à l’embranchement sur Way Name",
         "he": "היצמד לימין על Way Name",
         "id": "Tetap di kanan pada pertigaan ke arah Way Name",

--- a/test/fixtures/v5/fork/slight_right_exit_destination.json
+++ b/test/fixtures/v5/fork/slight_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Pluu dekstren direkte al Destination 1",
         "es": "Mantente a la derecha hacia Destination 1",
         "es-ES": "Mantente a la derecha hacia Destination 1",
+        "fi": "Pysy oikealla suuntana Destination 1",
         "fr": "Rester à droite à l’embranchement en direction de Destination 1",
         "he": "היצמד לימין לכיוון Destination 1",
         "id": "Tetap di kanan pada pertigaan menuju Destination 1",

--- a/test/fixtures/v5/fork/slight_right_name.json
+++ b/test/fixtures/v5/fork/slight_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Pluu dekstren al Way Name",
         "es": "Mantente a la derecha en Way Name",
         "es-ES": "Mantente a la derecha por Way Name",
+        "fi": "Pysy oikealla tielle Way Name",
         "fr": "Rester à droite à l’embranchement sur Way Name",
         "he": "היצמד לימין על Way Name",
         "id": "Tetap di kanan pada pertigaan ke arah Way Name",

--- a/test/fixtures/v5/fork/straight_default.json
+++ b/test/fixtures/v5/fork/straight_default.json
@@ -14,6 +14,7 @@
         "eo": "Daŭru rekten ĉe la vojforko",
         "es": "Mantente recto en el cruza",
         "es-ES": "Mantente recto en el cruce",
+        "fi": "Jatka tienhaarassa suoraan eteenpäin",
         "fr": "Rester tout droit à l’embranchement",
         "he": "היצמד ישר בהתפצלות",
         "id": "Tetap lurus di pertigaan",

--- a/test/fixtures/v5/fork/straight_destination.json
+++ b/test/fixtures/v5/fork/straight_destination.json
@@ -15,6 +15,7 @@
         "eo": "Pluu rekten direkte al Destination 1",
         "es": "Mantente recto hacia Destination 1",
         "es-ES": "Mantente recto hacia Destination 1",
+        "fi": "Jatka suoraan eteenpäin suuntana Destination 1",
         "fr": "Rester tout droit à l’embranchement en direction de Destination 1",
         "he": "היצמד ישר לכיוון Destination 1",
         "id": "Tetap lurus di pertigaan menuju Destination 1",

--- a/test/fixtures/v5/fork/straight_exit.json
+++ b/test/fixtures/v5/fork/straight_exit.json
@@ -15,6 +15,7 @@
         "eo": "Pluu rekten al Way Name",
         "es": "Mantente recto en Way Name",
         "es-ES": "Mantente recto por Way Name",
+        "fi": "Jatka suoraan eteenpäin tielle Way Name",
         "fr": "Rester tout droit à l’embranchement sur Way Name",
         "he": "היצמד ישר על Way Name",
         "id": "Tetap lurus di pertigaan ke Way Name",

--- a/test/fixtures/v5/fork/straight_exit_destination.json
+++ b/test/fixtures/v5/fork/straight_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Pluu rekten direkte al Destination 1",
         "es": "Mantente recto hacia Destination 1",
         "es-ES": "Mantente recto hacia Destination 1",
+        "fi": "Jatka suoraan eteenpäin suuntana Destination 1",
         "fr": "Rester tout droit à l’embranchement en direction de Destination 1",
         "he": "היצמד ישר לכיוון Destination 1",
         "id": "Tetap lurus di pertigaan menuju Destination 1",

--- a/test/fixtures/v5/fork/straight_name.json
+++ b/test/fixtures/v5/fork/straight_name.json
@@ -14,6 +14,7 @@
         "eo": "Pluu rekten al Way Name",
         "es": "Mantente recto en Way Name",
         "es-ES": "Mantente recto por Way Name",
+        "fi": "Jatka suoraan eteenpäin tielle Way Name",
         "fr": "Rester tout droit à l’embranchement sur Way Name",
         "he": "היצמד ישר על Way Name",
         "id": "Tetap lurus di pertigaan ke Way Name",

--- a/test/fixtures/v5/fork/uturn_default.json
+++ b/test/fixtures/v5/fork/uturn_default.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu malantaŭen",
         "es": "Haz un cambio de sentido",
         "es-ES": "Haz un cambio de sentido",
+        "fi": "Tee U-käännös",
         "fr": "Faire demi-tour",
         "he": "פנה פניית פרסה",
         "id": "Putar balik",

--- a/test/fixtures/v5/fork/uturn_destination.json
+++ b/test/fixtures/v5/fork/uturn_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu malantaŭen direkte al Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
         "es-ES": "Haz un cambio de sentido hacia Destination 1",
+        "fi": "Tee U-käännös suuntana Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "he": "פנה פניית פרסה לכיוון Destination 1",
         "id": "Putar balik menuju Destination 1",

--- a/test/fixtures/v5/fork/uturn_exit.json
+++ b/test/fixtures/v5/fork/uturn_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu malantaŭen al Way Name",
         "es": "Haz un cambio de sentido en Way Name",
         "es-ES": "Haz un cambio de sentido en Way Name",
+        "fi": "Tee U-käännös tielle Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "he": "פנה פניית פרסה על Way Name",
         "id": "Putar balik ke arah Way Name",

--- a/test/fixtures/v5/fork/uturn_exit_destination.json
+++ b/test/fixtures/v5/fork/uturn_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu malantaŭen direkte al Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
         "es-ES": "Haz un cambio de sentido hacia Destination 1",
+        "fi": "Tee U-käännös suuntana Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "he": "פנה פניית פרסה לכיוון Destination 1",
         "id": "Putar balik menuju Destination 1",

--- a/test/fixtures/v5/fork/uturn_name.json
+++ b/test/fixtures/v5/fork/uturn_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu malantaŭen al Way Name",
         "es": "Haz un cambio de sentido en Way Name",
         "es-ES": "Haz un cambio de sentido en Way Name",
+        "fi": "Tee U-käännös tielle Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "he": "פנה פניית פרסה על Way Name",
         "id": "Putar balik ke arah Way Name",

--- a/test/fixtures/v5/merge/left_default.json
+++ b/test/fixtures/v5/merge/left_default.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu maldekstren",
         "es": "Incorpórate a izquierda",
         "es-ES": "Incorpórate a la izquierda",
+        "fi": "Liity vasemmall(e/a)",
         "fr": "Rejoindre à gauche",
         "he": "השתלב שמאלה",
         "id": "Bergabung kiri",

--- a/test/fixtures/v5/merge/left_destination.json
+++ b/test/fixtures/v5/merge/left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu maldekstren direkte al Destination 1",
         "es": "Incorpórate a izquierda hacia Destination 1",
         "es-ES": "Incorpórate a la izquierda hacia Destination 1",
+        "fi": "Liity vasemmall(e/a), suuntana Destination 1",
         "fr": "Rejoindre à gauche en direction de Destination 1",
         "he": "השתלב שמאלה לכיוון Destination 1",
         "id": "Bergabung kiri menuju Destination 1",

--- a/test/fixtures/v5/merge/left_exit.json
+++ b/test/fixtures/v5/merge/left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu maldekstren al Way Name",
         "es": "Incorpórate a izquierda en Way Name",
         "es-ES": "Incorpórate a la izquierda por Way Name",
+        "fi": "Liity vasemmall(e/a), tielle Way Name",
         "fr": "Rejoindre à gauche sur Way Name",
         "he": "השתלב שמאלה על Way Name",
         "id": "Bergabung kiri ke arah Way Name",

--- a/test/fixtures/v5/merge/left_exit_destination.json
+++ b/test/fixtures/v5/merge/left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Enveturu maldekstren direkte al Destination 1",
         "es": "Incorpórate a izquierda hacia Destination 1",
         "es-ES": "Incorpórate a la izquierda hacia Destination 1",
+        "fi": "Liity vasemmall(e/a), suuntana Destination 1",
         "fr": "Rejoindre à gauche en direction de Destination 1",
         "he": "השתלב שמאלה לכיוון Destination 1",
         "id": "Bergabung kiri menuju Destination 1",

--- a/test/fixtures/v5/merge/left_name.json
+++ b/test/fixtures/v5/merge/left_name.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu maldekstren al Way Name",
         "es": "Incorpórate a izquierda en Way Name",
         "es-ES": "Incorpórate a la izquierda por Way Name",
+        "fi": "Liity vasemmall(e/a), tielle Way Name",
         "fr": "Rejoindre à gauche sur Way Name",
         "he": "השתלב שמאלה על Way Name",
         "id": "Bergabung kiri ke arah Way Name",

--- a/test/fixtures/v5/merge/right_default.json
+++ b/test/fixtures/v5/merge/right_default.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu dekstren",
         "es": "Incorpórate a derecha",
         "es-ES": "Incorpórate a la derecha",
+        "fi": "Liity oikeall(e/a)",
         "fr": "Rejoindre à droite",
         "he": "השתלב ימינה",
         "id": "Bergabung kanan",

--- a/test/fixtures/v5/merge/right_destination.json
+++ b/test/fixtures/v5/merge/right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu dekstren direkte al Destination 1",
         "es": "Incorpórate a derecha hacia Destination 1",
         "es-ES": "Incorpórate a la derecha hacia Destination 1",
+        "fi": "Liity oikeall(e/a), suuntana Destination 1",
         "fr": "Rejoindre à droite en direction de Destination 1",
         "he": "השתלב ימינה לכיוון Destination 1",
         "id": "Bergabung kanan menuju Destination 1",

--- a/test/fixtures/v5/merge/right_exit.json
+++ b/test/fixtures/v5/merge/right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu dekstren al Way Name",
         "es": "Incorpórate a derecha en Way Name",
         "es-ES": "Incorpórate a la derecha por Way Name",
+        "fi": "Liity oikeall(e/a), tielle Way Name",
         "fr": "Rejoindre à droite sur Way Name",
         "he": "השתלב ימינה על Way Name",
         "id": "Bergabung kanan ke arah Way Name",

--- a/test/fixtures/v5/merge/right_exit_destination.json
+++ b/test/fixtures/v5/merge/right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Enveturu dekstren direkte al Destination 1",
         "es": "Incorpórate a derecha hacia Destination 1",
         "es-ES": "Incorpórate a la derecha hacia Destination 1",
+        "fi": "Liity oikeall(e/a), suuntana Destination 1",
         "fr": "Rejoindre à droite en direction de Destination 1",
         "he": "השתלב ימינה לכיוון Destination 1",
         "id": "Bergabung kanan menuju Destination 1",

--- a/test/fixtures/v5/merge/right_name.json
+++ b/test/fixtures/v5/merge/right_name.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu dekstren al Way Name",
         "es": "Incorpórate a derecha en Way Name",
         "es-ES": "Incorpórate a la derecha por Way Name",
+        "fi": "Liity oikeall(e/a), tielle Way Name",
         "fr": "Rejoindre à droite sur Way Name",
         "he": "השתלב ימינה על Way Name",
         "id": "Bergabung kanan ke arah Way Name",

--- a/test/fixtures/v5/merge/sharp_left_default.json
+++ b/test/fixtures/v5/merge/sharp_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu de maldekstre",
         "es": "Incorpórate a la izquierda",
         "es-ES": "Incorpórate a la izquierda",
+        "fi": "Liity vasemmalle",
         "fr": "S’insérer à gauche",
         "he": "השתלב שמאלה",
         "id": "Bergabung di kiri",

--- a/test/fixtures/v5/merge/sharp_left_destination.json
+++ b/test/fixtures/v5/merge/sharp_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu de maldekstre direkte al Destination 1",
         "es": "Incorpórate a la izquierda hacia Destination 1",
         "es-ES": "Incorpórate a la izquierda hacia Destination 1",
+        "fi": "Liity vasemmalle, suuntana Destination 1",
         "fr": "S’insérer à gauche en direction de Destination 1",
         "he": "השתלב שמאלה לכיוון Destination 1",
         "id": "Bergabung di kiri menuju Destination 1",

--- a/test/fixtures/v5/merge/sharp_left_exit.json
+++ b/test/fixtures/v5/merge/sharp_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Enveture de maldekstre al Way Name",
         "es": "Incorpórate a la izquierda en Way Name",
         "es-ES": "Incorpórate a la izquierda por Way Name",
+        "fi": "Liity vasemmalle, tielle Way Name",
         "fr": "S’insérer à gauche sur Way Name",
         "he": "השתלב שמאלה על Way Name",
         "id": "Bergabung di kiri ke arah Way Name",

--- a/test/fixtures/v5/merge/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/merge/sharp_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Enveturu de maldekstre direkte al Destination 1",
         "es": "Incorpórate a la izquierda hacia Destination 1",
         "es-ES": "Incorpórate a la izquierda hacia Destination 1",
+        "fi": "Liity vasemmalle, suuntana Destination 1",
         "fr": "S’insérer à gauche en direction de Destination 1",
         "he": "השתלב שמאלה לכיוון Destination 1",
         "id": "Bergabung di kiri menuju Destination 1",

--- a/test/fixtures/v5/merge/sharp_left_name.json
+++ b/test/fixtures/v5/merge/sharp_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Enveture de maldekstre al Way Name",
         "es": "Incorpórate a la izquierda en Way Name",
         "es-ES": "Incorpórate a la izquierda por Way Name",
+        "fi": "Liity vasemmalle, tielle Way Name",
         "fr": "S’insérer à gauche sur Way Name",
         "he": "השתלב שמאלה על Way Name",
         "id": "Bergabung di kiri ke arah Way Name",

--- a/test/fixtures/v5/merge/sharp_right_default.json
+++ b/test/fixtures/v5/merge/sharp_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu de dekstre",
         "es": "Incorpórate a la derecha",
         "es-ES": "Incorpórate a la derecha",
+        "fi": "Liity oikealle",
         "fr": "S’insérer à droite",
         "he": "השתלב ימינה",
         "id": "Bergabung di kanan",

--- a/test/fixtures/v5/merge/sharp_right_destination.json
+++ b/test/fixtures/v5/merge/sharp_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu de dekstre direkte al Destination 1",
         "es": "Incorpórate a la derecha hacia Destination 1",
         "es-ES": "Incorpórate a la derecha hacia Destination 1",
+        "fi": "Liity oikealle, suuntana Destination 1",
         "fr": "S’insérer à droite en direction de Destination 1",
         "he": "השתלב ימינה לכיוון Destination 1",
         "id": "Bergabung di kanan menuju Destination 1",

--- a/test/fixtures/v5/merge/sharp_right_exit.json
+++ b/test/fixtures/v5/merge/sharp_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu de dekstre al Way Name",
         "es": "Incorpórate a la derecha en Way Name",
         "es-ES": "Incorpórate a la derecha por Way Name",
+        "fi": "Liity oikealle, tielle Way Name",
         "fr": "S’insérer à droite sur Way Name",
         "he": "השתלב ימינה על Way Name",
         "id": "Bergabung di kanan ke arah Way Name",

--- a/test/fixtures/v5/merge/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/merge/sharp_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Enveturu de dekstre direkte al Destination 1",
         "es": "Incorpórate a la derecha hacia Destination 1",
         "es-ES": "Incorpórate a la derecha hacia Destination 1",
+        "fi": "Liity oikealle, suuntana Destination 1",
         "fr": "S’insérer à droite en direction de Destination 1",
         "he": "השתלב ימינה לכיוון Destination 1",
         "id": "Bergabung di kanan menuju Destination 1",

--- a/test/fixtures/v5/merge/sharp_right_name.json
+++ b/test/fixtures/v5/merge/sharp_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu de dekstre al Way Name",
         "es": "Incorpórate a la derecha en Way Name",
         "es-ES": "Incorpórate a la derecha por Way Name",
+        "fi": "Liity oikealle, tielle Way Name",
         "fr": "S’insérer à droite sur Way Name",
         "he": "השתלב ימינה על Way Name",
         "id": "Bergabung di kanan ke arah Way Name",

--- a/test/fixtures/v5/merge/slight_left_default.json
+++ b/test/fixtures/v5/merge/slight_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu de maldekstre",
         "es": "Incorpórate a la izquierda",
         "es-ES": "Incorpórate a la izquierda",
+        "fi": "Liity vasemmalle",
         "fr": "S’insérer légèrement à gauche",
         "he": "השתלב שמאלה",
         "id": "Bergabung di kiri",

--- a/test/fixtures/v5/merge/slight_left_destination.json
+++ b/test/fixtures/v5/merge/slight_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu de maldekstre direkte al Destination 1",
         "es": "Incorpórate a la izquierda hacia Destination 1",
         "es-ES": "Incorpórate a la izquierda hacia Destination 1",
+        "fi": "Liity vasemmalle, suuntana Destination 1",
         "fr": "S’insérer légèrement à gauche en direction de Destination 1",
         "he": "השתלב שמאלה לכיוון Destination 1",
         "id": "Bergabung di kiri menuju Destination 1",

--- a/test/fixtures/v5/merge/slight_left_exit.json
+++ b/test/fixtures/v5/merge/slight_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu de maldekstre al Way Name",
         "es": "Incorpórate a la izquierda en Way Name",
         "es-ES": "Incorpórate a la izquierda por Way Name",
+        "fi": "Liity vasemmalle, tielle Way Name",
         "fr": "S’insérer légèrement à gauche sur Way Name",
         "he": "השתלב שמאלה על Way Name",
         "id": "Bergabung di kiri ke arah Way Name",

--- a/test/fixtures/v5/merge/slight_left_exit_destination.json
+++ b/test/fixtures/v5/merge/slight_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Enveturu de maldekstre direkte al Destination 1",
         "es": "Incorpórate a la izquierda hacia Destination 1",
         "es-ES": "Incorpórate a la izquierda hacia Destination 1",
+        "fi": "Liity vasemmalle, suuntana Destination 1",
         "fr": "S’insérer légèrement à gauche en direction de Destination 1",
         "he": "השתלב שמאלה לכיוון Destination 1",
         "id": "Bergabung di kiri menuju Destination 1",

--- a/test/fixtures/v5/merge/slight_left_name.json
+++ b/test/fixtures/v5/merge/slight_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu de maldekstre al Way Name",
         "es": "Incorpórate a la izquierda en Way Name",
         "es-ES": "Incorpórate a la izquierda por Way Name",
+        "fi": "Liity vasemmalle, tielle Way Name",
         "fr": "S’insérer légèrement à gauche sur Way Name",
         "he": "השתלב שמאלה על Way Name",
         "id": "Bergabung di kiri ke arah Way Name",

--- a/test/fixtures/v5/merge/slight_right_default.json
+++ b/test/fixtures/v5/merge/slight_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu de dekstre",
         "es": "Incorpórate a la derecha",
         "es-ES": "Incorpórate a la derecha",
+        "fi": "Liity oikealle",
         "fr": "S’insérer légèrement à droite",
         "he": "השתלב ימינה",
         "id": "Bergabung di kanan",

--- a/test/fixtures/v5/merge/slight_right_destination.json
+++ b/test/fixtures/v5/merge/slight_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu de dekstre direkte al Destination 1",
         "es": "Incorpórate a la derecha hacia Destination 1",
         "es-ES": "Incorpórate a la derecha hacia Destination 1",
+        "fi": "Liity oikealle, suuntana Destination 1",
         "fr": "S’insérer à droite en direction de Destination 1",
         "he": "השתלב ימינה לכיוון Destination 1",
         "id": "Bergabung di kanan menuju Destination 1",

--- a/test/fixtures/v5/merge/slight_right_exit.json
+++ b/test/fixtures/v5/merge/slight_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu de dekstre al Way Name",
         "es": "Incorpórate a la derecha en Way Name",
         "es-ES": "Incorpórate a la derecha por Way Name",
+        "fi": "Liity oikealle, tielle Way Name",
         "fr": "S’insérer légèrement à droite sur Way Name",
         "he": "השתלב ימינה על Way Name",
         "id": "Bergabung di kanan ke arah Way Name",

--- a/test/fixtures/v5/merge/slight_right_exit_destination.json
+++ b/test/fixtures/v5/merge/slight_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Enveturu de dekstre direkte al Destination 1",
         "es": "Incorpórate a la derecha hacia Destination 1",
         "es-ES": "Incorpórate a la derecha hacia Destination 1",
+        "fi": "Liity oikealle, suuntana Destination 1",
         "fr": "S’insérer à droite en direction de Destination 1",
         "he": "השתלב ימינה לכיוון Destination 1",
         "id": "Bergabung di kanan menuju Destination 1",

--- a/test/fixtures/v5/merge/slight_right_name.json
+++ b/test/fixtures/v5/merge/slight_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu de dekstre al Way Name",
         "es": "Incorpórate a la derecha en Way Name",
         "es-ES": "Incorpórate a la derecha por Way Name",
+        "fi": "Liity oikealle, tielle Way Name",
         "fr": "S’insérer légèrement à droite sur Way Name",
         "he": "השתלב ימינה על Way Name",
         "id": "Bergabung di kanan ke arah Way Name",

--- a/test/fixtures/v5/merge/straight_default.json
+++ b/test/fixtures/v5/merge/straight_default.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu",
         "es": "Incorpórate",
         "es-ES": "Incorpórate",
+        "fi": "Liity",
         "fr": "S’insérer",
         "he": "השתלב",
         "id": "Bergabung lurus",

--- a/test/fixtures/v5/merge/straight_destination.json
+++ b/test/fixtures/v5/merge/straight_destination.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu direkte al Destination 1",
         "es": "Incorpórate hacia Destination 1",
         "es-ES": "Incorpórate hacia Destination 1",
+        "fi": "Liity suuntana Destination 1",
         "fr": "S’insérer en direction de Destination 1",
         "he": "השתלב לכיוון Destination 1",
         "id": "Bergabung lurus menuju Destination 1",

--- a/test/fixtures/v5/merge/straight_exit.json
+++ b/test/fixtures/v5/merge/straight_exit.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu al Way Name",
         "es": "Incorpórate a Way Name",
         "es-ES": "Incorpórate por Way Name",
+        "fi": "Liity tielle Way Name",
         "fr": "S’insérer sur Way Name",
         "he": "השתלב על Way Name",
         "id": "Bergabung lurus ke arah Way Name",

--- a/test/fixtures/v5/merge/straight_exit_destination.json
+++ b/test/fixtures/v5/merge/straight_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Enveturu direkte al Destination 1",
         "es": "Incorpórate hacia Destination 1",
         "es-ES": "Incorpórate hacia Destination 1",
+        "fi": "Liity suuntana Destination 1",
         "fr": "S’insérer en direction de Destination 1",
         "he": "השתלב לכיוון Destination 1",
         "id": "Bergabung lurus menuju Destination 1",

--- a/test/fixtures/v5/merge/straight_name.json
+++ b/test/fixtures/v5/merge/straight_name.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu al Way Name",
         "es": "Incorpórate a Way Name",
         "es-ES": "Incorpórate por Way Name",
+        "fi": "Liity tielle Way Name",
         "fr": "S’insérer sur Way Name",
         "he": "השתלב על Way Name",
         "id": "Bergabung lurus ke arah Way Name",

--- a/test/fixtures/v5/merge/uturn_default.json
+++ b/test/fixtures/v5/merge/uturn_default.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu malantaŭen",
         "es": "Haz un cambio de sentido",
         "es-ES": "Haz un cambio de sentido",
+        "fi": "Tee U-käännös",
         "fr": "Faire demi-tour",
         "he": "פנה פניית פרסה",
         "id": "Putar balik",

--- a/test/fixtures/v5/merge/uturn_destination.json
+++ b/test/fixtures/v5/merge/uturn_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu malantaŭen direkte al Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
         "es-ES": "Haz un cambio de sentido hacia Destination 1",
+        "fi": "Tee U-käännös suuntana Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "he": "פנה פניית פרסה לכיוון Destination 1",
         "id": "Putar balik menuju Destination 1",

--- a/test/fixtures/v5/merge/uturn_exit.json
+++ b/test/fixtures/v5/merge/uturn_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu malantaŭen al Way Name",
         "es": "Haz un cambio de sentido en Way Name",
         "es-ES": "Haz un cambio de sentido en Way Name",
+        "fi": "Tee U-käännös tielle Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "he": "פנה פניית פרסה על Way Name",
         "id": "Putar balik ke arah Way Name",

--- a/test/fixtures/v5/merge/uturn_exit_destination.json
+++ b/test/fixtures/v5/merge/uturn_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu malantaŭen direkte al Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
         "es-ES": "Haz un cambio de sentido hacia Destination 1",
+        "fi": "Tee U-käännös suuntana Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "he": "פנה פניית פרסה לכיוון Destination 1",
         "id": "Putar balik menuju Destination 1",

--- a/test/fixtures/v5/merge/uturn_name.json
+++ b/test/fixtures/v5/merge/uturn_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu malantaŭen al Way Name",
         "es": "Haz un cambio de sentido en Way Name",
         "es-ES": "Haz un cambio de sentido en Way Name",
+        "fi": "Tee U-käännös tielle Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "he": "פנה פניית פרסה על Way Name",
         "id": "Putar balik ke arah Way Name",

--- a/test/fixtures/v5/modes/driving_turn_left.json
+++ b/test/fixtures/v5/modes/driving_turn_left.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu maldekstren al Way Name",
         "es": "Gira a la izquierda en Way Name",
         "es-ES": "Gira a la izquierda por Way Name",
+        "fi": "Käänny vasempaan tielle Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "he": "פנה שמאלה לWay Name",
         "id": "Belok kiri ke Way Name",

--- a/test/fixtures/v5/modes/ferry_fork_left_default.json
+++ b/test/fixtures/v5/modes/ferry_fork_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Enpramiĝu",
         "es": "Coge el ferry",
         "es-ES": "Coge el ferry",
+        "fi": "Aja lautalle",
         "fr": "Prendre le ferry",
         "he": "עלה על המעבורת",
         "id": "Naik ferry",

--- a/test/fixtures/v5/modes/ferry_fork_left_destination.json
+++ b/test/fixtures/v5/modes/ferry_fork_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Enpramiĝu direkte al Destination 1",
         "es": "Coge el ferry a Destination 1",
         "es-ES": "Coge el ferry hacia Destination 1",
+        "fi": "Aja lautalle, jonka määränpää on Destination 1",
         "fr": "Prendre le ferry en direction de Destination 1",
         "he": "עלה על המעבורת לכיוון Destination 1",
         "id": "Naik ferry menuju Destination 1",

--- a/test/fixtures/v5/modes/ferry_fork_left_exit.json
+++ b/test/fixtures/v5/modes/ferry_fork_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Enpramiĝu Way Name",
         "es": "Coge el ferry Way Name",
         "es-ES": "Coge el ferry Way Name",
+        "fi": "Aja lautalle Way Name",
         "fr": "Prendre le ferry Way Name",
         "he": "עלה על המעבורת Way Name",
         "id": "Naik ferry di Way Name",

--- a/test/fixtures/v5/modes/ferry_fork_left_exit_destination.json
+++ b/test/fixtures/v5/modes/ferry_fork_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Enpramiĝu direkte al Destination 1",
         "es": "Coge el ferry a Destination 1",
         "es-ES": "Coge el ferry hacia Destination 1",
+        "fi": "Aja lautalle, jonka määränpää on Destination 1",
         "fr": "Prendre le ferry en direction de Destination 1",
         "he": "עלה על המעבורת לכיוון Destination 1",
         "id": "Naik ferry menuju Destination 1",

--- a/test/fixtures/v5/modes/ferry_fork_left_name.json
+++ b/test/fixtures/v5/modes/ferry_fork_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Enpramiĝu Way Name",
         "es": "Coge el ferry Way Name",
         "es-ES": "Coge el ferry Way Name",
+        "fi": "Aja lautalle Way Name",
         "fr": "Prendre le ferry Way Name",
         "he": "עלה על המעבורת Way Name",
         "id": "Naik ferry di Way Name",

--- a/test/fixtures/v5/modes/ferry_turn_left_default.json
+++ b/test/fixtures/v5/modes/ferry_turn_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Enpramiĝu",
         "es": "Coge el ferry",
         "es-ES": "Coge el ferry",
+        "fi": "Aja lautalle",
         "fr": "Prendre le ferry",
         "he": "עלה על המעבורת",
         "id": "Naik ferry",

--- a/test/fixtures/v5/modes/ferry_turn_left_destination.json
+++ b/test/fixtures/v5/modes/ferry_turn_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Enpramiĝu direkte al Destination 1",
         "es": "Coge el ferry a Destination 1",
         "es-ES": "Coge el ferry hacia Destination 1",
+        "fi": "Aja lautalle, jonka määränpää on Destination 1",
         "fr": "Prendre le ferry en direction de Destination 1",
         "he": "עלה על המעבורת לכיוון Destination 1",
         "id": "Naik ferry menuju Destination 1",

--- a/test/fixtures/v5/modes/ferry_turn_left_exit.json
+++ b/test/fixtures/v5/modes/ferry_turn_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Enpramiĝu Way Name",
         "es": "Coge el ferry Way Name",
         "es-ES": "Coge el ferry Way Name",
+        "fi": "Aja lautalle Way Name",
         "fr": "Prendre le ferry Way Name",
         "he": "עלה על המעבורת Way Name",
         "id": "Naik ferry di Way Name",

--- a/test/fixtures/v5/modes/ferry_turn_left_exit_destination.json
+++ b/test/fixtures/v5/modes/ferry_turn_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Enpramiĝu direkte al Destination 1",
         "es": "Coge el ferry a Destination 1",
         "es-ES": "Coge el ferry hacia Destination 1",
+        "fi": "Aja lautalle, jonka määränpää on Destination 1",
         "fr": "Prendre le ferry en direction de Destination 1",
         "he": "עלה על המעבורת לכיוון Destination 1",
         "id": "Naik ferry menuju Destination 1",

--- a/test/fixtures/v5/modes/ferry_turn_left_name.json
+++ b/test/fixtures/v5/modes/ferry_turn_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Enpramiĝu Way Name",
         "es": "Coge el ferry Way Name",
         "es-ES": "Coge el ferry Way Name",
+        "fi": "Aja lautalle Way Name",
         "fr": "Prendre le ferry Way Name",
         "he": "עלה על המעבורת Way Name",
         "id": "Naik ferry di Way Name",

--- a/test/fixtures/v5/new_name/left_default.json
+++ b/test/fixtures/v5/new_name/left_default.json
@@ -14,6 +14,7 @@
         "eo": "Pluu maldekstren",
         "es": "Continúa izquierda",
         "es-ES": "Continúa a la izquierda",
+        "fi": "Jatka vasemmall(e/a)",
         "fr": "Continuer à gauche",
         "he": "המשך שמאלה",
         "id": "Lanjutkan kiri",

--- a/test/fixtures/v5/new_name/left_destination.json
+++ b/test/fixtures/v5/new_name/left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Pluu maldekstren direkte al Destination 1",
         "es": "Continúa izquierda hacia Destination 1",
         "es-ES": "Continúa a la izquierda hacia Destination 1",
+        "fi": "Jatka vasemmall(e/a) suuntana Destination 1",
         "fr": "Continuer à gauche en direction de Destination 1",
         "he": "המשך שמאלה לכיוון Destination 1",
         "id": "Lanjutkan kiri menuju Destination 1",

--- a/test/fixtures/v5/new_name/left_exit.json
+++ b/test/fixtures/v5/new_name/left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Pluu maldekstren al Way Name",
         "es": "Continúa izquierda en Way Name",
         "es-ES": "Continúa a la izquierda por Way Name",
+        "fi": "Jatka vasemmall(e/a) tielle Way Name",
         "fr": "Continuer à gauche sur Way Name",
         "he": "המשך שמאלה על Way Name",
         "id": "Lanjutkan kiri menuju Way Name",

--- a/test/fixtures/v5/new_name/left_exit_destination.json
+++ b/test/fixtures/v5/new_name/left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Pluu maldekstren direkte al Destination 1",
         "es": "Continúa izquierda hacia Destination 1",
         "es-ES": "Continúa a la izquierda hacia Destination 1",
+        "fi": "Jatka vasemmall(e/a) suuntana Destination 1",
         "fr": "Continuer à gauche en direction de Destination 1",
         "he": "המשך שמאלה לכיוון Destination 1",
         "id": "Lanjutkan kiri menuju Destination 1",

--- a/test/fixtures/v5/new_name/left_name.json
+++ b/test/fixtures/v5/new_name/left_name.json
@@ -14,6 +14,7 @@
         "eo": "Pluu maldekstren al Way Name",
         "es": "Continúa izquierda en Way Name",
         "es-ES": "Continúa a la izquierda por Way Name",
+        "fi": "Jatka vasemmall(e/a) tielle Way Name",
         "fr": "Continuer à gauche sur Way Name",
         "he": "המשך שמאלה על Way Name",
         "id": "Lanjutkan kiri menuju Way Name",

--- a/test/fixtures/v5/new_name/right_default.json
+++ b/test/fixtures/v5/new_name/right_default.json
@@ -14,6 +14,7 @@
         "eo": "Pluu dekstren",
         "es": "Continúa derecha",
         "es-ES": "Continúa a la derecha",
+        "fi": "Jatka oikeall(e/a)",
         "fr": "Continuer à droite",
         "he": "המשך ימינה",
         "id": "Lanjutkan kanan",

--- a/test/fixtures/v5/new_name/right_destination.json
+++ b/test/fixtures/v5/new_name/right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Pluu dekstren direkte al Destination 1",
         "es": "Continúa derecha hacia Destination 1",
         "es-ES": "Continúa a la derecha hacia Destination 1",
+        "fi": "Jatka oikeall(e/a) suuntana Destination 1",
         "fr": "Continuer à droite en direction de Destination 1",
         "he": "המשך ימינה לכיוון Destination 1",
         "id": "Lanjutkan kanan menuju Destination 1",

--- a/test/fixtures/v5/new_name/right_exit.json
+++ b/test/fixtures/v5/new_name/right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Pluu dekstren al Way Name",
         "es": "Continúa derecha en Way Name",
         "es-ES": "Continúa a la derecha por Way Name",
+        "fi": "Jatka oikeall(e/a) tielle Way Name",
         "fr": "Continuer à droite sur Way Name",
         "he": "המשך ימינה על Way Name",
         "id": "Lanjutkan kanan menuju Way Name",

--- a/test/fixtures/v5/new_name/right_exit_destination.json
+++ b/test/fixtures/v5/new_name/right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Pluu dekstren direkte al Destination 1",
         "es": "Continúa derecha hacia Destination 1",
         "es-ES": "Continúa a la derecha hacia Destination 1",
+        "fi": "Jatka oikeall(e/a) suuntana Destination 1",
         "fr": "Continuer à droite en direction de Destination 1",
         "he": "המשך ימינה לכיוון Destination 1",
         "id": "Lanjutkan kanan menuju Destination 1",

--- a/test/fixtures/v5/new_name/right_name.json
+++ b/test/fixtures/v5/new_name/right_name.json
@@ -14,6 +14,7 @@
         "eo": "Pluu dekstren al Way Name",
         "es": "Continúa derecha en Way Name",
         "es-ES": "Continúa a la derecha por Way Name",
+        "fi": "Jatka oikeall(e/a) tielle Way Name",
         "fr": "Continuer à droite sur Way Name",
         "he": "המשך ימינה על Way Name",
         "id": "Lanjutkan kanan menuju Way Name",

--- a/test/fixtures/v5/new_name/sharp_left_default.json
+++ b/test/fixtures/v5/new_name/sharp_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ege maldekstren",
         "es": "Gira a la izquierda",
         "es-ES": "Gira a la izquierda",
+        "fi": "Käänny jyrkästi vasempaan",
         "fr": "Prendre franchement à gauche",
         "he": "פנה בחדות שמאלה",
         "id": "Belok kiri tajam",

--- a/test/fixtures/v5/new_name/sharp_left_destination.json
+++ b/test/fixtures/v5/new_name/sharp_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu ege maldekstren direkte al Destination 1",
         "es": "Gira a la izquierda hacia Destination 1",
         "es-ES": "Gira a la izquierda hacia Destination 1",
+        "fi": "Käänny jyrkästi vasempaan suuntana Destination 1",
         "fr": "Prendre franchement à gauche en direction de Destination 1",
         "he": "פנה בחדות שמאלה לכיוון Destination 1",
         "id": "Belok kiri tajam menuju Destination 1",

--- a/test/fixtures/v5/new_name/sharp_left_exit.json
+++ b/test/fixtures/v5/new_name/sharp_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu ege maldekstren al Way Name",
         "es": "Gira a la izquierda en Way Name",
         "es-ES": "Gira a la izquierda por Way Name",
+        "fi": "Käänny jyrkästi vasempaan tielle Way Name",
         "fr": "Prendre franchement à gauche sur Way Name",
         "he": "פנה בחדות שמאלה על Way Name",
         "id": "Belok kiri tajam ke arah Way Name",

--- a/test/fixtures/v5/new_name/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/new_name/sharp_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu ege maldekstren direkte al Destination 1",
         "es": "Gira a la izquierda hacia Destination 1",
         "es-ES": "Gira a la izquierda hacia Destination 1",
+        "fi": "Käänny jyrkästi vasempaan suuntana Destination 1",
         "fr": "Prendre franchement à gauche en direction de Destination 1",
         "he": "פנה בחדות שמאלה לכיוון Destination 1",
         "id": "Belok kiri tajam menuju Destination 1",

--- a/test/fixtures/v5/new_name/sharp_left_name.json
+++ b/test/fixtures/v5/new_name/sharp_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ege maldekstren al Way Name",
         "es": "Gira a la izquierda en Way Name",
         "es-ES": "Gira a la izquierda por Way Name",
+        "fi": "Käänny jyrkästi vasempaan tielle Way Name",
         "fr": "Prendre franchement à gauche sur Way Name",
         "he": "פנה בחדות שמאלה על Way Name",
         "id": "Belok kiri tajam ke arah Way Name",

--- a/test/fixtures/v5/new_name/sharp_right_default.json
+++ b/test/fixtures/v5/new_name/sharp_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ege dekstren",
         "es": "Gira a la derecha",
         "es-ES": "Gira a la derecha",
+        "fi": "Käänny jyrkästi oikeaan",
         "fr": "Prendre franchement à droite",
         "he": "פנה בחדות ימינה",
         "id": "Belok kanan tajam",

--- a/test/fixtures/v5/new_name/sharp_right_destination.json
+++ b/test/fixtures/v5/new_name/sharp_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu ege dekstren direkte al Destination 1",
         "es": "Gira a la derecha hacia Destination 1",
         "es-ES": "Gira a la derecha hacia Destination 1",
+        "fi": "Käänny jyrkästi oikeaan suuntana Destination 1",
         "fr": "Prendre franchement à droite en direction de Destination 1",
         "he": "פנה בחדות ימינה לכיוון Destination 1",
         "id": "Belok kanan tajam menuju Destination 1",

--- a/test/fixtures/v5/new_name/sharp_right_exit.json
+++ b/test/fixtures/v5/new_name/sharp_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu ege dekstren al Way Name",
         "es": "Gira a la derecha en Way Name",
         "es-ES": "Gira a la derecha por Way Name",
+        "fi": "Käänny jyrkästi oikeaan tielle Way Name",
         "fr": "Prendre franchement à droite sur Way Name",
         "he": "פנה בחדות ימינה על Way Name",
         "id": "Belok kanan tajam ke arah Way Name",

--- a/test/fixtures/v5/new_name/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/new_name/sharp_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu ege dekstren direkte al Destination 1",
         "es": "Gira a la derecha hacia Destination 1",
         "es-ES": "Gira a la derecha hacia Destination 1",
+        "fi": "Käänny jyrkästi oikeaan suuntana Destination 1",
         "fr": "Prendre franchement à droite en direction de Destination 1",
         "he": "פנה בחדות ימינה לכיוון Destination 1",
         "id": "Belok kanan tajam menuju Destination 1",

--- a/test/fixtures/v5/new_name/sharp_right_name.json
+++ b/test/fixtures/v5/new_name/sharp_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ege dekstren al Way Name",
         "es": "Gira a la derecha en Way Name",
         "es-ES": "Gira a la derecha por Way Name",
+        "fi": "Käänny jyrkästi oikeaan tielle Way Name",
         "fr": "Prendre franchement à droite sur Way Name",
         "he": "פנה בחדות ימינה על Way Name",
         "id": "Belok kanan tajam ke arah Way Name",

--- a/test/fixtures/v5/new_name/slight_left_default.json
+++ b/test/fixtures/v5/new_name/slight_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Pluu ete maldekstren",
         "es": "Continúa levemente a la izquierda",
         "es-ES": "Continúa ligeramente por la izquierda",
+        "fi": "Jatka loivasti vasempaan",
         "fr": "Continuer légèrement à gauche",
         "he": "המשך בנטייה קלה שמאלה",
         "id": "Lanjut dengan agak ke kiri",

--- a/test/fixtures/v5/new_name/slight_left_destination.json
+++ b/test/fixtures/v5/new_name/slight_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Pluu ete maldekstren direkte al Destination 1",
         "es": "Continúa levemente a la izquierda hacia Destination 1",
         "es-ES": "Continúa ligeramente por la izquierda hacia Destination 1",
+        "fi": "Jatka loivasti vasempaan suuntana Destination 1",
         "fr": "Continuer légèrement à gauche en direction de Destination 1",
         "he": "המשך בנטייה קלה שמאלה לכיוון Destination 1",
         "id": "Tetap agak di kiri menuju Destination 1",

--- a/test/fixtures/v5/new_name/slight_left_exit.json
+++ b/test/fixtures/v5/new_name/slight_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Pluu ete maldekstren al Way Name",
         "es": "Continúa levemente a la izquierda en Way Name",
         "es-ES": "Continúa ligeramente por la izquierda por Way Name",
+        "fi": "Jatka loivasti vasempaan tielle Way Name",
         "fr": "Continuer légèrement à gauche sur Way Name",
         "he": "המשך בנטייה קלה שמאלה על Way Name",
         "id": "Lanjut dengan agak di kiri ke Way Name",

--- a/test/fixtures/v5/new_name/slight_left_exit_destination.json
+++ b/test/fixtures/v5/new_name/slight_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Pluu ete maldekstren direkte al Destination 1",
         "es": "Continúa levemente a la izquierda hacia Destination 1",
         "es-ES": "Continúa ligeramente por la izquierda hacia Destination 1",
+        "fi": "Jatka loivasti vasempaan suuntana Destination 1",
         "fr": "Continuer légèrement à gauche en direction de Destination 1",
         "he": "המשך בנטייה קלה שמאלה לכיוון Destination 1",
         "id": "Tetap agak di kiri menuju Destination 1",

--- a/test/fixtures/v5/new_name/slight_left_name.json
+++ b/test/fixtures/v5/new_name/slight_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Pluu ete maldekstren al Way Name",
         "es": "Continúa levemente a la izquierda en Way Name",
         "es-ES": "Continúa ligeramente por la izquierda por Way Name",
+        "fi": "Jatka loivasti vasempaan tielle Way Name",
         "fr": "Continuer légèrement à gauche sur Way Name",
         "he": "המשך בנטייה קלה שמאלה על Way Name",
         "id": "Lanjut dengan agak di kiri ke Way Name",

--- a/test/fixtures/v5/new_name/slight_right_default.json
+++ b/test/fixtures/v5/new_name/slight_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Pluu ete dekstren",
         "es": "Continúa levemente a la derecha",
         "es-ES": "Continúa ligeramente por la derecha",
+        "fi": "Jatka loivasti oikeaan",
         "fr": "Continuer légèrement à droite",
         "he": "המשך בנטייה קלה ימינה",
         "id": "Tetap agak di kanan",

--- a/test/fixtures/v5/new_name/slight_right_destination.json
+++ b/test/fixtures/v5/new_name/slight_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Pluu ete dekstren direkte al Destination 1",
         "es": "Continúa levemente a la derecha hacia Destination 1",
         "es-ES": "Continúa ligeramente por la derecha hacia Destination 1",
+        "fi": "Jatka loivasti oikeaan suuntana Destination 1",
         "fr": "Continuer légèrement à droite en direction de Destination 1",
         "he": "המשך בנטייה קלה ימינה לכיוון Destination 1",
         "id": "Tetap agak di kanan menuju Destination 1",

--- a/test/fixtures/v5/new_name/slight_right_exit.json
+++ b/test/fixtures/v5/new_name/slight_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Pluu ete dekstren al Way Name",
         "es": "Continúa levemente a la derecha en Way Name",
         "es-ES": "Continúa ligeramente por la derecha por Way Name",
+        "fi": "Jatka loivasti oikeaan tielle Way Name",
         "fr": "Continuer légèrement à droite sur Way Name",
         "he": "המשך בנטייה קלה ימינה על Way Name",
         "id": "Tetap agak di kanan ke Way Name",

--- a/test/fixtures/v5/new_name/slight_right_exit_destination.json
+++ b/test/fixtures/v5/new_name/slight_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Pluu ete dekstren direkte al Destination 1",
         "es": "Continúa levemente a la derecha hacia Destination 1",
         "es-ES": "Continúa ligeramente por la derecha hacia Destination 1",
+        "fi": "Jatka loivasti oikeaan suuntana Destination 1",
         "fr": "Continuer légèrement à droite en direction de Destination 1",
         "he": "המשך בנטייה קלה ימינה לכיוון Destination 1",
         "id": "Tetap agak di kanan menuju Destination 1",

--- a/test/fixtures/v5/new_name/slight_right_name.json
+++ b/test/fixtures/v5/new_name/slight_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Pluu ete dekstren al Way Name",
         "es": "Continúa levemente a la derecha en Way Name",
         "es-ES": "Continúa ligeramente por la derecha por Way Name",
+        "fi": "Jatka loivasti oikeaan tielle Way Name",
         "fr": "Continuer légèrement à droite sur Way Name",
         "he": "המשך בנטייה קלה ימינה על Way Name",
         "id": "Tetap agak di kanan ke Way Name",

--- a/test/fixtures/v5/new_name/straight_default.json
+++ b/test/fixtures/v5/new_name/straight_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu rekten",
         "es": "Continúa recto",
         "es-ES": "Continúa recto",
+        "fi": "Jatka suoraan eteenpäin",
         "fr": "Continuer tout droit",
         "he": "המשך ישר",
         "id": "Lurus terus",

--- a/test/fixtures/v5/new_name/straight_destination.json
+++ b/test/fixtures/v5/new_name/straight_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu rekten direkte al Destination 1",
         "es": "Continúa hacia Destination 1",
         "es-ES": "Continúa hacia Destination 1",
+        "fi": "Jatka suuntana Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "he": "המשך לכיוון Destination 1",
         "id": "Terus menuju Destination 1",

--- a/test/fixtures/v5/new_name/straight_exit.json
+++ b/test/fixtures/v5/new_name/straight_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu rekten al Way Name",
         "es": "Continúa en Way Name",
         "es-ES": "Continúa por Way Name",
+        "fi": "Jatka tielle Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "he": "המשך על Way Name",
         "id": "Terus ke Way Name",

--- a/test/fixtures/v5/new_name/straight_exit_destination.json
+++ b/test/fixtures/v5/new_name/straight_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu rekten direkte al Destination 1",
         "es": "Continúa hacia Destination 1",
         "es-ES": "Continúa hacia Destination 1",
+        "fi": "Jatka suuntana Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "he": "המשך לכיוון Destination 1",
         "id": "Terus menuju Destination 1",

--- a/test/fixtures/v5/new_name/straight_name.json
+++ b/test/fixtures/v5/new_name/straight_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu rekten al Way Name",
         "es": "Continúa en Way Name",
         "es-ES": "Continúa por Way Name",
+        "fi": "Jatka tielle Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "he": "המשך על Way Name",
         "id": "Terus ke Way Name",

--- a/test/fixtures/v5/new_name/uturn_default.json
+++ b/test/fixtures/v5/new_name/uturn_default.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu malantaŭen",
         "es": "Haz un cambio de sentido",
         "es-ES": "Haz un cambio de sentido",
+        "fi": "Tee U-käännös",
         "fr": "Faire demi-tour",
         "he": "פנה פניית פרסה",
         "id": "Putar balik",

--- a/test/fixtures/v5/new_name/uturn_destination.json
+++ b/test/fixtures/v5/new_name/uturn_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu malantaŭen direkte al Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
         "es-ES": "Haz un cambio de sentido hacia Destination 1",
+        "fi": "Tee U-käännös suuntana Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "he": "פנה פניית פרסה לכיוון Destination 1",
         "id": "Putar balik menuju Destination 1",

--- a/test/fixtures/v5/new_name/uturn_exit.json
+++ b/test/fixtures/v5/new_name/uturn_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu malantaŭen al Way Name",
         "es": "Haz un cambio de sentido en Way Name",
         "es-ES": "Haz un cambio de sentido en Way Name",
+        "fi": "Tee U-käännös tielle Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "he": "פנה פניית פרסה על Way Name",
         "id": "Putar balik ke arah Way Name",

--- a/test/fixtures/v5/new_name/uturn_exit_destination.json
+++ b/test/fixtures/v5/new_name/uturn_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu malantaŭen direkte al Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
         "es-ES": "Haz un cambio de sentido hacia Destination 1",
+        "fi": "Tee U-käännös suuntana Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "he": "פנה פניית פרסה לכיוון Destination 1",
         "id": "Putar balik menuju Destination 1",

--- a/test/fixtures/v5/new_name/uturn_name.json
+++ b/test/fixtures/v5/new_name/uturn_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu malantaŭen al Way Name",
         "es": "Haz un cambio de sentido en Way Name",
         "es-ES": "Haz un cambio de sentido en Way Name",
+        "fi": "Tee U-käännös tielle Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "he": "פנה פניית פרסה על Way Name",
         "id": "Putar balik ke arah Way Name",

--- a/test/fixtures/v5/notification/left_default.json
+++ b/test/fixtures/v5/notification/left_default.json
@@ -14,6 +14,7 @@
         "eo": "Pluu maldekstren",
         "es": "Continúa izquierda",
         "es-ES": "Continúa a la izquierda",
+        "fi": "Jatka vasemmall(e/a)",
         "fr": "Continuer à gauche",
         "he": "המשך שמאלה",
         "id": "Lanjutkan kiri",

--- a/test/fixtures/v5/notification/left_destination.json
+++ b/test/fixtures/v5/notification/left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Pluu maldekstren direkte al Destination 1",
         "es": "Continúa izquierda hacia Destination 1",
         "es-ES": "Continúa a la izquierda hacia Destination 1",
+        "fi": "Jatka vasemmall(e/a) suuntana Destination 1",
         "fr": "Continuer à gauche en direction de Destination 1",
         "he": "המשך שמאלה לכיוון Destination 1",
         "id": "Lanjutkan kiri menuju Destination 1",

--- a/test/fixtures/v5/notification/left_exit.json
+++ b/test/fixtures/v5/notification/left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Pluu maldekstren al Way Name",
         "es": "Continúa izquierda en Way Name",
         "es-ES": "Continúa a la izquierda por Way Name",
+        "fi": "Jatka vasemmall(e/a) tielle Way Name",
         "fr": "Continuer à gauche sur Way Name",
         "he": "המשך שמאלה על Way Name",
         "id": "Lanjutkan kiri menuju Way Name",

--- a/test/fixtures/v5/notification/left_exit_destination.json
+++ b/test/fixtures/v5/notification/left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Pluu maldekstren direkte al Destination 1",
         "es": "Continúa izquierda hacia Destination 1",
         "es-ES": "Continúa a la izquierda hacia Destination 1",
+        "fi": "Jatka vasemmall(e/a) suuntana Destination 1",
         "fr": "Continuer à gauche en direction de Destination 1",
         "he": "המשך שמאלה לכיוון Destination 1",
         "id": "Lanjutkan kiri menuju Destination 1",

--- a/test/fixtures/v5/notification/left_name.json
+++ b/test/fixtures/v5/notification/left_name.json
@@ -14,6 +14,7 @@
         "eo": "Pluu maldekstren al Way Name",
         "es": "Continúa izquierda en Way Name",
         "es-ES": "Continúa a la izquierda por Way Name",
+        "fi": "Jatka vasemmall(e/a) tielle Way Name",
         "fr": "Continuer à gauche sur Way Name",
         "he": "המשך שמאלה על Way Name",
         "id": "Lanjutkan kiri menuju Way Name",

--- a/test/fixtures/v5/notification/right_default.json
+++ b/test/fixtures/v5/notification/right_default.json
@@ -14,6 +14,7 @@
         "eo": "Pluu dekstren",
         "es": "Continúa derecha",
         "es-ES": "Continúa a la derecha",
+        "fi": "Jatka oikeall(e/a)",
         "fr": "Continuer à droite",
         "he": "המשך ימינה",
         "id": "Lanjutkan kanan",

--- a/test/fixtures/v5/notification/right_destination.json
+++ b/test/fixtures/v5/notification/right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Pluu dekstren direkte al Destination 1",
         "es": "Continúa derecha hacia Destination 1",
         "es-ES": "Continúa a la derecha hacia Destination 1",
+        "fi": "Jatka oikeall(e/a) suuntana Destination 1",
         "fr": "Continuer à droite en direction de Destination 1",
         "he": "המשך ימינה לכיוון Destination 1",
         "id": "Lanjutkan kanan menuju Destination 1",

--- a/test/fixtures/v5/notification/right_exit.json
+++ b/test/fixtures/v5/notification/right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Pluu dekstren al Way Name",
         "es": "Continúa derecha en Way Name",
         "es-ES": "Continúa a la derecha por Way Name",
+        "fi": "Jatka oikeall(e/a) tielle Way Name",
         "fr": "Continuer à droite sur Way Name",
         "he": "המשך ימינה על Way Name",
         "id": "Lanjutkan kanan menuju Way Name",

--- a/test/fixtures/v5/notification/right_exit_destination.json
+++ b/test/fixtures/v5/notification/right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Pluu dekstren direkte al Destination 1",
         "es": "Continúa derecha hacia Destination 1",
         "es-ES": "Continúa a la derecha hacia Destination 1",
+        "fi": "Jatka oikeall(e/a) suuntana Destination 1",
         "fr": "Continuer à droite en direction de Destination 1",
         "he": "המשך ימינה לכיוון Destination 1",
         "id": "Lanjutkan kanan menuju Destination 1",

--- a/test/fixtures/v5/notification/right_name.json
+++ b/test/fixtures/v5/notification/right_name.json
@@ -14,6 +14,7 @@
         "eo": "Pluu dekstren al Way Name",
         "es": "Continúa derecha en Way Name",
         "es-ES": "Continúa a la derecha por Way Name",
+        "fi": "Jatka oikeall(e/a) tielle Way Name",
         "fr": "Continuer à droite sur Way Name",
         "he": "המשך ימינה על Way Name",
         "id": "Lanjutkan kanan menuju Way Name",

--- a/test/fixtures/v5/notification/sharp_left_default.json
+++ b/test/fixtures/v5/notification/sharp_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Pluu maldekstregen",
         "es": "Continúa cerrada a la izquierda",
         "es-ES": "Continúa cerrada a la izquierda",
+        "fi": "Jatka jyrkästi vasempaan",
         "fr": "Continuer franchement à gauche",
         "he": "המשך חדה שמאלה",
         "id": "Lanjutkan tajam kiri",

--- a/test/fixtures/v5/notification/sharp_left_destination.json
+++ b/test/fixtures/v5/notification/sharp_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Pluu maldekstregen direkte al Destination 1",
         "es": "Continúa cerrada a la izquierda hacia Destination 1",
         "es-ES": "Continúa cerrada a la izquierda hacia Destination 1",
+        "fi": "Jatka jyrkästi vasempaan suuntana Destination 1",
         "fr": "Continuer franchement à gauche en direction de Destination 1",
         "he": "המשך חדה שמאלה לכיוון Destination 1",
         "id": "Lanjutkan tajam kiri menuju Destination 1",

--- a/test/fixtures/v5/notification/sharp_left_exit.json
+++ b/test/fixtures/v5/notification/sharp_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Pluu maldekstregen al Way Name",
         "es": "Continúa cerrada a la izquierda en Way Name",
         "es-ES": "Continúa cerrada a la izquierda por Way Name",
+        "fi": "Jatka jyrkästi vasempaan tielle Way Name",
         "fr": "Continuer franchement à gauche sur Way Name",
         "he": "המשך חדה שמאלה על Way Name",
         "id": "Lanjutkan tajam kiri menuju Way Name",

--- a/test/fixtures/v5/notification/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/notification/sharp_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Pluu maldekstregen direkte al Destination 1",
         "es": "Continúa cerrada a la izquierda hacia Destination 1",
         "es-ES": "Continúa cerrada a la izquierda hacia Destination 1",
+        "fi": "Jatka jyrkästi vasempaan suuntana Destination 1",
         "fr": "Continuer franchement à gauche en direction de Destination 1",
         "he": "המשך חדה שמאלה לכיוון Destination 1",
         "id": "Lanjutkan tajam kiri menuju Destination 1",

--- a/test/fixtures/v5/notification/sharp_left_name.json
+++ b/test/fixtures/v5/notification/sharp_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Pluu maldekstregen al Way Name",
         "es": "Continúa cerrada a la izquierda en Way Name",
         "es-ES": "Continúa cerrada a la izquierda por Way Name",
+        "fi": "Jatka jyrkästi vasempaan tielle Way Name",
         "fr": "Continuer franchement à gauche sur Way Name",
         "he": "המשך חדה שמאלה על Way Name",
         "id": "Lanjutkan tajam kiri menuju Way Name",

--- a/test/fixtures/v5/notification/sharp_right_default.json
+++ b/test/fixtures/v5/notification/sharp_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Pluu dekstregen",
         "es": "Continúa cerrada a la derecha",
         "es-ES": "Continúa cerrada a la derecha",
+        "fi": "Jatka jyrkästi oikeaan",
         "fr": "Continuer franchement à droite",
         "he": "המשך חדה ימינה",
         "id": "Lanjutkan tajam kanan",

--- a/test/fixtures/v5/notification/sharp_right_destination.json
+++ b/test/fixtures/v5/notification/sharp_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Pluu dekstregen direkte al Destination 1",
         "es": "Continúa cerrada a la derecha hacia Destination 1",
         "es-ES": "Continúa cerrada a la derecha hacia Destination 1",
+        "fi": "Jatka jyrkästi oikeaan suuntana Destination 1",
         "fr": "Continuer franchement à droite en direction de Destination 1",
         "he": "המשך חדה ימינה לכיוון Destination 1",
         "id": "Lanjutkan tajam kanan menuju Destination 1",

--- a/test/fixtures/v5/notification/sharp_right_exit.json
+++ b/test/fixtures/v5/notification/sharp_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Pluu dekstregen al Way Name",
         "es": "Continúa cerrada a la derecha en Way Name",
         "es-ES": "Continúa cerrada a la derecha por Way Name",
+        "fi": "Jatka jyrkästi oikeaan tielle Way Name",
         "fr": "Continuer franchement à droite sur Way Name",
         "he": "המשך חדה ימינה על Way Name",
         "id": "Lanjutkan tajam kanan menuju Way Name",

--- a/test/fixtures/v5/notification/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/notification/sharp_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Pluu dekstregen direkte al Destination 1",
         "es": "Continúa cerrada a la derecha hacia Destination 1",
         "es-ES": "Continúa cerrada a la derecha hacia Destination 1",
+        "fi": "Jatka jyrkästi oikeaan suuntana Destination 1",
         "fr": "Continuer franchement à droite en direction de Destination 1",
         "he": "המשך חדה ימינה לכיוון Destination 1",
         "id": "Lanjutkan tajam kanan menuju Destination 1",

--- a/test/fixtures/v5/notification/sharp_right_name.json
+++ b/test/fixtures/v5/notification/sharp_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Pluu dekstregen al Way Name",
         "es": "Continúa cerrada a la derecha en Way Name",
         "es-ES": "Continúa cerrada a la derecha por Way Name",
+        "fi": "Jatka jyrkästi oikeaan tielle Way Name",
         "fr": "Continuer franchement à droite sur Way Name",
         "he": "המשך חדה ימינה על Way Name",
         "id": "Lanjutkan tajam kanan menuju Way Name",

--- a/test/fixtures/v5/notification/slight_left_default.json
+++ b/test/fixtures/v5/notification/slight_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Pluu maldekstreten",
         "es": "Continúa levemente a la izquierda",
         "es-ES": "Continúa ligeramente a la izquierda",
+        "fi": "Jatka loivasti vasempaan",
         "fr": "Continuer légèrement à gauche",
         "he": "המשך קלה שמאלה",
         "id": "Lanjutkan agak ke kiri",

--- a/test/fixtures/v5/notification/slight_left_destination.json
+++ b/test/fixtures/v5/notification/slight_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Pluu maldekstreten direkte al Destination 1",
         "es": "Continúa levemente a la izquierda hacia Destination 1",
         "es-ES": "Continúa ligeramente a la izquierda hacia Destination 1",
+        "fi": "Jatka loivasti vasempaan suuntana Destination 1",
         "fr": "Continuer légèrement à gauche en direction de Destination 1",
         "he": "המשך קלה שמאלה לכיוון Destination 1",
         "id": "Lanjutkan agak ke kiri menuju Destination 1",

--- a/test/fixtures/v5/notification/slight_left_exit.json
+++ b/test/fixtures/v5/notification/slight_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Pluu maldekstreten al Way Name",
         "es": "Continúa levemente a la izquierda en Way Name",
         "es-ES": "Continúa ligeramente a la izquierda por Way Name",
+        "fi": "Jatka loivasti vasempaan tielle Way Name",
         "fr": "Continuer légèrement à gauche sur Way Name",
         "he": "המשך קלה שמאלה על Way Name",
         "id": "Lanjutkan agak ke kiri menuju Way Name",

--- a/test/fixtures/v5/notification/slight_left_exit_destination.json
+++ b/test/fixtures/v5/notification/slight_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Pluu maldekstreten direkte al Destination 1",
         "es": "Continúa levemente a la izquierda hacia Destination 1",
         "es-ES": "Continúa ligeramente a la izquierda hacia Destination 1",
+        "fi": "Jatka loivasti vasempaan suuntana Destination 1",
         "fr": "Continuer légèrement à gauche en direction de Destination 1",
         "he": "המשך קלה שמאלה לכיוון Destination 1",
         "id": "Lanjutkan agak ke kiri menuju Destination 1",

--- a/test/fixtures/v5/notification/slight_left_name.json
+++ b/test/fixtures/v5/notification/slight_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Pluu maldekstreten al Way Name",
         "es": "Continúa levemente a la izquierda en Way Name",
         "es-ES": "Continúa ligeramente a la izquierda por Way Name",
+        "fi": "Jatka loivasti vasempaan tielle Way Name",
         "fr": "Continuer légèrement à gauche sur Way Name",
         "he": "המשך קלה שמאלה על Way Name",
         "id": "Lanjutkan agak ke kiri menuju Way Name",

--- a/test/fixtures/v5/notification/slight_right_default.json
+++ b/test/fixtures/v5/notification/slight_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Pluu dekstreten",
         "es": "Continúa levemente a la derecha",
         "es-ES": "Continúa ligeramente a la derecha",
+        "fi": "Jatka loivasti oikeaan",
         "fr": "Continuer légèrement à droite",
         "he": "המשך קלה ימינה",
         "id": "Lanjutkan agak ke kanan",

--- a/test/fixtures/v5/notification/slight_right_destination.json
+++ b/test/fixtures/v5/notification/slight_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Pluu dekstreten direkte al Destination 1",
         "es": "Continúa levemente a la derecha hacia Destination 1",
         "es-ES": "Continúa ligeramente a la derecha hacia Destination 1",
+        "fi": "Jatka loivasti oikeaan suuntana Destination 1",
         "fr": "Continuer légèrement à droite en direction de Destination 1",
         "he": "המשך קלה ימינה לכיוון Destination 1",
         "id": "Lanjutkan agak ke kanan menuju Destination 1",

--- a/test/fixtures/v5/notification/slight_right_exit.json
+++ b/test/fixtures/v5/notification/slight_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Pluu dekstreten al Way Name",
         "es": "Continúa levemente a la derecha en Way Name",
         "es-ES": "Continúa ligeramente a la derecha por Way Name",
+        "fi": "Jatka loivasti oikeaan tielle Way Name",
         "fr": "Continuer légèrement à droite sur Way Name",
         "he": "המשך קלה ימינה על Way Name",
         "id": "Lanjutkan agak ke kanan menuju Way Name",

--- a/test/fixtures/v5/notification/slight_right_exit_destination.json
+++ b/test/fixtures/v5/notification/slight_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Pluu dekstreten direkte al Destination 1",
         "es": "Continúa levemente a la derecha hacia Destination 1",
         "es-ES": "Continúa ligeramente a la derecha hacia Destination 1",
+        "fi": "Jatka loivasti oikeaan suuntana Destination 1",
         "fr": "Continuer légèrement à droite en direction de Destination 1",
         "he": "המשך קלה ימינה לכיוון Destination 1",
         "id": "Lanjutkan agak ke kanan menuju Destination 1",

--- a/test/fixtures/v5/notification/slight_right_name.json
+++ b/test/fixtures/v5/notification/slight_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Pluu dekstreten al Way Name",
         "es": "Continúa levemente a la derecha en Way Name",
         "es-ES": "Continúa ligeramente a la derecha por Way Name",
+        "fi": "Jatka loivasti oikeaan tielle Way Name",
         "fr": "Continuer légèrement à droite sur Way Name",
         "he": "המשך קלה ימינה על Way Name",
         "id": "Lanjutkan agak ke kanan menuju Way Name",

--- a/test/fixtures/v5/notification/straight_default.json
+++ b/test/fixtures/v5/notification/straight_default.json
@@ -14,6 +14,7 @@
         "eo": "Pluu rekten",
         "es": "Continúa recto",
         "es-ES": "Continúa recto",
+        "fi": "Jatka suoraan eteenpäin",
         "fr": "Continuer tout droit",
         "he": "המשך ישר",
         "id": "Lanjutkan lurus",

--- a/test/fixtures/v5/notification/straight_destination.json
+++ b/test/fixtures/v5/notification/straight_destination.json
@@ -15,6 +15,7 @@
         "eo": "Pluu rekten direkte al Destination 1",
         "es": "Continúa recto hacia Destination 1",
         "es-ES": "Continúa recto hacia Destination 1",
+        "fi": "Jatka suoraan eteenpäin suuntana Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "he": "המשך ישר לכיוון Destination 1",
         "id": "Lanjutkan lurus menuju Destination 1",

--- a/test/fixtures/v5/notification/straight_exit.json
+++ b/test/fixtures/v5/notification/straight_exit.json
@@ -15,6 +15,7 @@
         "eo": "Pluu rekten al Way Name",
         "es": "Continúa recto en Way Name",
         "es-ES": "Continúa recto por Way Name",
+        "fi": "Jatka suoraan eteenpäin tielle Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "he": "המשך ישר על Way Name",
         "id": "Lanjutkan lurus menuju Way Name",

--- a/test/fixtures/v5/notification/straight_exit_destination.json
+++ b/test/fixtures/v5/notification/straight_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Pluu rekten direkte al Destination 1",
         "es": "Continúa recto hacia Destination 1",
         "es-ES": "Continúa recto hacia Destination 1",
+        "fi": "Jatka suoraan eteenpäin suuntana Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "he": "המשך ישר לכיוון Destination 1",
         "id": "Lanjutkan lurus menuju Destination 1",

--- a/test/fixtures/v5/notification/straight_name.json
+++ b/test/fixtures/v5/notification/straight_name.json
@@ -14,6 +14,7 @@
         "eo": "Pluu rekten al Way Name",
         "es": "Continúa recto en Way Name",
         "es-ES": "Continúa recto por Way Name",
+        "fi": "Jatka suoraan eteenpäin tielle Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "he": "המשך ישר על Way Name",
         "id": "Lanjutkan lurus menuju Way Name",

--- a/test/fixtures/v5/notification/uturn_default.json
+++ b/test/fixtures/v5/notification/uturn_default.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu malantaŭen",
         "es": "Haz un cambio de sentido",
         "es-ES": "Haz un cambio de sentido",
+        "fi": "Tee U-käännös",
         "fr": "Faire demi-tour",
         "he": "פנה פניית פרסה",
         "id": "Putar balik",

--- a/test/fixtures/v5/notification/uturn_destination.json
+++ b/test/fixtures/v5/notification/uturn_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu malantaŭen direkte al Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
         "es-ES": "Haz un cambio de sentido hacia Destination 1",
+        "fi": "Tee U-käännös suuntana Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "he": "פנה פניית פרסה לכיוון Destination 1",
         "id": "Putar balik menuju Destination 1",

--- a/test/fixtures/v5/notification/uturn_exit.json
+++ b/test/fixtures/v5/notification/uturn_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu malantaŭen al Way Name",
         "es": "Haz un cambio de sentido en Way Name",
         "es-ES": "Haz un cambio de sentido en Way Name",
+        "fi": "Tee U-käännös tielle Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "he": "פנה פניית פרסה על Way Name",
         "id": "Putar balik ke arah Way Name",

--- a/test/fixtures/v5/notification/uturn_exit_destination.json
+++ b/test/fixtures/v5/notification/uturn_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu malantaŭen direkte al Destination 1",
         "es": "Haz un cambio de sentido hacia Destination 1",
         "es-ES": "Haz un cambio de sentido hacia Destination 1",
+        "fi": "Tee U-käännös suuntana Destination 1",
         "fr": "Faire demi-tour en direction de Destination 1",
         "he": "פנה פניית פרסה לכיוון Destination 1",
         "id": "Putar balik menuju Destination 1",

--- a/test/fixtures/v5/notification/uturn_name.json
+++ b/test/fixtures/v5/notification/uturn_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu malantaŭen al Way Name",
         "es": "Haz un cambio de sentido en Way Name",
         "es-ES": "Haz un cambio de sentido en Way Name",
+        "fi": "Tee U-käännös tielle Way Name",
         "fr": "Faire demi-tour sur Way Name",
         "he": "פנה פניית פרסה על Way Name",
         "id": "Putar balik ke arah Way Name",

--- a/test/fixtures/v5/off_ramp/left_default.json
+++ b/test/fixtures/v5/off_ramp/left_default.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre",
         "es": "Toma la salida en la izquierda",
         "es-ES": "Coge la cuesta abajo de la izquierda",
+        "fi": "Aja vasemmalla olevalle erkanemiskaistalle",
         "fr": "Prendre la sortie à gauche",
         "he": "צא ביציאה שמשמאלך",
         "id": "Ambil jalan yang melandai di sebelah kiri",

--- a/test/fixtures/v5/off_ramp/left_destination.json
+++ b/test/fixtures/v5/off_ramp/left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Destination 1",
         "es": "Toma la salida en la izquierda en Destination 1",
         "es-ES": "Coge la cuesta abajo de la izquierda hacia Destination 1",
+        "fi": "Aja vasemmalla olevalle erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "he": "צא ביציאה שמשמאלך לכיוון Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",

--- a/test/fixtures/v5/off_ramp/left_exit.json
+++ b/test/fixtures/v5/off_ramp/left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al elveturejo 4A ĉe maldekstre",
         "es": "Toma la salida 4A en la izquierda",
         "es-ES": "Coge la cuesta abajo 4A a tu izquierda",
+        "fi": "Ota poistuminen 4A vasemmalla",
         "fr": "Prendre la sortie 4A sur la gauche",
         "he": "צא ביציאה 4A משמאלך",
         "id": "Take exit 4A on the left",

--- a/test/fixtures/v5/off_ramp/left_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Direktiĝu al elveturejo 4A ĉe maldekstre direkte al Destination 1",
         "es": "Toma la salida 4A en la izquierda hacia Destination 1",
         "es-ES": "Coge la cuesta abajo 4A a tu izquierda hacia Destination 1",
+        "fi": "Ota poistuminen 4A vasemmalla, suuntana Destination 1",
         "fr": "Prendre la sortie 4A sur la gauche en direction de Destination 1",
         "he": "צא ביציאה 4A משמאלך לכיוון Destination 1",
         "id": "Take exit 4A on the left towards Destination 1",

--- a/test/fixtures/v5/off_ramp/left_name.json
+++ b/test/fixtures/v5/off_ramp/left_name.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Way Name",
         "es": "Toma la salida en la izquierda en Way Name",
         "es-ES": "Coge la cuesta abajo de la izquierda por Way Name",
+        "fi": "Aja vasemmalla olevaa erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "he": "צא ביציאה שמשמאלך על Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",

--- a/test/fixtures/v5/off_ramp/right_default.json
+++ b/test/fixtures/v5/off_ramp/right_default.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo",
         "es": "Toma la salida",
         "es-ES": "Coge la cuesta abajo",
+        "fi": "Aja erkanemiskaistalle",
         "fr": "Prendre la sortie",
         "he": "צא ביציאה",
         "id": "Ambil jalan melandai",

--- a/test/fixtures/v5/off_ramp/right_destination.json
+++ b/test/fixtures/v5/off_ramp/right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo direkte al Destination 1",
         "es": "Toma la salida hacia Destination 1",
         "es-ES": "Coge la cuesta abajo hacia Destination 1",
+        "fi": "Aja erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "he": "צא ביציאה לכיוון Destination 1",
         "id": "Ambil jalan melandai menuju Destination 1",

--- a/test/fixtures/v5/off_ramp/right_exit.json
+++ b/test/fixtures/v5/off_ramp/right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al elveturejo 4A",
         "es": "Toma la salida 4A",
         "es-ES": "Coge la cuesta abajo 4A",
+        "fi": "Ota poistuminen 4A",
         "fr": "Prendre la sortie 4A",
         "he": "צא ביציאה 4A",
         "id": "Take exit 4A",

--- a/test/fixtures/v5/off_ramp/right_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Direktiĝu al elveturejo 4A direkte al Destination 1",
         "es": "Toma la salida 4A hacia Destination 1",
         "es-ES": "Coge la cuesta abajo 4A hacia Destination 1",
+        "fi": "Ota poistuminen 4A, suuntana Destination 1",
         "fr": "Prendre la sortie 4A en direction de Destination 1",
         "he": "צא ביציאה 4A לכיוון Destination 1",
         "id": "Take exit 4A towards Destination 1",

--- a/test/fixtures/v5/off_ramp/right_name.json
+++ b/test/fixtures/v5/off_ramp/right_name.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo al Way Name",
         "es": "Toma la salida en Way Name",
         "es-ES": "Coge la cuesta abajo por Way Name",
+        "fi": "Aja erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "he": "צא ביציאה על Way Name",
         "id": "Ambil jalan melandai ke Way Name",

--- a/test/fixtures/v5/off_ramp/sharp_left_default.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre",
         "es": "Ve cuesta abajo en la izquierda",
         "es-ES": "Coge la cuesta abajo de la izquierda",
+        "fi": "Aja vasemmalla olevalle erkanemiskaistalle",
         "fr": "Prendre la sortie à gauche",
         "he": "צא ביציאה שבשמאלך",
         "id": "Ambil jalan yang melandai di sebelah kiri",

--- a/test/fixtures/v5/off_ramp/sharp_left_destination.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Destination 1",
         "es": "Ve cuesta abajo en la izquierda hacia Destination 1",
         "es-ES": "Coge la cuesta abajo de la izquierda hacia Destination 1",
+        "fi": "Aja vasemmalla olevalle erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "he": "צא ביציאה שמשמאלך לכיוון Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",

--- a/test/fixtures/v5/off_ramp/sharp_left_exit.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al 4A elveturejo ĉe maldekstre",
         "es": "Toma la salida 4A en la izquierda",
         "es-ES": "Coge la cuesta abajo 4A a tu izquierda",
+        "fi": "Ota poistuminen 4A vasemmalla",
         "fr": "Prendre la sortie 4A sur la gauche",
         "he": "צא ביציאה 4A משמאלך",
         "id": "Take exit 4A on the left",

--- a/test/fixtures/v5/off_ramp/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Direktiĝu al elveturejo 4A ĉe maldekstre direkte al Destination 1",
         "es": "Toma la salida 4A en la izquierda hacia Destination 1",
         "es-ES": "Coge la cuesta abajo 4A a tu izquierda hacia Destination 1",
+        "fi": "Ota poistuminen 4A vasemmalla, suuntana Destination 1",
         "fr": "Prendre la sortie 4A sur la gauche en direction de Destination 1",
         "he": "צא ביציאה 4A משמאלך לכיוון Destination 1",
         "id": "Take exit 4A on the left towards Destination 1",

--- a/test/fixtures/v5/off_ramp/sharp_left_name.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Way Name",
         "es": "Ve cuesta abajo en la izquierda en Way Name",
         "es-ES": "Coge la cuesta abajo de la izquierda por Way Name",
+        "fi": "Aja vasemmalla olevaa erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "he": "צא ביציאה שמשמאלך על Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",

--- a/test/fixtures/v5/off_ramp/sharp_right_default.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo",
         "es": "Toma la salida",
         "es-ES": "Coge la cuesta abajo",
+        "fi": "Aja erkanemiskaistalle",
         "fr": "Prendre la sortie",
         "he": "צא ביציאה",
         "id": "Ambil jalan melandai",

--- a/test/fixtures/v5/off_ramp/sharp_right_destination.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo direkte al Destination 1",
         "es": "Toma la salida hacia Destination 1",
         "es-ES": "Coge la cuesta abajo hacia Destination 1",
+        "fi": "Aja erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "he": "צא ביציאה לכיוון Destination 1",
         "id": "Ambil jalan melandai menuju Destination 1",

--- a/test/fixtures/v5/off_ramp/sharp_right_exit.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al elveturejo 4A",
         "es": "Toma la salida 4A",
         "es-ES": "Coge la cuesta abajo 4A",
+        "fi": "Ota poistuminen 4A",
         "fr": "Prendre la sortie 4A",
         "he": "צא ביציאה 4A",
         "id": "Take exit 4A",

--- a/test/fixtures/v5/off_ramp/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Direktiĝu al elveturejo 4A direkte al Destination 1",
         "es": "Toma la salida 4A hacia Destination 1",
         "es-ES": "Coge la cuesta abajo 4A hacia Destination 1",
+        "fi": "Ota poistuminen 4A, suuntana Destination 1",
         "fr": "Prendre la sortie 4A en direction de Destination 1",
         "he": "צא ביציאה 4A לכיוון Destination 1",
         "id": "Take exit 4A towards Destination 1",

--- a/test/fixtures/v5/off_ramp/sharp_right_name.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo al Way Name",
         "es": "Toma la salida en Way Name",
         "es-ES": "Coge la cuesta abajo por Way Name",
+        "fi": "Aja erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "he": "צא ביציאה על Way Name",
         "id": "Ambil jalan melandai ke Way Name",

--- a/test/fixtures/v5/off_ramp/slight_left_default.json
+++ b/test/fixtures/v5/off_ramp/slight_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre",
         "es": "Ve cuesta abajo en la izquierda",
         "es-ES": "Coge la cuesta abajo de la izquierda",
+        "fi": "Aja vasemmalla olevalle erkanemiskaistalle",
         "fr": "Prendre la sortie à gauche",
         "he": "צא ביציאה שבשמאלך",
         "id": "Ambil jalan yang melandai di sebelah kiri",

--- a/test/fixtures/v5/off_ramp/slight_left_destination.json
+++ b/test/fixtures/v5/off_ramp/slight_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Destination 1",
         "es": "Ve cuesta abajo en la izquierda hacia Destination 1",
         "es-ES": "Coge la cuesta abajo de la izquierda hacia Destination 1",
+        "fi": "Aja vasemmalla olevalle erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "he": "צא ביציאה שמשמאלך לכיוון Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",

--- a/test/fixtures/v5/off_ramp/slight_left_exit.json
+++ b/test/fixtures/v5/off_ramp/slight_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al 4A elveturejo ĉe maldekstre",
         "es": "Toma la salida 4A en la izquierda",
         "es-ES": "Coge la cuesta abajo 4A a tu izquierda",
+        "fi": "Ota poistuminen 4A vasemmalla",
         "fr": "Prendre la sortie 4A sur la gauche",
         "he": "צא ביציאה 4A משמאלך",
         "id": "Take exit 4A on the left",

--- a/test/fixtures/v5/off_ramp/slight_left_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/slight_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Direktiĝu al elveturejo 4A ĉe maldekstre direkte al Destination 1",
         "es": "Toma la salida 4A en la izquierda hacia Destination 1",
         "es-ES": "Coge la cuesta abajo 4A a tu izquierda hacia Destination 1",
+        "fi": "Ota poistuminen 4A vasemmalla, suuntana Destination 1",
         "fr": "Prendre la sortie 4A sur la gauche en direction de Destination 1",
         "he": "צא ביציאה 4A משמאלך לכיוון Destination 1",
         "id": "Take exit 4A on the left towards Destination 1",

--- a/test/fixtures/v5/off_ramp/slight_left_name.json
+++ b/test/fixtures/v5/off_ramp/slight_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Way Name",
         "es": "Ve cuesta abajo en la izquierda en Way Name",
         "es-ES": "Coge la cuesta abajo de la izquierda por Way Name",
+        "fi": "Aja vasemmalla olevaa erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "he": "צא ביציאה שמשמאלך על Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",

--- a/test/fixtures/v5/off_ramp/slight_right_default.json
+++ b/test/fixtures/v5/off_ramp/slight_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo",
         "es": "Toma la salida",
         "es-ES": "Coge la cuesta abajo",
+        "fi": "Aja erkanemiskaistalle",
         "fr": "Prendre la sortie",
         "he": "צא ביציאה",
         "id": "Ambil jalan melandai",

--- a/test/fixtures/v5/off_ramp/slight_right_destination.json
+++ b/test/fixtures/v5/off_ramp/slight_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo direkte al Destination 1",
         "es": "Toma la salida hacia Destination 1",
         "es-ES": "Coge la cuesta abajo hacia Destination 1",
+        "fi": "Aja erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "he": "צא ביציאה לכיוון Destination 1",
         "id": "Ambil jalan melandai menuju Destination 1",

--- a/test/fixtures/v5/off_ramp/slight_right_exit.json
+++ b/test/fixtures/v5/off_ramp/slight_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al elveturejo 4A",
         "es": "Toma la salida 4A",
         "es-ES": "Coge la cuesta abajo 4A",
+        "fi": "Ota poistuminen 4A",
         "fr": "Prendre la sortie 4A",
         "he": "צא ביציאה 4A",
         "id": "Take exit 4A",

--- a/test/fixtures/v5/off_ramp/slight_right_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/slight_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Direktiĝu al elveturejo 4A direkte al Destination 1",
         "es": "Toma la salida 4A hacia Destination 1",
         "es-ES": "Coge la cuesta abajo 4A hacia Destination 1",
+        "fi": "Ota poistuminen 4A, suuntana Destination 1",
         "fr": "Prendre la sortie 4A en direction de Destination 1",
         "he": "צא ביציאה 4A לכיוון Destination 1",
         "id": "Take exit 4A towards Destination 1",

--- a/test/fixtures/v5/off_ramp/slight_right_name.json
+++ b/test/fixtures/v5/off_ramp/slight_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo al Way Name",
         "es": "Toma la salida en Way Name",
         "es-ES": "Coge la cuesta abajo por Way Name",
+        "fi": "Aja erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "he": "צא ביציאה על Way Name",
         "id": "Ambil jalan melandai ke Way Name",

--- a/test/fixtures/v5/off_ramp/straight_default.json
+++ b/test/fixtures/v5/off_ramp/straight_default.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo",
         "es": "Toma la salida",
         "es-ES": "Coge la cuesta abajo",
+        "fi": "Aja erkanemiskaistalle",
         "fr": "Prendre la sortie",
         "he": "צא ביציאה",
         "id": "Ambil jalan melandai",

--- a/test/fixtures/v5/off_ramp/straight_destination.json
+++ b/test/fixtures/v5/off_ramp/straight_destination.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo direkte al Destination 1",
         "es": "Toma la salida hacia Destination 1",
         "es-ES": "Coge la cuesta abajo hacia Destination 1",
+        "fi": "Aja erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "he": "צא ביציאה לכיוון Destination 1",
         "id": "Ambil jalan melandai menuju Destination 1",

--- a/test/fixtures/v5/off_ramp/straight_exit.json
+++ b/test/fixtures/v5/off_ramp/straight_exit.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al elveturejo 4A",
         "es": "Toma la salida 4A",
         "es-ES": "Coge la cuesta abajo 4A",
+        "fi": "Ota poistuminen 4A",
         "fr": "Prendre la sortie 4A",
         "he": "צא ביציאה 4A",
         "id": "Take exit 4A",

--- a/test/fixtures/v5/off_ramp/straight_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/straight_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Direktiĝu al elveturejo 4A direkte al Destination 1",
         "es": "Toma la salida 4A hacia Destination 1",
         "es-ES": "Coge la cuesta abajo 4A hacia Destination 1",
+        "fi": "Ota poistuminen 4A, suuntana Destination 1",
         "fr": "Prendre la sortie 4A en direction de Destination 1",
         "he": "צא ביציאה 4A לכיוון Destination 1",
         "id": "Take exit 4A towards Destination 1",

--- a/test/fixtures/v5/off_ramp/straight_name.json
+++ b/test/fixtures/v5/off_ramp/straight_name.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo al Way Name",
         "es": "Toma la salida en Way Name",
         "es-ES": "Coge la cuesta abajo por Way Name",
+        "fi": "Aja erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "he": "צא ביציאה על Way Name",
         "id": "Ambil jalan melandai ke Way Name",

--- a/test/fixtures/v5/off_ramp/uturn_default.json
+++ b/test/fixtures/v5/off_ramp/uturn_default.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo",
         "es": "Toma la salida",
         "es-ES": "Coge la cuesta abajo",
+        "fi": "Aja erkanemiskaistalle",
         "fr": "Prendre la sortie",
         "he": "צא ביציאה",
         "id": "Ambil jalan melandai",

--- a/test/fixtures/v5/off_ramp/uturn_destination.json
+++ b/test/fixtures/v5/off_ramp/uturn_destination.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo direkte al Destination 1",
         "es": "Toma la salida hacia Destination 1",
         "es-ES": "Coge la cuesta abajo hacia Destination 1",
+        "fi": "Aja erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "he": "צא ביציאה לכיוון Destination 1",
         "id": "Ambil jalan melandai menuju Destination 1",

--- a/test/fixtures/v5/off_ramp/uturn_exit.json
+++ b/test/fixtures/v5/off_ramp/uturn_exit.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al elveturejo 4A",
         "es": "Toma la salida 4A",
         "es-ES": "Coge la cuesta abajo 4A",
+        "fi": "Ota poistuminen 4A",
         "fr": "Prendre la sortie 4A",
         "he": "צא ביציאה 4A",
         "id": "Take exit 4A",

--- a/test/fixtures/v5/off_ramp/uturn_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/uturn_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Direktiĝu al elveturejo 4A direkte al Destination 1",
         "es": "Toma la salida 4A hacia Destination 1",
         "es-ES": "Coge la cuesta abajo 4A hacia Destination 1",
+        "fi": "Ota poistuminen 4A, suuntana Destination 1",
         "fr": "Prendre la sortie 4A en direction de Destination 1",
         "he": "צא ביציאה 4A לכיוון Destination 1",
         "id": "Take exit 4A towards Destination 1",

--- a/test/fixtures/v5/off_ramp/uturn_name.json
+++ b/test/fixtures/v5/off_ramp/uturn_name.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo al Way Name",
         "es": "Toma la salida en Way Name",
         "es-ES": "Coge la cuesta abajo por Way Name",
+        "fi": "Aja erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "he": "צא ביציאה על Way Name",
         "id": "Ambil jalan melandai ke Way Name",

--- a/test/fixtures/v5/on_ramp/left_default.json
+++ b/test/fixtures/v5/on_ramp/left_default.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre",
         "es": "Toma la rampa en la izquierda",
         "es-ES": "Coge la cuesta de la izquierda",
+        "fi": "Aja vasemmalla olevalle erkanemiskaistalle",
         "fr": "Prendre la sortie à gauche",
         "he": "צא ביציאה שבשמאלך",
         "id": "Ambil jalan yang melandai di sebelah kiri",

--- a/test/fixtures/v5/on_ramp/left_destination.json
+++ b/test/fixtures/v5/on_ramp/left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Destination 1",
         "es": "Toma la rampa en la izquierda hacia Destination 1",
         "es-ES": "Coge la cuesta de la izquierda hacia Destination 1",
+        "fi": "Aja vasemmalla olevalle erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "he": "צא ביציאה שמשמאלך לכיוון Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",

--- a/test/fixtures/v5/on_ramp/left_exit.json
+++ b/test/fixtures/v5/on_ramp/left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Way Name",
         "es": "Toma la rampa en la izquierda en Way Name",
         "es-ES": "Coge la cuesta de la izquierda por Way Name",
+        "fi": "Aja vasemmalla olevaa erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "he": "צא ביציאה שמשמאלך על Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",

--- a/test/fixtures/v5/on_ramp/left_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Destination 1",
         "es": "Toma la rampa en la izquierda hacia Destination 1",
         "es-ES": "Coge la cuesta de la izquierda hacia Destination 1",
+        "fi": "Aja vasemmalla olevalle erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "he": "צא ביציאה שמשמאלך לכיוון Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",

--- a/test/fixtures/v5/on_ramp/left_name.json
+++ b/test/fixtures/v5/on_ramp/left_name.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Way Name",
         "es": "Toma la rampa en la izquierda en Way Name",
         "es-ES": "Coge la cuesta de la izquierda por Way Name",
+        "fi": "Aja vasemmalla olevaa erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "he": "צא ביציאה שמשמאלך על Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",

--- a/test/fixtures/v5/on_ramp/right_default.json
+++ b/test/fixtures/v5/on_ramp/right_default.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe dekstre",
         "es": "Toma la rampa en la derecha",
         "es-ES": "Coge la cuesta de la derecha",
+        "fi": "Aja oikealla olevalle erkanemiskaistalle",
         "fr": "Prendre la sortie à droite",
         "he": "צא ביציאה שמימינך",
         "id": "Ambil jalan melandai di sebelah kanan",

--- a/test/fixtures/v5/on_ramp/right_destination.json
+++ b/test/fixtures/v5/on_ramp/right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo ĉe dekstre al Destination 1",
         "es": "Toma la rampa en la derecha hacia Destination 1",
         "es-ES": "Coge la cuesta de la derecha hacia Destination 1",
+        "fi": "Aja oikealla olevalle erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "he": "צא ביציאה שמימינך לכיוון Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",

--- a/test/fixtures/v5/on_ramp/right_exit.json
+++ b/test/fixtures/v5/on_ramp/right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo ĉe dekstre al Way Name",
         "es": "Toma la rampa en la derecha en Way Name",
         "es-ES": "Coge la cuesta de la derecha por Way Name",
+        "fi": "Aja oikealla olevaa erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "he": "צא ביציאה שמימינך על Way Name",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",

--- a/test/fixtures/v5/on_ramp/right_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Direktiĝu al enveturejo ĉe dekstre al Destination 1",
         "es": "Toma la rampa en la derecha hacia Destination 1",
         "es-ES": "Coge la cuesta de la derecha hacia Destination 1",
+        "fi": "Aja oikealla olevalle erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "he": "צא ביציאה שמימינך לכיוון Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",

--- a/test/fixtures/v5/on_ramp/right_name.json
+++ b/test/fixtures/v5/on_ramp/right_name.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe dekstre al Way Name",
         "es": "Toma la rampa en la derecha en Way Name",
         "es-ES": "Coge la cuesta de la derecha por Way Name",
+        "fi": "Aja oikealla olevaa erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "he": "צא ביציאה שמימינך על Way Name",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",

--- a/test/fixtures/v5/on_ramp/sharp_left_default.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre",
         "es": "Toma la rampa en la izquierda",
         "es-ES": "Coge la cuesta de la izquierda",
+        "fi": "Aja vasemmalla olevalle erkanemiskaistalle",
         "fr": "Prendre la sortie à gauche",
         "he": "צא ביציאה שבשמאלך",
         "id": "Ambil jalan yang melandai di sebelah kiri",

--- a/test/fixtures/v5/on_ramp/sharp_left_destination.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Destination 1",
         "es": "Toma la rampa en la izquierda hacia Destination 1",
         "es-ES": "Coge la cuesta de la izquierda hacia Destination 1",
+        "fi": "Aja vasemmalla olevalle erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "he": "צא ביציאה שמשמאלך לכיוון Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",

--- a/test/fixtures/v5/on_ramp/sharp_left_exit.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Way Name",
         "es": "Toma la rampa en la izquierda en Way Name",
         "es-ES": "Coge la cuesta de la izquierda por Way Name",
+        "fi": "Aja vasemmalla olevaa erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "he": "צא ביציאה שמשמאלך על Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",

--- a/test/fixtures/v5/on_ramp/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Destination 1",
         "es": "Toma la rampa en la izquierda hacia Destination 1",
         "es-ES": "Coge la cuesta de la izquierda hacia Destination 1",
+        "fi": "Aja vasemmalla olevalle erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "he": "צא ביציאה שמשמאלך לכיוון Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",

--- a/test/fixtures/v5/on_ramp/sharp_left_name.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Way Name",
         "es": "Toma la rampa en la izquierda en Way Name",
         "es-ES": "Coge la cuesta de la izquierda por Way Name",
+        "fi": "Aja vasemmalla olevaa erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "he": "צא ביציאה שמשמאלך על Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",

--- a/test/fixtures/v5/on_ramp/sharp_right_default.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe dekstre",
         "es": "Toma la rampa en la derecha",
         "es-ES": "Coge la cuesta de la derecha",
+        "fi": "Aja oikealla olevalle erkanemiskaistalle",
         "fr": "Prendre la sortie à droite",
         "he": "צא ביציאה שמימינך",
         "id": "Ambil jalan melandai di sebelah kanan",

--- a/test/fixtures/v5/on_ramp/sharp_right_destination.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo ĉe dekstre al Destination 1",
         "es": "Toma la rampa en la derecha hacia Destination 1",
         "es-ES": "Coge la cuesta de la derecha hacia Destination 1",
+        "fi": "Aja oikealla olevalle erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "he": "צא ביציאה שמימינך לכיוון Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",

--- a/test/fixtures/v5/on_ramp/sharp_right_exit.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo ĉe dekstre al Way Name",
         "es": "Toma la rampa en la derecha en Way Name",
         "es-ES": "Coge la cuesta de la derecha por Way Name",
+        "fi": "Aja oikealla olevaa erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "he": "צא ביציאה שמימינך על Way Name",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",

--- a/test/fixtures/v5/on_ramp/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Direktiĝu al enveturejo ĉe dekstre al Destination 1",
         "es": "Toma la rampa en la derecha hacia Destination 1",
         "es-ES": "Coge la cuesta de la derecha hacia Destination 1",
+        "fi": "Aja oikealla olevalle erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "he": "צא ביציאה שמימינך לכיוון Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",

--- a/test/fixtures/v5/on_ramp/sharp_right_name.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe dekstre al Way Name",
         "es": "Toma la rampa en la derecha en Way Name",
         "es-ES": "Coge la cuesta de la derecha por Way Name",
+        "fi": "Aja oikealla olevaa erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "he": "צא ביציאה שמימינך על Way Name",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",

--- a/test/fixtures/v5/on_ramp/slight_left_default.json
+++ b/test/fixtures/v5/on_ramp/slight_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre",
         "es": "Toma la rampa en la izquierda",
         "es-ES": "Coge la cuesta de la izquierda",
+        "fi": "Aja vasemmalla olevalle erkanemiskaistalle",
         "fr": "Prendre la sortie à gauche",
         "he": "צא ביציאה שבשמאלך",
         "id": "Ambil jalan yang melandai di sebelah kiri",

--- a/test/fixtures/v5/on_ramp/slight_left_destination.json
+++ b/test/fixtures/v5/on_ramp/slight_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Destination 1",
         "es": "Toma la rampa en la izquierda hacia Destination 1",
         "es-ES": "Coge la cuesta de la izquierda hacia Destination 1",
+        "fi": "Aja vasemmalla olevalle erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "he": "צא ביציאה שמשמאלך לכיוון Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",

--- a/test/fixtures/v5/on_ramp/slight_left_exit.json
+++ b/test/fixtures/v5/on_ramp/slight_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Way Name",
         "es": "Toma la rampa en la izquierda en Way Name",
         "es-ES": "Coge la cuesta de la izquierda por Way Name",
+        "fi": "Aja vasemmalla olevaa erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "he": "צא ביציאה שמשמאלך על Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",

--- a/test/fixtures/v5/on_ramp/slight_left_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/slight_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Destination 1",
         "es": "Toma la rampa en la izquierda hacia Destination 1",
         "es-ES": "Coge la cuesta de la izquierda hacia Destination 1",
+        "fi": "Aja vasemmalla olevalle erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie à gauche en direction de Destination 1",
         "he": "צא ביציאה שמשמאלך לכיוון Destination 1",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",

--- a/test/fixtures/v5/on_ramp/slight_left_name.json
+++ b/test/fixtures/v5/on_ramp/slight_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe maldekstre al Way Name",
         "es": "Toma la rampa en la izquierda en Way Name",
         "es-ES": "Coge la cuesta de la izquierda por Way Name",
+        "fi": "Aja vasemmalla olevaa erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie à gauche sur Way Name",
         "he": "צא ביציאה שמשמאלך על Way Name",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",

--- a/test/fixtures/v5/on_ramp/slight_right_default.json
+++ b/test/fixtures/v5/on_ramp/slight_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe dekstre",
         "es": "Toma la rampa en la derecha",
         "es-ES": "Coge la cuesta de la derecha",
+        "fi": "Aja oikealla olevalle erkanemiskaistalle",
         "fr": "Prendre la sortie à droite",
         "he": "צא ביציאה שמימינך",
         "id": "Ambil jalan melandai di sebelah kanan",

--- a/test/fixtures/v5/on_ramp/slight_right_destination.json
+++ b/test/fixtures/v5/on_ramp/slight_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo ĉe dekstre al Destination 1",
         "es": "Toma la rampa en la derecha hacia Destination 1",
         "es-ES": "Coge la cuesta de la derecha hacia Destination 1",
+        "fi": "Aja oikealla olevalle erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "he": "צא ביציאה שמימינך לכיוון Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",

--- a/test/fixtures/v5/on_ramp/slight_right_exit.json
+++ b/test/fixtures/v5/on_ramp/slight_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo ĉe dekstre al Way Name",
         "es": "Toma la rampa en la derecha en Way Name",
         "es-ES": "Coge la cuesta de la derecha por Way Name",
+        "fi": "Aja oikealla olevaa erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "he": "צא ביציאה שמימינך על Way Name",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",

--- a/test/fixtures/v5/on_ramp/slight_right_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/slight_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Direktiĝu al enveturejo ĉe dekstre al Destination 1",
         "es": "Toma la rampa en la derecha hacia Destination 1",
         "es-ES": "Coge la cuesta de la derecha hacia Destination 1",
+        "fi": "Aja oikealla olevalle erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie à droite en direction de Destination 1",
         "he": "צא ביציאה שמימינך לכיוון Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",

--- a/test/fixtures/v5/on_ramp/slight_right_name.json
+++ b/test/fixtures/v5/on_ramp/slight_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo ĉe dekstre al Way Name",
         "es": "Toma la rampa en la derecha en Way Name",
         "es-ES": "Coge la cuesta de la derecha por Way Name",
+        "fi": "Aja oikealla olevaa erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie à droite sur Way Name",
         "he": "צא ביציאה שמימינך על Way Name",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",

--- a/test/fixtures/v5/on_ramp/straight_default.json
+++ b/test/fixtures/v5/on_ramp/straight_default.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo",
         "es": "Toma la rampa",
         "es-ES": "Coge la cuesta",
+        "fi": "Aja erkanemiskaistalle",
         "fr": "Prendre la sortie",
         "he": "צא ביציאה",
         "id": "Ambil jalan melandai",

--- a/test/fixtures/v5/on_ramp/straight_destination.json
+++ b/test/fixtures/v5/on_ramp/straight_destination.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo direkte al Destination 1",
         "es": "Toma la rampa hacia Destination 1",
         "es-ES": "Coge la cuesta hacia Destination 1",
+        "fi": "Aja erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "he": "צא ביציאה לכיוון Destination 1",
         "id": "Ambil jalan melandai menuju Destination 1",

--- a/test/fixtures/v5/on_ramp/straight_exit.json
+++ b/test/fixtures/v5/on_ramp/straight_exit.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo al Way Name",
         "es": "Toma la rampa en Way Name",
         "es-ES": "Coge la cuesta por Way Name",
+        "fi": "Aja erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "he": "צא ביציאה על Way Name",
         "id": "Ambil jalan melandai ke Way Name",

--- a/test/fixtures/v5/on_ramp/straight_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/straight_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Direktiĝu al enveturejo direkte al Destination 1",
         "es": "Toma la rampa hacia Destination 1",
         "es-ES": "Coge la cuesta hacia Destination 1",
+        "fi": "Aja erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "he": "צא ביציאה לכיוון Destination 1",
         "id": "Ambil jalan melandai menuju Destination 1",

--- a/test/fixtures/v5/on_ramp/straight_name.json
+++ b/test/fixtures/v5/on_ramp/straight_name.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo al Way Name",
         "es": "Toma la rampa en Way Name",
         "es-ES": "Coge la cuesta por Way Name",
+        "fi": "Aja erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "he": "צא ביציאה על Way Name",
         "id": "Ambil jalan melandai ke Way Name",

--- a/test/fixtures/v5/on_ramp/uturn_default.json
+++ b/test/fixtures/v5/on_ramp/uturn_default.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo",
         "es": "Toma la rampa",
         "es-ES": "Coge la cuesta",
+        "fi": "Aja erkanemiskaistalle",
         "fr": "Prendre la sortie",
         "he": "צא ביציאה",
         "id": "Ambil jalan melandai",

--- a/test/fixtures/v5/on_ramp/uturn_destination.json
+++ b/test/fixtures/v5/on_ramp/uturn_destination.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo direkte al Destination 1",
         "es": "Toma la rampa hacia Destination 1",
         "es-ES": "Coge la cuesta hacia Destination 1",
+        "fi": "Aja erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "he": "צא ביציאה לכיוון Destination 1",
         "id": "Ambil jalan melandai menuju Destination 1",

--- a/test/fixtures/v5/on_ramp/uturn_exit.json
+++ b/test/fixtures/v5/on_ramp/uturn_exit.json
@@ -15,6 +15,7 @@
         "eo": "Direktiĝu al enveturejo al Way Name",
         "es": "Toma la rampa en Way Name",
         "es-ES": "Coge la cuesta por Way Name",
+        "fi": "Aja erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "he": "צא ביציאה על Way Name",
         "id": "Ambil jalan melandai ke Way Name",

--- a/test/fixtures/v5/on_ramp/uturn_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/uturn_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Direktiĝu al enveturejo direkte al Destination 1",
         "es": "Toma la rampa hacia Destination 1",
         "es-ES": "Coge la cuesta hacia Destination 1",
+        "fi": "Aja erkanemiskaistalle suuntana Destination 1",
         "fr": "Prendre la sortie en direction de Destination 1",
         "he": "צא ביציאה לכיוון Destination 1",
         "id": "Ambil jalan melandai menuju Destination 1",

--- a/test/fixtures/v5/on_ramp/uturn_name.json
+++ b/test/fixtures/v5/on_ramp/uturn_name.json
@@ -14,6 +14,7 @@
         "eo": "Direktiĝu al enveturejo al Way Name",
         "es": "Toma la rampa en Way Name",
         "es-ES": "Coge la cuesta por Way Name",
+        "fi": "Aja erkanemiskaistaa tielle Way Name",
         "fr": "Prendre la sortie sur Way Name",
         "he": "צא ביציאה על Way Name",
         "id": "Ambil jalan melandai ke Way Name",

--- a/test/fixtures/v5/other/invalid_type.json
+++ b/test/fixtures/v5/other/invalid_type.json
@@ -13,6 +13,7 @@
         "eo": "Turniĝu maldekstren al Way Name",
         "es": "Gira a la izquierda en Way Name",
         "es-ES": "Gira a la izquierda por Way Name",
+        "fi": "Käänny vasempaan tielle Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "he": "פנה שמאלה לWay Name",
         "id": "Belok kiri ke Way Name",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_left.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstren al Cool highway",
         "es": "Cruza a laizquierda en Cool highway",
         "es-ES": "Cruce a la izquierda en Cool highway",
+        "fi": "Käänny vasemmall(e/a) pysyäksesi tiellä Cool highway",
         "fr": "Tourner à gauche pour rester Cool highway",
         "he": "פנה שמאלה כדי להישאר בCool highway",
         "id": "Terus kiri ke Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_right.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstren al Cool highway",
         "es": "Cruza a laderecha en Cool highway",
         "es-ES": "Cruce a la derecha en Cool highway",
+        "fi": "Käänny oikeall(e/a) pysyäksesi tiellä Cool highway",
         "fr": "Tourner à droite pour rester Cool highway",
         "he": "פנה ימינה כדי להישאר בCool highway",
         "id": "Terus kanan ke Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_sharp left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_sharp left.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ege maldekstren al Cool highway",
         "es": "Gira a la izquierda en Cool highway",
         "es-ES": "Gire a la izquierda en Cool highway",
+        "fi": "Jatka jyrkästi vasempaan pysyäksesi tiellä Cool highway",
         "fr": "Braquer à gauche pour rester sur Cool highway",
         "he": "פנה בחדות שמאלה כדי להישאר על Cool highway",
         "id": "Make a sharp left to stay on Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_sharp right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_sharp right.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ege dekstren al Cool highway",
         "es": "Gira a la derecha en Cool highway",
         "es-ES": "Gire a la derecha en Cool highway",
+        "fi": "Jatka jyrkästi oikeaan pysyäksesi tiellä Cool highway",
         "fr": "Braquer à droite pour rester sur Cool highway",
         "he": "פנה בחדות ימינה כדי להישאר על Cool highway",
         "id": "Make a sharp right to stay on Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_slight left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_slight left.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ete maldekstren al Cool highway",
         "es": "Dobla levemente a la izquierda en Cool highway",
         "es-ES": "Doble levemente a la izquierda en Cool highway",
+        "fi": "Jatka loivasti vasempaan pysyäksesi tiellä Cool highway",
         "fr": "S’aligner légèrement à gauche pour rester sur Cool highway",
         "he": "פנה קלות שמאלה כדי להישאר על Cool highway",
         "id": "Tetap agak di kiri ke Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_slight right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_slight right.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ete dekstren al Cool highway",
         "es": "Dobla levemente a la derecha en Cool highway",
         "es-ES": "Doble levemente a la derecha en Cool highway",
+        "fi": "Jatka loivasti oikeaan pysyäksesi tiellä Cool highway",
         "fr": "S’aligner légèrement à droite pour rester sur Cool highway",
         "he": "פנה קלות ימינה כדי להישאר על Cool highway",
         "id": "Tetap agak di kanan ke Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_straight.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_straight.json
@@ -14,6 +14,7 @@
         "eo": "Veturu rekten al Cool highway",
         "es": "Continúa en Cool highway",
         "es-ES": "Continúa en Cool highway",
+        "fi": "Jatka suoraan pysyäksesi tiellä Cool highway",
         "fr": "Continuer tout droit pour rester sur Cool highway",
         "he": "המשך ישר כדי להישאר על Cool highway",
         "id": "Terus ke Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_uturn.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_uturn.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu malantaŭen al Cool highway",
         "es": "Haz un cambio de sentido y continúa en Cool highway",
         "es-ES": "Haz un cambio de sentido y continúa en Cool highway",
+        "fi": "Tee U-käännös ja jatka tietä Cool highway",
         "fr": "Faire demi-tour et continuer sur Cool highway",
         "he": "פנה פניית פרסה והמשך על Cool highway",
         "id": "Putar balik ke arah Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_number_left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_left.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstren al Ref1",
         "es": "Cruza a laizquierda en Ref1",
         "es-ES": "Cruce a la izquierda en Ref1",
+        "fi": "Käänny vasemmall(e/a) pysyäksesi tiellä Ref1",
         "fr": "Tourner à gauche pour rester Ref1",
         "he": "פנה שמאלה כדי להישאר בRef1",
         "id": "Terus kiri ke Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_right.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstren al Ref1",
         "es": "Cruza a laderecha en Ref1",
         "es-ES": "Cruce a la derecha en Ref1",
+        "fi": "Käänny oikeall(e/a) pysyäksesi tiellä Ref1",
         "fr": "Tourner à droite pour rester Ref1",
         "he": "פנה ימינה כדי להישאר בRef1",
         "id": "Terus kanan ke Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_sharp left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_sharp left.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ege maldekstren al Ref1",
         "es": "Gira a la izquierda en Ref1",
         "es-ES": "Gire a la izquierda en Ref1",
+        "fi": "Jatka jyrkästi vasempaan pysyäksesi tiellä Ref1",
         "fr": "Braquer à gauche pour rester sur Ref1",
         "he": "פנה בחדות שמאלה כדי להישאר על Ref1",
         "id": "Make a sharp left to stay on Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_sharp right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_sharp right.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ege dekstren al Ref1",
         "es": "Gira a la derecha en Ref1",
         "es-ES": "Gire a la derecha en Ref1",
+        "fi": "Jatka jyrkästi oikeaan pysyäksesi tiellä Ref1",
         "fr": "Braquer à droite pour rester sur Ref1",
         "he": "פנה בחדות ימינה כדי להישאר על Ref1",
         "id": "Make a sharp right to stay on Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_slight left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_slight left.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ete maldekstren al Ref1",
         "es": "Dobla levemente a la izquierda en Ref1",
         "es-ES": "Doble levemente a la izquierda en Ref1",
+        "fi": "Jatka loivasti vasempaan pysyäksesi tiellä Ref1",
         "fr": "S’aligner légèrement à gauche pour rester sur Ref1",
         "he": "פנה קלות שמאלה כדי להישאר על Ref1",
         "id": "Tetap agak di kiri ke Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_slight right.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_slight right.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ete dekstren al Ref1",
         "es": "Dobla levemente a la derecha en Ref1",
         "es-ES": "Doble levemente a la derecha en Ref1",
+        "fi": "Jatka loivasti oikeaan pysyäksesi tiellä Ref1",
         "fr": "S’aligner légèrement à droite pour rester sur Ref1",
         "he": "פנה קלות ימינה כדי להישאר על Ref1",
         "id": "Tetap agak di kanan ke Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_straight.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_straight.json
@@ -14,6 +14,7 @@
         "eo": "Veturu rekten al Ref1",
         "es": "Continúa en Ref1",
         "es-ES": "Continúa en Ref1",
+        "fi": "Jatka suoraan pysyäksesi tiellä Ref1",
         "fr": "Continuer tout droit pour rester sur Ref1",
         "he": "המשך ישר כדי להישאר על Ref1",
         "id": "Terus ke Ref1",

--- a/test/fixtures/v5/other/motorway_ref_has_number_uturn.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_uturn.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu malantaŭen al Ref1",
         "es": "Haz un cambio de sentido y continúa en Ref1",
         "es-ES": "Haz un cambio de sentido y continúa en Ref1",
+        "fi": "Tee U-käännös ja jatka tietä Ref1",
         "fr": "Faire demi-tour et continuer sur Ref1",
         "he": "פנה פניית פרסה והמשך על Ref1",
         "id": "Putar balik ke arah Ref1",

--- a/test/fixtures/v5/other/way_name_class_ferry_left.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_left.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstren al Cool highway (Ref1)",
         "es": "Cruza a laizquierda en Cool highway (Ref1)",
         "es-ES": "Cruce a la izquierda en Cool highway (Ref1)",
+        "fi": "Käänny vasemmall(e/a) pysyäksesi tiellä Cool highway (Ref1)",
         "fr": "Tourner à gauche pour rester Cool highway (Ref1)",
         "he": "פנה שמאלה כדי להישאר בCool highway (Ref1)",
         "id": "Terus kiri ke Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_right.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_right.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstren al Cool highway (Ref1)",
         "es": "Cruza a laderecha en Cool highway (Ref1)",
         "es-ES": "Cruce a la derecha en Cool highway (Ref1)",
+        "fi": "Käänny oikeall(e/a) pysyäksesi tiellä Cool highway (Ref1)",
         "fr": "Tourner à droite pour rester Cool highway (Ref1)",
         "he": "פנה ימינה כדי להישאר בCool highway (Ref1)",
         "id": "Terus kanan ke Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_sharp left.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_sharp left.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ege maldekstren al Cool highway (Ref1)",
         "es": "Gira a la izquierda en Cool highway (Ref1)",
         "es-ES": "Gire a la izquierda en Cool highway (Ref1)",
+        "fi": "Jatka jyrkästi vasempaan pysyäksesi tiellä Cool highway (Ref1)",
         "fr": "Braquer à gauche pour rester sur Cool highway (Ref1)",
         "he": "פנה בחדות שמאלה כדי להישאר על Cool highway (Ref1)",
         "id": "Make a sharp left to stay on Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_sharp right.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_sharp right.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ege dekstren al Cool highway (Ref1)",
         "es": "Gira a la derecha en Cool highway (Ref1)",
         "es-ES": "Gire a la derecha en Cool highway (Ref1)",
+        "fi": "Jatka jyrkästi oikeaan pysyäksesi tiellä Cool highway (Ref1)",
         "fr": "Braquer à droite pour rester sur Cool highway (Ref1)",
         "he": "פנה בחדות ימינה כדי להישאר על Cool highway (Ref1)",
         "id": "Make a sharp right to stay on Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_slight left.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_slight left.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ete maldekstren al Cool highway (Ref1)",
         "es": "Dobla levemente a la izquierda en Cool highway (Ref1)",
         "es-ES": "Doble levemente a la izquierda en Cool highway (Ref1)",
+        "fi": "Jatka loivasti vasempaan pysyäksesi tiellä Cool highway (Ref1)",
         "fr": "S’aligner légèrement à gauche pour rester sur Cool highway (Ref1)",
         "he": "פנה קלות שמאלה כדי להישאר על Cool highway (Ref1)",
         "id": "Tetap agak di kiri ke Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_slight right.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_slight right.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu ete dekstren al Cool highway (Ref1)",
         "es": "Dobla levemente a la derecha en Cool highway (Ref1)",
         "es-ES": "Doble levemente a la derecha en Cool highway (Ref1)",
+        "fi": "Jatka loivasti oikeaan pysyäksesi tiellä Cool highway (Ref1)",
         "fr": "S’aligner légèrement à droite pour rester sur Cool highway (Ref1)",
         "he": "פנה קלות ימינה כדי להישאר על Cool highway (Ref1)",
         "id": "Tetap agak di kanan ke Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_straight.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_straight.json
@@ -14,6 +14,7 @@
         "eo": "Veturu rekten al Cool highway (Ref1)",
         "es": "Continúa en Cool highway (Ref1)",
         "es-ES": "Continúa en Cool highway (Ref1)",
+        "fi": "Jatka suoraan pysyäksesi tiellä Cool highway (Ref1)",
         "fr": "Continuer tout droit pour rester sur Cool highway (Ref1)",
         "he": "המשך ישר כדי להישאר על Cool highway (Ref1)",
         "id": "Terus ke Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_class_ferry_uturn.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_uturn.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu malantaŭen al Cool highway (Ref1)",
         "es": "Haz un cambio de sentido y continúa en Cool highway (Ref1)",
         "es-ES": "Haz un cambio de sentido y continúa en Cool highway (Ref1)",
+        "fi": "Tee U-käännös ja jatka tietä Cool highway (Ref1)",
         "fr": "Faire demi-tour et continuer sur Cool highway (Ref1)",
         "he": "פנה פניית פרסה והמשך על Cool highway (Ref1)",
         "id": "Putar balik ke arah Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_destination_refs.json
+++ b/test/fixtures/v5/other/way_name_destination_refs.json
@@ -13,6 +13,7 @@
         "eo": "Direktiĝu al enveturejo ĉe dekstre al Ref1: Destination 1",
         "es": "Toma la salida en la derecha hacia Ref1: Destination 1",
         "es-ES": "Coge la cuesta abajo de la derecha hacia Ref1: Destination 1",
+        "fi": "Aja oikealla olevalle erkanemiskaistalle suuntana Ref1: Destination 1",
         "fr": "Prendre la sortie à droite en direction de Ref1: Destination 1",
         "he": "צא ביציאה שמימינך לכיוון Ref1: Destination 1",
         "id": "Ambil jalan melandai di sebelah kanan menuju Ref1: Destination 1",

--- a/test/fixtures/v5/other/way_name_ref.json
+++ b/test/fixtures/v5/other/way_name_ref.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu maldekstren al Ref1",
         "es": "Gira a la izquierda en Ref1",
         "es-ES": "Gira a la izquierda por Ref1",
+        "fi": "Käänny vasempaan tielle Ref1",
         "fr": "Tourner à gauche sur Ref1",
         "he": "פנה שמאלה לRef1",
         "id": "Belok kiri ke Ref1",

--- a/test/fixtures/v5/other/way_name_ref_destinations.json
+++ b/test/fixtures/v5/other/way_name_ref_destinations.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu maldekstren direkte al Destination 1",
         "es": "Gira a la izquierda hacia Destination 1",
         "es-ES": "Gira a la izquierda hacia Destination 1",
+        "fi": "Käänny vasempaan suuntana Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "he": "פנה שמאלה לכיוון Destination 1",
         "id": "Belok kiri menuju Destination 1",

--- a/test/fixtures/v5/other/way_name_ref_mapbox_hack_1.json
+++ b/test/fixtures/v5/other/way_name_ref_mapbox_hack_1.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu maldekstren al Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
         "es": "Gira a la izquierda en Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
         "es-ES": "Gira a la izquierda por Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
+        "fi": "Käänny vasempaan tielle Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
         "fr": "Tourner à gauche sur Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
         "he": "פנה שמאלה לWay Name (Ref1 (Another+Way \\ (Ref1.1)))",
         "id": "Belok kiri ke Way Name (Ref1 (Another+Way \\ (Ref1.1)))",

--- a/test/fixtures/v5/other/way_name_ref_mapbox_hack_2.json
+++ b/test/fixtures/v5/other/way_name_ref_mapbox_hack_2.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu maldekstren al Way Name (Ref0)",
         "es": "Gira a la izquierda en Way Name (Ref0)",
         "es-ES": "Gira a la izquierda por Way Name (Ref0)",
+        "fi": "Käänny vasempaan tielle Way Name (Ref0)",
         "fr": "Tourner à gauche sur Way Name (Ref0)",
         "he": "פנה שמאלה לWay Name (Ref0)",
         "id": "Belok kiri ke Way Name (Ref0)",

--- a/test/fixtures/v5/other/way_name_ref_mapbox_hack_3.json
+++ b/test/fixtures/v5/other/way_name_ref_mapbox_hack_3.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu maldekstren al Ref0",
         "es": "Gira a la izquierda en Ref0",
         "es-ES": "Gira a la izquierda por Ref0",
+        "fi": "Käänny vasempaan tielle Ref0",
         "fr": "Tourner à gauche sur Ref0",
         "he": "פנה שמאלה לRef0",
         "id": "Belok kiri ke Ref0",

--- a/test/fixtures/v5/other/way_name_ref_name.json
+++ b/test/fixtures/v5/other/way_name_ref_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu maldekstren al Way Name (Ref1)",
         "es": "Gira a la izquierda en Way Name (Ref1)",
         "es-ES": "Gira a la izquierda por Way Name (Ref1)",
+        "fi": "Käänny vasempaan tielle Way Name (Ref1)",
         "fr": "Tourner à gauche sur Way Name (Ref1)",
         "he": "פנה שמאלה לWay Name (Ref1)",
         "id": "Belok kiri ke Way Name (Ref1)",

--- a/test/fixtures/v5/phrase/exit_with_number.json
+++ b/test/fixtures/v5/phrase/exit_with_number.json
@@ -9,6 +9,7 @@
         "eo": "Elveturejo 123A",
         "es": "Salida 123A",
         "es-ES": "Salida 123A",
+        "fi": "123A",
         "fr": "Sortie 123A",
         "he": "יציאה 123A",
         "id": "Exit 123A",

--- a/test/fixtures/v5/phrase/name_and_ref.json
+++ b/test/fixtures/v5/phrase/name_and_ref.json
@@ -10,6 +10,7 @@
         "eo": "Metropolis (123)",
         "es": "Metropolis (123)",
         "es-ES": "Metropolis (123)",
+        "fi": "Metropolis (123)",
         "fr": "Metropolis (123)",
         "he": "Metropolis (123)",
         "id": "Metropolis (123)",

--- a/test/fixtures/v5/phrase/one_in_distance.json
+++ b/test/fixtures/v5/phrase/one_in_distance.json
@@ -10,6 +10,7 @@
         "eo": "Post 0 units, Do something",
         "es": "A 0 units, Do something",
         "es-ES": "A 0 units, Do something",
+        "fi": "0 units päästä, Do something",
         "fr": "Dans 0 units, Do something",
         "he": "בעוד 0 units, Do something",
         "id": "In 0 units, Do something",

--- a/test/fixtures/v5/phrase/two_linked.json
+++ b/test/fixtures/v5/phrase/two_linked.json
@@ -10,6 +10,7 @@
         "eo": "Do this kaj sekve Do that",
         "es": "Do this y luego Do that",
         "es-ES": "Do this y luego Do that",
+        "fi": "Do this, sitten Do that",
         "fr": "Do this, puis Do that",
         "he": "Do this, ואז Do that",
         "id": "Do this, then Do that",

--- a/test/fixtures/v5/phrase/two_linked_by_distance.json
+++ b/test/fixtures/v5/phrase/two_linked_by_distance.json
@@ -11,6 +11,7 @@
         "eo": "Do this kaj post 0 units Do that",
         "es": "Do this y luego a 0 units, Do that",
         "es-ES": "Do this y luego en 0 units, Do that",
+        "fi": "Do this, sitten 0 units päästä, Do that",
         "fr": "Do this, puis, dans 0 units, Do that",
         "he": "Do this, ואז, בעוד0 units, Do that",
         "id": "Do this, then, in 0 units, Do that",

--- a/test/fixtures/v5/rotary/default_default.json
+++ b/test/fixtures/v5/rotary/default_default.json
@@ -13,6 +13,7 @@
         "eo": "Enveturu trafikcirklegon",
         "es": "Entra en la rotonda",
         "es-ES": "Incorpórate en la rotonda",
+        "fi": "Aja liikenneympyrään",
         "fr": "Prendre le rond-point",
         "he": "השתלב במעגל התנועה",
         "id": "Masuk bundaran",

--- a/test/fixtures/v5/rotary/default_destination.json
+++ b/test/fixtures/v5/rotary/default_destination.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj elveturu direkte al Destination 1",
         "es": "Entra en la rotonda y sal hacia Destination 1",
         "es-ES": "En la rotonda sal hacia Destination 1",
+        "fi": "Aja liikenneympyrään ja valitse erkanemiskaista suuntana Destination 1",
         "fr": "Prendre le rond-point et sortir en direction de Destination 1",
         "he": "השתלב במעגל התנועה וצא לכיוון Destination 1",
         "id": "Masuk bundaran dan keluar menuju Destination 1",

--- a/test/fixtures/v5/rotary/default_exit.json
+++ b/test/fixtures/v5/rotary/default_exit.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj elveturu al Way Name",
         "es": "Entra en la rotonda y sal en Way Name",
         "es-ES": "En la rotonda sal por Way Name",
+        "fi": "Aja liikenneympyrään ja valitse erkanemiskaista tielle Way Name",
         "fr": "Prendre le rond-point et sortir sur Way Name",
         "he": "השתלב במעגל התנועה וצא על Way Name",
         "id": "Masuk bundaran dan keluar arah Way Name",

--- a/test/fixtures/v5/rotary/default_exit_destination.json
+++ b/test/fixtures/v5/rotary/default_exit_destination.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu trafikcirklegon kaj elveturu direkte al Destination 1",
         "es": "Entra en la rotonda y sal hacia Destination 1",
         "es-ES": "En la rotonda sal hacia Destination 1",
+        "fi": "Aja liikenneympyrään ja valitse erkanemiskaista suuntana Destination 1",
         "fr": "Prendre le rond-point et sortir en direction de Destination 1",
         "he": "השתלב במעגל התנועה וצא לכיוון Destination 1",
         "id": "Masuk bundaran dan keluar menuju Destination 1",

--- a/test/fixtures/v5/rotary/default_name.json
+++ b/test/fixtures/v5/rotary/default_name.json
@@ -13,6 +13,7 @@
         "eo": "Enveturu trafikcirklegon kaj elveturu al Way Name",
         "es": "Entra en la rotonda y sal en Way Name",
         "es-ES": "En la rotonda sal por Way Name",
+        "fi": "Aja liikenneympyrään ja valitse erkanemiskaista tielle Way Name",
         "fr": "Prendre le rond-point et sortir sur Way Name",
         "he": "השתלב במעגל התנועה וצא על Way Name",
         "id": "Masuk bundaran dan keluar arah Way Name",

--- a/test/fixtures/v5/rotary/exit_10.json
+++ b/test/fixtures/v5/rotary/exit_10.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 10. elveturejo",
         "es": "Entra en la rotonda y toma la 10ª salida",
         "es-ES": "En la rotonda toma la 10ª salida",
+        "fi": "Aja liikenneympyrään ja valitse 10. erkanemiskaista",
         "fr": "Prendre le rond-point et prendre la dixième sortie",
         "he": "השתלב במעגל התנועה וצא ביציאה עשירית",
         "id": "Masuk bundaran dan ambil jalan keluar 10",

--- a/test/fixtures/v5/rotary/exit_11.json
+++ b/test/fixtures/v5/rotary/exit_11.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al elveturejo",
         "es": "Entra en la rotonda y toma la salida",
         "es-ES": "En la rotonda toma la salida",
+        "fi": "Aja liikenneympyrään ja valitse erkanemiskaista",
         "fr": "Prendre le rond-point et prendre la sortie",
         "he": "השתלב במעגל התנועה וצא ביציאה ",
         "id": "Masuk bundaran dan ambil jalan keluar ",

--- a/test/fixtures/v5/rotary/exit_1_default.json
+++ b/test/fixtures/v5/rotary/exit_1_default.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo",
         "es": "Entra en la rotonda y toma la 1ª salida",
         "es-ES": "En la rotonda toma la 1ª salida",
+        "fi": "Aja liikenneympyrään ja valitse 1. erkanemiskaista",
         "fr": "Prendre le rond-point et prendre la première sortie",
         "he": "השתלב במעגל התנועה וצא ביציאה ראשונה",
         "id": "Masuk bundaran dan ambil jalan keluar 1",

--- a/test/fixtures/v5/rotary/exit_1_destination.json
+++ b/test/fixtures/v5/rotary/exit_1_destination.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo direkte al Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "es-ES": "En la rotonda toma la 1ª salida hacia Destination 1",
+        "fi": "Aja liikenneympyrään ja valitse 1. erkanemiskaista suuntana Destination 1",
         "fr": "Prendre le rond-point et prendre la première sortie en direction de Destination 1",
         "he": "השתלב במעגל התנועה וצא ביציאה ראשונה לכיוון Destination 1",
         "id": "Masuk bundaran dan ambil jalan keluar 1 menuju Destination 1",

--- a/test/fixtures/v5/rotary/exit_1_exit.json
+++ b/test/fixtures/v5/rotary/exit_1_exit.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo al Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
         "es-ES": "En la rotonda toma la 1ª salida por Way Name",
+        "fi": "Aja liikenneympyrään ja valitse 1. erkanemiskaista tielle Way Name",
         "fr": "Prendre le rond-point et prendre la première sortie sur Way Name",
         "he": "השתלב במעגל התנועה וצא ביציאה ראשונה לWay Name",
         "id": "Masuk bundaran dan ambil jalan keluar 1 arah Way Name",

--- a/test/fixtures/v5/rotary/exit_1_exit_destination.json
+++ b/test/fixtures/v5/rotary/exit_1_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo direkte al Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "es-ES": "En la rotonda toma la 1ª salida hacia Destination 1",
+        "fi": "Aja liikenneympyrään ja valitse 1. erkanemiskaista suuntana Destination 1",
         "fr": "Prendre le rond-point et prendre la première sortie en direction de Destination 1",
         "he": "השתלב במעגל התנועה וצא ביציאה ראשונה לכיוון Destination 1",
         "id": "Masuk bundaran dan ambil jalan keluar 1 menuju Destination 1",

--- a/test/fixtures/v5/rotary/exit_1_name.json
+++ b/test/fixtures/v5/rotary/exit_1_name.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo al Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
         "es-ES": "En la rotonda toma la 1ª salida por Way Name",
+        "fi": "Aja liikenneympyrään ja valitse 1. erkanemiskaista tielle Way Name",
         "fr": "Prendre le rond-point et prendre la première sortie sur Way Name",
         "he": "השתלב במעגל התנועה וצא ביציאה ראשונה לWay Name",
         "id": "Masuk bundaran dan ambil jalan keluar 1 arah Way Name",

--- a/test/fixtures/v5/rotary/exit_2.json
+++ b/test/fixtures/v5/rotary/exit_2.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 2. elveturejo",
         "es": "Entra en la rotonda y toma la 2ª salida",
         "es-ES": "En la rotonda toma la 2ª salida",
+        "fi": "Aja liikenneympyrään ja valitse 2. erkanemiskaista",
         "fr": "Prendre le rond-point et prendre la seconde sortie",
         "he": "השתלב במעגל התנועה וצא ביציאה שניה",
         "id": "Masuk bundaran dan ambil jalan keluar 2",

--- a/test/fixtures/v5/rotary/exit_3.json
+++ b/test/fixtures/v5/rotary/exit_3.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 3. elveturejo",
         "es": "Entra en la rotonda y toma la 3ª salida",
         "es-ES": "En la rotonda toma la 3ª salida",
+        "fi": "Aja liikenneympyrään ja valitse 3. erkanemiskaista",
         "fr": "Prendre le rond-point et prendre la troisième sortie",
         "he": "השתלב במעגל התנועה וצא ביציאה שלישית",
         "id": "Masuk bundaran dan ambil jalan keluar 3",

--- a/test/fixtures/v5/rotary/exit_4.json
+++ b/test/fixtures/v5/rotary/exit_4.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 4. elveturejo",
         "es": "Entra en la rotonda y toma la 4ª salida",
         "es-ES": "En la rotonda toma la 4ª salida",
+        "fi": "Aja liikenneympyrään ja valitse 4. erkanemiskaista",
         "fr": "Prendre le rond-point et prendre la quatrième sortie",
         "he": "השתלב במעגל התנועה וצא ביציאה רביעית",
         "id": "Masuk bundaran dan ambil jalan keluar 4",

--- a/test/fixtures/v5/rotary/exit_5.json
+++ b/test/fixtures/v5/rotary/exit_5.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 5. elveturejo",
         "es": "Entra en la rotonda y toma la 5ª salida",
         "es-ES": "En la rotonda toma la 5ª salida",
+        "fi": "Aja liikenneympyrään ja valitse 5. erkanemiskaista",
         "fr": "Prendre le rond-point et prendre la cinquième sortie",
         "he": "השתלב במעגל התנועה וצא ביציאה חמישית",
         "id": "Masuk bundaran dan ambil jalan keluar 5",

--- a/test/fixtures/v5/rotary/exit_6.json
+++ b/test/fixtures/v5/rotary/exit_6.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 6. elveturejo",
         "es": "Entra en la rotonda y toma la 6ª salida",
         "es-ES": "En la rotonda toma la 6ª salida",
+        "fi": "Aja liikenneympyrään ja valitse 6. erkanemiskaista",
         "fr": "Prendre le rond-point et prendre la sixième sortie",
         "he": "השתלב במעגל התנועה וצא ביציאה שישית",
         "id": "Masuk bundaran dan ambil jalan keluar 6",

--- a/test/fixtures/v5/rotary/exit_7.json
+++ b/test/fixtures/v5/rotary/exit_7.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 7. elveturejo",
         "es": "Entra en la rotonda y toma la 7ª salida",
         "es-ES": "En la rotonda toma la 7ª salida",
+        "fi": "Aja liikenneympyrään ja valitse 7. erkanemiskaista",
         "fr": "Prendre le rond-point et prendre la septième sortie",
         "he": "השתלב במעגל התנועה וצא ביציאה שביעית",
         "id": "Masuk bundaran dan ambil jalan keluar 7",

--- a/test/fixtures/v5/rotary/exit_8.json
+++ b/test/fixtures/v5/rotary/exit_8.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 8. elveturejo",
         "es": "Entra en la rotonda y toma la 8ª salida",
         "es-ES": "En la rotonda toma la 8ª salida",
+        "fi": "Aja liikenneympyrään ja valitse 8. erkanemiskaista",
         "fr": "Prendre le rond-point et prendre la huitième sortie",
         "he": "השתלב במעגל התנועה וצא ביציאה שמינית",
         "id": "Masuk bundaran dan ambil jalan keluar 8",

--- a/test/fixtures/v5/rotary/exit_9.json
+++ b/test/fixtures/v5/rotary/exit_9.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 9. elveturejo",
         "es": "Entra en la rotonda y toma la 9ª salida",
         "es-ES": "En la rotonda toma la 9ª salida",
+        "fi": "Aja liikenneympyrään ja valitse 9. erkanemiskaista",
         "fr": "Prendre le rond-point et prendre la neuvième sortie",
         "he": "השתלב במעגל התנועה וצא ביציאה תשיעית",
         "id": "Masuk bundaran dan ambil jalan keluar 9",

--- a/test/fixtures/v5/rotary/name_default.json
+++ b/test/fixtures/v5/rotary/name_default.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu Rotary Name",
         "es": "Entra en Rotary Name",
         "es-ES": "En Rotary Name",
+        "fi": "Aja liikenneympyrään Rotary Name",
         "fr": "Prendre le rond-point Rotary Name",
         "he": "היכנס לRotary Name",
         "id": "Masuk Rotary Name",

--- a/test/fixtures/v5/rotary/name_destination.json
+++ b/test/fixtures/v5/rotary/name_destination.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu Rotary Name kaj elveturu direkte al Destination 1",
         "es": "Entra en Rotary Name y sal hacia Destination 1",
         "es-ES": "En Rotary Name sal hacia Destination 1",
+        "fi": "Aja liikenneympyrään Rotary Name ja valitse erkanemiskaista suuntana Destination 1",
         "fr": "Prendre le rond-point Rotary Name et sortir en direction de Destination 1",
         "he": "היכנס לRotary Name וצא לכיוון Destination 1",
         "id": "Masuk Rotary Name dan keluar menuju Destination 1",

--- a/test/fixtures/v5/rotary/name_exit.json
+++ b/test/fixtures/v5/rotary/name_exit.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu Rotary Name kaj elveturu al Way Name",
         "es": "Entra en Rotary Name y sal en Way Name",
         "es-ES": "En Rotary Name sal por Way Name",
+        "fi": "Aja liikenneympyrään Rotary Name ja valitse erkanemiskaista tielle Way Name",
         "fr": "Prendre le rond-point Rotary Name et sortir par Way Name",
         "he": "היכנס לRotary Name וצא על Way Name",
         "id": "Masuk Rotary Name dan keluar arah Way Name",

--- a/test/fixtures/v5/rotary/name_exit_default.json
+++ b/test/fixtures/v5/rotary/name_exit_default.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu Rotary Name kaj sekve al 2. elveturejo",
         "es": "Entra en Rotary Name y coge la 2ª salida",
         "es-ES": "En Rotary Name toma la 2ª salida",
+        "fi": "Aja liikenneympyrään Rotary Name ja valitse 2. erkanemiskaista",
         "fr": "Prendre le rond-point Rotary Name et prendre la seconde sortie",
         "he": "היכנס לRotary Name וצא ביציאה השניה",
         "id": "Masuk Rotary Name dan ambil jalan keluar 2",

--- a/test/fixtures/v5/rotary/name_exit_destination.json
+++ b/test/fixtures/v5/rotary/name_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Enveturu Rotary Name kaj sekve al 2. elveturejo direkte al Destination 1",
         "es": "Entra en Rotary Name y coge la 2ª salida hacia Destination 1",
         "es-ES": "En Rotary Name toma la 2ª salida hacia Destination 1",
+        "fi": "Aja liikenneympyrään Rotary Name ja valitse 2. erkanemiskaista suuntana Destination 1",
         "fr": "Prendre le rond-point Rotary Name et prendre la seconde sortie en direction de Destination 1",
         "he": "היכנס לRotary Name וצא ביציאה השניה לכיוון Destination 1",
         "id": "Masuk Rotary Name dan ambil jalan keluar 2 menuju Destination 1",

--- a/test/fixtures/v5/rotary/name_exit_exit.json
+++ b/test/fixtures/v5/rotary/name_exit_exit.json
@@ -16,6 +16,7 @@
         "eo": "Enveturu Rotary Name kaj sekve al 2. elveturejo al Way Name",
         "es": "Entra en Rotary Name y coge la 2ª salida en Way Name",
         "es-ES": "En Rotary Name toma la 2ª salida por Way Name",
+        "fi": "Aja liikenneympyrään Rotary Name ja valitse 2. erkanemiskaista tielle Way Name",
         "fr": "Prendre le rond-point Rotary Name et prendre la seconde sortie sur Way Name",
         "he": "היכנס לRotary Name וצא ביציאה השניה לWay Name",
         "id": "Masuk Rotary Name dan ambil jalan keluar 2 arah Way Name",

--- a/test/fixtures/v5/rotary/name_exit_exit_destination.json
+++ b/test/fixtures/v5/rotary/name_exit_exit_destination.json
@@ -17,6 +17,7 @@
         "eo": "Enveturu Rotary Name kaj sekve al 2. elveturejo direkte al Destination 1",
         "es": "Entra en Rotary Name y coge la 2ª salida hacia Destination 1",
         "es-ES": "En Rotary Name toma la 2ª salida hacia Destination 1",
+        "fi": "Aja liikenneympyrään Rotary Name ja valitse 2. erkanemiskaista suuntana Destination 1",
         "fr": "Prendre le rond-point Rotary Name et prendre la seconde sortie en direction de Destination 1",
         "he": "היכנס לRotary Name וצא ביציאה השניה לכיוון Destination 1",
         "id": "Masuk Rotary Name dan ambil jalan keluar 2 menuju Destination 1",

--- a/test/fixtures/v5/rotary/name_exit_name.json
+++ b/test/fixtures/v5/rotary/name_exit_name.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu Rotary Name kaj sekve al 2. elveturejo al Way Name",
         "es": "Entra en Rotary Name y coge la 2ª salida en Way Name",
         "es-ES": "En Rotary Name toma la 2ª salida por Way Name",
+        "fi": "Aja liikenneympyrään Rotary Name ja valitse 2. erkanemiskaista tielle Way Name",
         "fr": "Prendre le rond-point Rotary Name et prendre la seconde sortie sur Way Name",
         "he": "היכנס לRotary Name וצא ביציאה השניה לWay Name",
         "id": "Masuk Rotary Name dan ambil jalan keluar 2 arah Way Name",

--- a/test/fixtures/v5/rotary/name_name.json
+++ b/test/fixtures/v5/rotary/name_name.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu Rotary Name kaj elveturu al Way Name",
         "es": "Entra en Rotary Name y sal en Way Name",
         "es-ES": "En Rotary Name sal por Way Name",
+        "fi": "Aja liikenneympyrään Rotary Name ja valitse erkanemiskaista tielle Way Name",
         "fr": "Prendre le rond-point Rotary Name et sortir par Way Name",
         "he": "היכנס לRotary Name וצא על Way Name",
         "id": "Masuk Rotary Name dan keluar arah Way Name",

--- a/test/fixtures/v5/roundabout/default_default.json
+++ b/test/fixtures/v5/roundabout/default_default.json
@@ -13,6 +13,7 @@
         "eo": "Enveturu trafikcirklegon",
         "es": "Entra en la rotonda",
         "es-ES": "Incorpórate en la rotonda",
+        "fi": "Aja liikenneympyrään",
         "fr": "Prendre le rond-point",
         "he": "השתלב במעגל התנועה",
         "id": "Masuk bundaran",

--- a/test/fixtures/v5/roundabout/default_destination.json
+++ b/test/fixtures/v5/roundabout/default_destination.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj elveturu direkte al Destination 1",
         "es": "Entra en la rotonda y sal hacia Destination 1",
         "es-ES": "Incorpórate en la rotonda y sal hacia Destination 1",
+        "fi": "Aja liikenneympyrään ja valitse erkanemiskaista suuntana Destination 1",
         "fr": "Prendre le rond-point et sortir en direction de Destination 1",
         "he": "השתלב במעגל התנועה וצא לכיוון Destination 1",
         "id": "Masuk bundaran dan keluar menuju Destination 1",

--- a/test/fixtures/v5/roundabout/default_exit.json
+++ b/test/fixtures/v5/roundabout/default_exit.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj elveturu al Way Name",
         "es": "Entra en la rotonda y sal en Way Name",
         "es-ES": "Incorpórate en la rotonda y sal en Way Name",
+        "fi": "Aja liikenneympyrään ja valitse erkanemiskaista tielle Way Name",
         "fr": "Prendre le rond-point et sortir sur Way Name",
         "he": "השתלב במעגל התנועה וצא על Way Name",
         "id": "Masuk bundaran dan keluar arah Way Name",

--- a/test/fixtures/v5/roundabout/default_exit_destination.json
+++ b/test/fixtures/v5/roundabout/default_exit_destination.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu trafikcirklegon kaj elveturu direkte al Destination 1",
         "es": "Entra en la rotonda y sal hacia Destination 1",
         "es-ES": "Incorpórate en la rotonda y sal hacia Destination 1",
+        "fi": "Aja liikenneympyrään ja valitse erkanemiskaista suuntana Destination 1",
         "fr": "Prendre le rond-point et sortir en direction de Destination 1",
         "he": "השתלב במעגל התנועה וצא לכיוון Destination 1",
         "id": "Masuk bundaran dan keluar menuju Destination 1",

--- a/test/fixtures/v5/roundabout/default_name.json
+++ b/test/fixtures/v5/roundabout/default_name.json
@@ -13,6 +13,7 @@
         "eo": "Enveturu trafikcirklegon kaj elveturu al Way Name",
         "es": "Entra en la rotonda y sal en Way Name",
         "es-ES": "Incorpórate en la rotonda y sal en Way Name",
+        "fi": "Aja liikenneympyrään ja valitse erkanemiskaista tielle Way Name",
         "fr": "Prendre le rond-point et sortir sur Way Name",
         "he": "השתלב במעגל התנועה וצא על Way Name",
         "id": "Masuk bundaran dan keluar arah Way Name",

--- a/test/fixtures/v5/roundabout/exit_default.json
+++ b/test/fixtures/v5/roundabout/exit_default.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo",
         "es": "Entra en la rotonda y toma la 1ª salida",
         "es-ES": "En la rotonda toma la 1ª salida",
+        "fi": "Aja liikenneympyrään ja valitse 1. erkanemiskaista",
         "fr": "Prendre le rond-point et prendre la première sortie",
         "he": "השתלב במעגל התנועה וצא ביציאה ראשונה",
         "id": "Masuk bundaran dan ambil jalan keluar 1",

--- a/test/fixtures/v5/roundabout/exit_destination.json
+++ b/test/fixtures/v5/roundabout/exit_destination.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo direkte al Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "es-ES": "En la rotonda toma la 1ª salida hacia Destination 1",
+        "fi": "Aja liikenneympyrään ja valitse 1. erkanemiskaista suuntana Destination 1",
         "fr": "Prendre le rond-point et prendre la première sortie en direction de Destination 1",
         "he": "השתלב במעגל התנועה וצא ביציאה ראשונה לכיוון Destination 1",
         "id": "Masuk bundaran dan ambil jalan keluar 1 menuju Destination 1",

--- a/test/fixtures/v5/roundabout/exit_exit.json
+++ b/test/fixtures/v5/roundabout/exit_exit.json
@@ -15,6 +15,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo al Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
         "es-ES": "En la rotonda toma la 1ª salida por Way Name",
+        "fi": "Aja liikenneympyrään ja valitse 1. erkanemiskaista tielle Way Name",
         "fr": "Prendre le rond-point et prendre la première sortie sur Way Name",
         "he": "השתלב במעגל התנועה וצא ביציאה ראשונה לWay Name",
         "id": "Masuk bundaran dan ambil jalan keluar 1 arah Way Name",

--- a/test/fixtures/v5/roundabout/exit_exit_destination.json
+++ b/test/fixtures/v5/roundabout/exit_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo direkte al Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "es-ES": "En la rotonda toma la 1ª salida hacia Destination 1",
+        "fi": "Aja liikenneympyrään ja valitse 1. erkanemiskaista suuntana Destination 1",
         "fr": "Prendre le rond-point et prendre la première sortie en direction de Destination 1",
         "he": "השתלב במעגל התנועה וצא ביציאה ראשונה לכיוון Destination 1",
         "id": "Masuk bundaran dan ambil jalan keluar 1 menuju Destination 1",

--- a/test/fixtures/v5/roundabout/exit_name.json
+++ b/test/fixtures/v5/roundabout/exit_name.json
@@ -14,6 +14,7 @@
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo al Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
         "es-ES": "En la rotonda toma la 1ª salida por Way Name",
+        "fi": "Aja liikenneympyrään ja valitse 1. erkanemiskaista tielle Way Name",
         "fr": "Prendre le rond-point et prendre la première sortie sur Way Name",
         "he": "השתלב במעגל התנועה וצא ביציאה ראשונה לWay Name",
         "id": "Masuk bundaran dan ambil jalan keluar 1 arah Way Name",

--- a/test/fixtures/v5/roundabout_turn/left_default.json
+++ b/test/fixtures/v5/roundabout_turn/left_default.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu maldekstren",
         "es": "Gira a la izquierda",
         "es-ES": "Gire a la izquierda",
+        "fi": "Käänny vasempaan",
         "fr": "Tourner à gauche",
         "he": "פנה שמאלה",
         "id": "Di bundaran belok kiri",

--- a/test/fixtures/v5/roundabout_turn/left_destination.json
+++ b/test/fixtures/v5/roundabout_turn/left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu maldekstren direkte al Destination 1",
         "es": "Gira a la izquierda hacia Destination 1",
         "es-ES": "Gire a la izquierda hacia Destination 1",
+        "fi": "Käänny vasempaan suuntana Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "he": "פנה שמאלה לכיוון Destination 1",
         "id": "Di bundaran, belok kiri menuju Destination 1",

--- a/test/fixtures/v5/roundabout_turn/left_exit.json
+++ b/test/fixtures/v5/roundabout_turn/left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu maldekstren al Way Name",
         "es": "Gira a la izquierda en Way Name",
         "es-ES": "Gire a la izquierda en Way Name",
+        "fi": "Käänny vasempaan tielle Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "he": "פנה שמאלה לWay Name",
         "id": "Di bundaran, belok kiri arah Way Name",

--- a/test/fixtures/v5/roundabout_turn/left_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu maldekstren direkte al Destination 1",
         "es": "Gira a la izquierda hacia Destination 1",
         "es-ES": "Gire a la izquierda hacia Destination 1",
+        "fi": "Käänny vasempaan suuntana Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "he": "פנה שמאלה לכיוון Destination 1",
         "id": "Di bundaran, belok kiri menuju Destination 1",

--- a/test/fixtures/v5/roundabout_turn/left_name.json
+++ b/test/fixtures/v5/roundabout_turn/left_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu maldekstren al Way Name",
         "es": "Gira a la izquierda en Way Name",
         "es-ES": "Gire a la izquierda en Way Name",
+        "fi": "Käänny vasempaan tielle Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "he": "פנה שמאלה לWay Name",
         "id": "Di bundaran, belok kiri arah Way Name",

--- a/test/fixtures/v5/roundabout_turn/right_default.json
+++ b/test/fixtures/v5/roundabout_turn/right_default.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu dekstren",
         "es": "Gira a la derecha",
         "es-ES": "Gire a la derecha",
+        "fi": "Käänny oikeaan",
         "fr": "Tourner à droite",
         "he": "פנה ימינה",
         "id": "Di bundaran belok kanan",

--- a/test/fixtures/v5/roundabout_turn/right_destination.json
+++ b/test/fixtures/v5/roundabout_turn/right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu dekstren direkte al Destination 1",
         "es": "Gira a la derecha hacia Destination 1",
         "es-ES": "Gire a la derecha hacia Destination 1",
+        "fi": "Käänny oikeaan suuntana Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "he": "פנה ימינה לכיוון Destination 1",
         "id": "Di bundaran belok kanan menuju Destination 1",

--- a/test/fixtures/v5/roundabout_turn/right_exit.json
+++ b/test/fixtures/v5/roundabout_turn/right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu dekstren al Way Name",
         "es": "Gira a la derecha en Way Name",
         "es-ES": "Gire a la derecha en Way Name",
+        "fi": "Käänny oikeaan tielle Way Name",
         "fr": "Tourner à droite sur Way Name",
         "he": "פנה ימינה לWay Name",
         "id": "Di bundaran belok kanan ke arah Way Name",

--- a/test/fixtures/v5/roundabout_turn/right_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu dekstren direkte al Destination 1",
         "es": "Gira a la derecha hacia Destination 1",
         "es-ES": "Gire a la derecha hacia Destination 1",
+        "fi": "Käänny oikeaan suuntana Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "he": "פנה ימינה לכיוון Destination 1",
         "id": "Di bundaran belok kanan menuju Destination 1",

--- a/test/fixtures/v5/roundabout_turn/right_name.json
+++ b/test/fixtures/v5/roundabout_turn/right_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu dekstren al Way Name",
         "es": "Gira a la derecha en Way Name",
         "es-ES": "Gire a la derecha en Way Name",
+        "fi": "Käänny oikeaan tielle Way Name",
         "fr": "Tourner à droite sur Way Name",
         "he": "פנה ימינה לWay Name",
         "id": "Di bundaran belok kanan ke arah Way Name",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_default.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstregen",
         "es": "Sigue cerrada a la izquierda",
         "es-ES": "Siga cerrada a la izquierda",
+        "fi": "Käänny jyrkästi vasempaan",
         "fr": "Tourner franchement à gauche",
         "he": "פנה חדה שמאלה",
         "id": "Di bundaran, lakukan tajam kiri",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu maldekstregen direkte al Destination 1",
         "es": "Sigue cerrada a la izquierda hacia Destination 1",
         "es-ES": "Siga cerrada a la izquierda hacia Destination 1",
+        "fi": "Käänny jyrkästi vasempaan suuntana Destination 1",
         "fr": "Tourner franchement à gauche en direction de Destination 1",
         "he": "פנה חדה שמאלה לכיוון Destination 1",
         "id": "Di bundaran, lakukan tajam kiri menuju Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_exit.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu maldekstregen al Way Name",
         "es": "Sigue cerrada a la izquierda en Way Name",
         "es-ES": "Siga cerrada a la izquierda en Way Name",
+        "fi": "Käänny jyrkästi vasempaan tielle Way Name",
         "fr": "Tourner franchement à gauche sur Way Name",
         "he": "פנה חדה שמאלה על Way Name",
         "id": "Di bundaran, lakukan tajam kiri ke arah Way Name",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu maldekstregen direkte al Destination 1",
         "es": "Sigue cerrada a la izquierda hacia Destination 1",
         "es-ES": "Siga cerrada a la izquierda hacia Destination 1",
+        "fi": "Käänny jyrkästi vasempaan suuntana Destination 1",
         "fr": "Tourner franchement à gauche en direction de Destination 1",
         "he": "פנה חדה שמאלה לכיוון Destination 1",
         "id": "Di bundaran, lakukan tajam kiri menuju Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_name.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstregen al Way Name",
         "es": "Sigue cerrada a la izquierda en Way Name",
         "es-ES": "Siga cerrada a la izquierda en Way Name",
+        "fi": "Käänny jyrkästi vasempaan tielle Way Name",
         "fr": "Tourner franchement à gauche sur Way Name",
         "he": "פנה חדה שמאלה על Way Name",
         "id": "Di bundaran, lakukan tajam kiri ke arah Way Name",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_default.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstregen",
         "es": "Sigue cerrada a la derecha",
         "es-ES": "Siga cerrada a la derecha",
+        "fi": "Käänny jyrkästi oikeaan",
         "fr": "Tourner franchement à droite",
         "he": "פנה חדה ימינה",
         "id": "Di bundaran, lakukan tajam kanan",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu dekstregen direkte al Destination 1",
         "es": "Sigue cerrada a la derecha hacia Destination 1",
         "es-ES": "Siga cerrada a la derecha hacia Destination 1",
+        "fi": "Käänny jyrkästi oikeaan suuntana Destination 1",
         "fr": "Tourner franchement à droite en direction de Destination 1",
         "he": "פנה חדה ימינה לכיוון Destination 1",
         "id": "Di bundaran, lakukan tajam kanan menuju Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_exit.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu dekstregen al Way Name",
         "es": "Sigue cerrada a la derecha en Way Name",
         "es-ES": "Siga cerrada a la derecha en Way Name",
+        "fi": "Käänny jyrkästi oikeaan tielle Way Name",
         "fr": "Tourner franchement à droite sur Way Name",
         "he": "פנה חדה ימינה על Way Name",
         "id": "Di bundaran, lakukan tajam kanan ke arah Way Name",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu dekstregen direkte al Destination 1",
         "es": "Sigue cerrada a la derecha hacia Destination 1",
         "es-ES": "Siga cerrada a la derecha hacia Destination 1",
+        "fi": "Käänny jyrkästi oikeaan suuntana Destination 1",
         "fr": "Tourner franchement à droite en direction de Destination 1",
         "he": "פנה חדה ימינה לכיוון Destination 1",
         "id": "Di bundaran, lakukan tajam kanan menuju Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_name.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstregen al Way Name",
         "es": "Sigue cerrada a la derecha en Way Name",
         "es-ES": "Siga cerrada a la derecha en Way Name",
+        "fi": "Käänny jyrkästi oikeaan tielle Way Name",
         "fr": "Tourner franchement à droite sur Way Name",
         "he": "פנה חדה ימינה על Way Name",
         "id": "Di bundaran, lakukan tajam kanan ke arah Way Name",

--- a/test/fixtures/v5/roundabout_turn/slight_left_default.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstreten",
         "es": "Sigue levemente a la izquierda",
         "es-ES": "Siga ligeramente a la izquierda",
+        "fi": "Käänny loivasti vasempaan",
         "fr": "Tourner légèrement à gauche",
         "he": "פנה קלה שמאלה",
         "id": "Di bundaran, lakukan agak ke kiri",

--- a/test/fixtures/v5/roundabout_turn/slight_left_destination.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu maldekstreten direkte al Destination 1",
         "es": "Sigue levemente a la izquierda hacia Destination 1",
         "es-ES": "Siga ligeramente a la izquierda hacia Destination 1",
+        "fi": "Käänny loivasti vasempaan suuntana Destination 1",
         "fr": "Tourner légèrement à gauche en direction de Destination 1",
         "he": "פנה קלה שמאלה לכיוון Destination 1",
         "id": "Di bundaran, lakukan agak ke kiri menuju Destination 1",

--- a/test/fixtures/v5/roundabout_turn/slight_left_exit.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu maldekstreten al Way Name",
         "es": "Sigue levemente a la izquierda en Way Name",
         "es-ES": "Siga ligeramente a la izquierda en Way Name",
+        "fi": "Käänny loivasti vasempaan tielle Way Name",
         "fr": "Tourner légèrement à gauche sur Way Name",
         "he": "פנה קלה שמאלה על Way Name",
         "id": "Di bundaran, lakukan agak ke kiri ke arah Way Name",

--- a/test/fixtures/v5/roundabout_turn/slight_left_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu maldekstreten direkte al Destination 1",
         "es": "Sigue levemente a la izquierda hacia Destination 1",
         "es-ES": "Siga ligeramente a la izquierda hacia Destination 1",
+        "fi": "Käänny loivasti vasempaan suuntana Destination 1",
         "fr": "Tourner légèrement à gauche en direction de Destination 1",
         "he": "פנה קלה שמאלה לכיוון Destination 1",
         "id": "Di bundaran, lakukan agak ke kiri menuju Destination 1",

--- a/test/fixtures/v5/roundabout_turn/slight_left_name.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstreten al Way Name",
         "es": "Sigue levemente a la izquierda en Way Name",
         "es-ES": "Siga ligeramente a la izquierda en Way Name",
+        "fi": "Käänny loivasti vasempaan tielle Way Name",
         "fr": "Tourner légèrement à gauche sur Way Name",
         "he": "פנה קלה שמאלה על Way Name",
         "id": "Di bundaran, lakukan agak ke kiri ke arah Way Name",

--- a/test/fixtures/v5/roundabout_turn/slight_right_default.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstreten",
         "es": "Sigue levemente a la derecha",
         "es-ES": "Siga ligeramente a la derecha",
+        "fi": "Käänny loivasti oikeaan",
         "fr": "Tourner légèrement à droite",
         "he": "פנה קלה ימינה",
         "id": "Di bundaran, lakukan agak ke kanan",

--- a/test/fixtures/v5/roundabout_turn/slight_right_destination.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu dekstreten direkte al Destination 1",
         "es": "Sigue levemente a la derecha hacia Destination 1",
         "es-ES": "Siga ligeramente a la derecha hacia Destination 1",
+        "fi": "Käänny loivasti oikeaan suuntana Destination 1",
         "fr": "Tourner légèrement à droite en direction de Destination 1",
         "he": "פנה קלה ימינה לכיוון Destination 1",
         "id": "Di bundaran, lakukan agak ke kanan menuju Destination 1",

--- a/test/fixtures/v5/roundabout_turn/slight_right_exit.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu dekstreten al Way Name",
         "es": "Sigue levemente a la derecha en Way Name",
         "es-ES": "Siga ligeramente a la derecha en Way Name",
+        "fi": "Käänny loivasti oikeaan tielle Way Name",
         "fr": "Tourner légèrement à droite sur Way Name",
         "he": "פנה קלה ימינה על Way Name",
         "id": "Di bundaran, lakukan agak ke kanan ke arah Way Name",

--- a/test/fixtures/v5/roundabout_turn/slight_right_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu dekstreten direkte al Destination 1",
         "es": "Sigue levemente a la derecha hacia Destination 1",
         "es-ES": "Siga ligeramente a la derecha hacia Destination 1",
+        "fi": "Käänny loivasti oikeaan suuntana Destination 1",
         "fr": "Tourner légèrement à droite en direction de Destination 1",
         "he": "פנה קלה ימינה לכיוון Destination 1",
         "id": "Di bundaran, lakukan agak ke kanan menuju Destination 1",

--- a/test/fixtures/v5/roundabout_turn/slight_right_name.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstreten al Way Name",
         "es": "Sigue levemente a la derecha en Way Name",
         "es-ES": "Siga ligeramente a la derecha en Way Name",
+        "fi": "Käänny loivasti oikeaan tielle Way Name",
         "fr": "Tourner légèrement à droite sur Way Name",
         "he": "פנה קלה ימינה על Way Name",
         "id": "Di bundaran, lakukan agak ke kanan ke arah Way Name",

--- a/test/fixtures/v5/roundabout_turn/straight_default.json
+++ b/test/fixtures/v5/roundabout_turn/straight_default.json
@@ -14,6 +14,7 @@
         "eo": "Pluu rekten",
         "es": "Continúa recto",
         "es-ES": "Continúa recto",
+        "fi": "Jatka suoraan eteenpäin",
         "fr": "Continuer tout droit",
         "he": "המשך ישר",
         "id": "Di bundaran tetap lurus",

--- a/test/fixtures/v5/roundabout_turn/straight_destination.json
+++ b/test/fixtures/v5/roundabout_turn/straight_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu rekten direkte al Destination 1",
         "es": "Continúa recto hacia Destination 1",
         "es-ES": "Continúa recto hacia Destination 1",
+        "fi": "Jatka suoraan eteenpäin suuntana Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "he": "המשך ישר לכיוון Destination 1",
         "id": "Di bundaran tetap lurus menuju Destination 1",

--- a/test/fixtures/v5/roundabout_turn/straight_exit.json
+++ b/test/fixtures/v5/roundabout_turn/straight_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu rekten al Way Name",
         "es": "Continúa recto en Way Name",
         "es-ES": "Continúa recto por Way Name",
+        "fi": "Jatka suoraan eteenpäin tielle Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "he": "המשך ישר על Way Name",
         "id": "Di bundaran tetap lurus ke arah Way Name",

--- a/test/fixtures/v5/roundabout_turn/straight_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/straight_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu rekten direkte al Destination 1",
         "es": "Continúa recto hacia Destination 1",
         "es-ES": "Continúa recto hacia Destination 1",
+        "fi": "Jatka suoraan eteenpäin suuntana Destination 1",
         "fr": "Continuer tout droit en direction de Destination 1",
         "he": "המשך ישר לכיוון Destination 1",
         "id": "Di bundaran tetap lurus menuju Destination 1",

--- a/test/fixtures/v5/roundabout_turn/straight_name.json
+++ b/test/fixtures/v5/roundabout_turn/straight_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu rekten al Way Name",
         "es": "Continúa recto en Way Name",
         "es-ES": "Continúa recto por Way Name",
+        "fi": "Jatka suoraan eteenpäin tielle Way Name",
         "fr": "Continuer tout droit sur Way Name",
         "he": "המשך ישר על Way Name",
         "id": "Di bundaran tetap lurus ke arah Way Name",

--- a/test/fixtures/v5/roundabout_turn/uturn_default.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu turniĝu malantaŭen",
         "es": "Sigue cambio de sentido",
         "es-ES": "Siga cambio de sentido",
+        "fi": "Käänny U-käännös",
         "fr": "Tourner demi-tour",
         "he": "פנה פניית פרסה",
         "id": "Di bundaran, lakukan putar balik",

--- a/test/fixtures/v5/roundabout_turn/uturn_destination.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu turniĝu malantaŭen direkte al Destination 1",
         "es": "Sigue cambio de sentido hacia Destination 1",
         "es-ES": "Siga cambio de sentido hacia Destination 1",
+        "fi": "Käänny U-käännös suuntana Destination 1",
         "fr": "Tourner demi-tour en direction de Destination 1",
         "he": "פנה פניית פרסה לכיוון Destination 1",
         "id": "Di bundaran, lakukan putar balik menuju Destination 1",

--- a/test/fixtures/v5/roundabout_turn/uturn_exit.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu turniĝu malantaŭen al Way Name",
         "es": "Sigue cambio de sentido en Way Name",
         "es-ES": "Siga cambio de sentido en Way Name",
+        "fi": "Käänny U-käännös tielle Way Name",
         "fr": "Tourner demi-tour sur Way Name",
         "he": "פנה פניית פרסה על Way Name",
         "id": "Di bundaran, lakukan putar balik ke arah Way Name",

--- a/test/fixtures/v5/roundabout_turn/uturn_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu turniĝu malantaŭen direkte al Destination 1",
         "es": "Sigue cambio de sentido hacia Destination 1",
         "es-ES": "Siga cambio de sentido hacia Destination 1",
+        "fi": "Käänny U-käännös suuntana Destination 1",
         "fr": "Tourner demi-tour en direction de Destination 1",
         "he": "פנה פניית פרסה לכיוון Destination 1",
         "id": "Di bundaran, lakukan putar balik menuju Destination 1",

--- a/test/fixtures/v5/roundabout_turn/uturn_name.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu turniĝu malantaŭen al Way Name",
         "es": "Sigue cambio de sentido en Way Name",
         "es-ES": "Siga cambio de sentido en Way Name",
+        "fi": "Käänny U-käännös tielle Way Name",
         "fr": "Tourner demi-tour sur Way Name",
         "he": "פנה פניית פרסה על Way Name",
         "id": "Di bundaran, lakukan putar balik ke arah Way Name",

--- a/test/fixtures/v5/turn/left_default.json
+++ b/test/fixtures/v5/turn/left_default.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu maldekstren",
         "es": "Gira a la izquierda",
         "es-ES": "Gira a la izquierda",
+        "fi": "Käänny vasempaan",
         "fr": "Tourner à gauche",
         "he": "פנה שמאלה",
         "id": "Belok kiri",

--- a/test/fixtures/v5/turn/left_destination.json
+++ b/test/fixtures/v5/turn/left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu maldekstren direkte al Destination 1",
         "es": "Gira a la izquierda hacia Destination 1",
         "es-ES": "Gira a la izquierda hacia Destination 1",
+        "fi": "Käänny vasempaan suuntana Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "he": "פנה שמאלה לכיוון Destination 1",
         "id": "Belok kiri menuju Destination 1",

--- a/test/fixtures/v5/turn/left_exit.json
+++ b/test/fixtures/v5/turn/left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu maldekstren al Way Name",
         "es": "Gira a la izquierda en Way Name",
         "es-ES": "Gira a la izquierda por Way Name",
+        "fi": "Käänny vasempaan tielle Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "he": "פנה שמאלה לWay Name",
         "id": "Belok kiri ke Way Name",

--- a/test/fixtures/v5/turn/left_exit_destination.json
+++ b/test/fixtures/v5/turn/left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu maldekstren direkte al Destination 1",
         "es": "Gira a la izquierda hacia Destination 1",
         "es-ES": "Gira a la izquierda hacia Destination 1",
+        "fi": "Käänny vasempaan suuntana Destination 1",
         "fr": "Tourner à gauche en direction de Destination 1",
         "he": "פנה שמאלה לכיוון Destination 1",
         "id": "Belok kiri menuju Destination 1",

--- a/test/fixtures/v5/turn/left_name.json
+++ b/test/fixtures/v5/turn/left_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu maldekstren al Way Name",
         "es": "Gira a la izquierda en Way Name",
         "es-ES": "Gira a la izquierda por Way Name",
+        "fi": "Käänny vasempaan tielle Way Name",
         "fr": "Tourner à gauche sur Way Name",
         "he": "פנה שמאלה לWay Name",
         "id": "Belok kiri ke Way Name",

--- a/test/fixtures/v5/turn/right_default.json
+++ b/test/fixtures/v5/turn/right_default.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu dekstren",
         "es": "Gira a la derecha",
         "es-ES": "Gira a la derecha",
+        "fi": "Käänny oikeaan",
         "fr": "Tourner à droite",
         "he": "פנה ימינה",
         "id": "Belok kanan",

--- a/test/fixtures/v5/turn/right_destination.json
+++ b/test/fixtures/v5/turn/right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu dekstren direkte al Destination 1",
         "es": "Gira a la derecha hacia Destination 1",
         "es-ES": "Gira a la derecha hacia Destination 1",
+        "fi": "Käänny oikeaan suuntana Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "he": "פנה ימינה לכיוון Destination 1",
         "id": "Belok kanan menuju Destination 1",

--- a/test/fixtures/v5/turn/right_exit.json
+++ b/test/fixtures/v5/turn/right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Turniĝu dekstren al Way Name",
         "es": "Gira a la derecha en Way Name",
         "es-ES": "Gira a la derecha por Way Name",
+        "fi": "Käänny oikeaan tielle Way Name",
         "fr": "Tourner à droite sur Way Name",
         "he": "פנה ימינה לWay Name",
         "id": "Belok kanan ke Way Name",

--- a/test/fixtures/v5/turn/right_exit_destination.json
+++ b/test/fixtures/v5/turn/right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Turniĝu dekstren direkte al Destination 1",
         "es": "Gira a la derecha hacia Destination 1",
         "es-ES": "Gira a la derecha hacia Destination 1",
+        "fi": "Käänny oikeaan suuntana Destination 1",
         "fr": "Tourner à droite en direction de Destination 1",
         "he": "פנה ימינה לכיוון Destination 1",
         "id": "Belok kanan menuju Destination 1",

--- a/test/fixtures/v5/turn/right_name.json
+++ b/test/fixtures/v5/turn/right_name.json
@@ -14,6 +14,7 @@
         "eo": "Turniĝu dekstren al Way Name",
         "es": "Gira a la derecha en Way Name",
         "es-ES": "Gira a la derecha por Way Name",
+        "fi": "Käänny oikeaan tielle Way Name",
         "fr": "Tourner à droite sur Way Name",
         "he": "פנה ימינה לWay Name",
         "id": "Belok kanan ke Way Name",

--- a/test/fixtures/v5/turn/sharp_left_default.json
+++ b/test/fixtures/v5/turn/sharp_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstregen",
         "es": "Sigue cerrada a la izquierda",
         "es-ES": "Gira cerrada a la izquierda",
+        "fi": "Käänny jyrkästi vasempaan",
         "fr": "Tourner franchement à gauche",
         "he": "פנה חדה שמאלה",
         "id": "Lakukan tajam kiri",

--- a/test/fixtures/v5/turn/sharp_left_destination.json
+++ b/test/fixtures/v5/turn/sharp_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu maldekstregen direkte al Destination 1",
         "es": "Sigue cerrada a la izquierda hacia Destination 1",
         "es-ES": "Gira cerrada a la izquierda hacia Destination 1",
+        "fi": "Käänny jyrkästi vasempaan suuntana Destination 1",
         "fr": "Tourner franchement à gauche en direction de Destination 1",
         "he": "פנה חדה שמאלה לכיוון Destination 1",
         "id": "Lakukan tajam kiri menuju Destination 1",

--- a/test/fixtures/v5/turn/sharp_left_exit.json
+++ b/test/fixtures/v5/turn/sharp_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu maldekstregen al Way Name",
         "es": "Sigue cerrada a la izquierda en Way Name",
         "es-ES": "Gira cerrada a la izquierda por Way Name",
+        "fi": "Käänny jyrkästi vasempaan tielle Way Name",
         "fr": "Tourner franchement à gauche sur Way Name",
         "he": "פנה חדה שמאלה על Way Name",
         "id": "Lakukan tajam kiri ke arah Way Name",

--- a/test/fixtures/v5/turn/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/turn/sharp_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu maldekstregen direkte al Destination 1",
         "es": "Sigue cerrada a la izquierda hacia Destination 1",
         "es-ES": "Gira cerrada a la izquierda hacia Destination 1",
+        "fi": "Käänny jyrkästi vasempaan suuntana Destination 1",
         "fr": "Tourner franchement à gauche en direction de Destination 1",
         "he": "פנה חדה שמאלה לכיוון Destination 1",
         "id": "Lakukan tajam kiri menuju Destination 1",

--- a/test/fixtures/v5/turn/sharp_left_name.json
+++ b/test/fixtures/v5/turn/sharp_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstregen al Way Name",
         "es": "Sigue cerrada a la izquierda en Way Name",
         "es-ES": "Gira cerrada a la izquierda por Way Name",
+        "fi": "Käänny jyrkästi vasempaan tielle Way Name",
         "fr": "Tourner franchement à gauche sur Way Name",
         "he": "פנה חדה שמאלה על Way Name",
         "id": "Lakukan tajam kiri ke arah Way Name",

--- a/test/fixtures/v5/turn/sharp_right_default.json
+++ b/test/fixtures/v5/turn/sharp_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstregen",
         "es": "Sigue cerrada a la derecha",
         "es-ES": "Gira cerrada a la derecha",
+        "fi": "Käänny jyrkästi oikeaan",
         "fr": "Tourner franchement à droite",
         "he": "פנה חדה ימינה",
         "id": "Lakukan tajam kanan",

--- a/test/fixtures/v5/turn/sharp_right_destination.json
+++ b/test/fixtures/v5/turn/sharp_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu dekstregen direkte al Destination 1",
         "es": "Sigue cerrada a la derecha hacia Destination 1",
         "es-ES": "Gira cerrada a la derecha hacia Destination 1",
+        "fi": "Käänny jyrkästi oikeaan suuntana Destination 1",
         "fr": "Tourner franchement à droite en direction de Destination 1",
         "he": "פנה חדה ימינה לכיוון Destination 1",
         "id": "Lakukan tajam kanan menuju Destination 1",

--- a/test/fixtures/v5/turn/sharp_right_exit.json
+++ b/test/fixtures/v5/turn/sharp_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu dekstregen al Way Name",
         "es": "Sigue cerrada a la derecha en Way Name",
         "es-ES": "Gira cerrada a la derecha por Way Name",
+        "fi": "Käänny jyrkästi oikeaan tielle Way Name",
         "fr": "Tourner franchement à droite sur Way Name",
         "he": "פנה חדה ימינה על Way Name",
         "id": "Lakukan tajam kanan ke arah Way Name",

--- a/test/fixtures/v5/turn/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/turn/sharp_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu dekstregen direkte al Destination 1",
         "es": "Sigue cerrada a la derecha hacia Destination 1",
         "es-ES": "Gira cerrada a la derecha hacia Destination 1",
+        "fi": "Käänny jyrkästi oikeaan suuntana Destination 1",
         "fr": "Tourner franchement à droite en direction de Destination 1",
         "he": "פנה חדה ימינה לכיוון Destination 1",
         "id": "Lakukan tajam kanan menuju Destination 1",

--- a/test/fixtures/v5/turn/sharp_right_name.json
+++ b/test/fixtures/v5/turn/sharp_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstregen al Way Name",
         "es": "Sigue cerrada a la derecha en Way Name",
         "es-ES": "Gira cerrada a la derecha por Way Name",
+        "fi": "Käänny jyrkästi oikeaan tielle Way Name",
         "fr": "Tourner franchement à droite sur Way Name",
         "he": "פנה חדה ימינה על Way Name",
         "id": "Lakukan tajam kanan ke arah Way Name",

--- a/test/fixtures/v5/turn/slight_left_default.json
+++ b/test/fixtures/v5/turn/slight_left_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstreten",
         "es": "Sigue levemente a la izquierda",
         "es-ES": "Gira ligeramente a la izquierda",
+        "fi": "Käänny loivasti vasempaan",
         "fr": "Tourner légèrement à gauche",
         "he": "פנה קלה שמאלה",
         "id": "Lakukan agak ke kiri",

--- a/test/fixtures/v5/turn/slight_left_destination.json
+++ b/test/fixtures/v5/turn/slight_left_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu maldekstreten direkte al Destination 1",
         "es": "Sigue levemente a la izquierda hacia Destination 1",
         "es-ES": "Gira ligeramente a la izquierda hacia Destination 1",
+        "fi": "Käänny loivasti vasempaan suuntana Destination 1",
         "fr": "Tourner légèrement à gauche en direction de Destination 1",
         "he": "פנה קלה שמאלה לכיוון Destination 1",
         "id": "Lakukan agak ke kiri menuju Destination 1",

--- a/test/fixtures/v5/turn/slight_left_exit.json
+++ b/test/fixtures/v5/turn/slight_left_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu maldekstreten al Way Name",
         "es": "Sigue levemente a la izquierda en Way Name",
         "es-ES": "Gira ligeramente a la izquierda por Way Name",
+        "fi": "Käänny loivasti vasempaan tielle Way Name",
         "fr": "Tourner légèrement à gauche sur Way Name",
         "he": "פנה קלה שמאלה על Way Name",
         "id": "Lakukan agak ke kiri ke arah Way Name",

--- a/test/fixtures/v5/turn/slight_left_exit_destination.json
+++ b/test/fixtures/v5/turn/slight_left_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu maldekstreten direkte al Destination 1",
         "es": "Sigue levemente a la izquierda hacia Destination 1",
         "es-ES": "Gira ligeramente a la izquierda hacia Destination 1",
+        "fi": "Käänny loivasti vasempaan suuntana Destination 1",
         "fr": "Tourner légèrement à gauche en direction de Destination 1",
         "he": "פנה קלה שמאלה לכיוון Destination 1",
         "id": "Lakukan agak ke kiri menuju Destination 1",

--- a/test/fixtures/v5/turn/slight_left_name.json
+++ b/test/fixtures/v5/turn/slight_left_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu maldekstreten al Way Name",
         "es": "Sigue levemente a la izquierda en Way Name",
         "es-ES": "Gira ligeramente a la izquierda por Way Name",
+        "fi": "Käänny loivasti vasempaan tielle Way Name",
         "fr": "Tourner légèrement à gauche sur Way Name",
         "he": "פנה קלה שמאלה על Way Name",
         "id": "Lakukan agak ke kiri ke arah Way Name",

--- a/test/fixtures/v5/turn/slight_right_default.json
+++ b/test/fixtures/v5/turn/slight_right_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstreten",
         "es": "Sigue levemente a la derecha",
         "es-ES": "Gira ligeramente a la derecha",
+        "fi": "Käänny loivasti oikeaan",
         "fr": "Tourner légèrement à droite",
         "he": "פנה קלה ימינה",
         "id": "Lakukan agak ke kanan",

--- a/test/fixtures/v5/turn/slight_right_destination.json
+++ b/test/fixtures/v5/turn/slight_right_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu dekstreten direkte al Destination 1",
         "es": "Sigue levemente a la derecha hacia Destination 1",
         "es-ES": "Gira ligeramente a la derecha hacia Destination 1",
+        "fi": "Käänny loivasti oikeaan suuntana Destination 1",
         "fr": "Tourner légèrement à droite en direction de Destination 1",
         "he": "פנה קלה ימינה לכיוון Destination 1",
         "id": "Lakukan agak ke kanan menuju Destination 1",

--- a/test/fixtures/v5/turn/slight_right_exit.json
+++ b/test/fixtures/v5/turn/slight_right_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu dekstreten al Way Name",
         "es": "Sigue levemente a la derecha en Way Name",
         "es-ES": "Gira ligeramente a la derecha por Way Name",
+        "fi": "Käänny loivasti oikeaan tielle Way Name",
         "fr": "Tourner légèrement à droite sur Way Name",
         "he": "פנה קלה ימינה על Way Name",
         "id": "Lakukan agak ke kanan ke arah Way Name",

--- a/test/fixtures/v5/turn/slight_right_exit_destination.json
+++ b/test/fixtures/v5/turn/slight_right_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu dekstreten direkte al Destination 1",
         "es": "Sigue levemente a la derecha hacia Destination 1",
         "es-ES": "Gira ligeramente a la derecha hacia Destination 1",
+        "fi": "Käänny loivasti oikeaan suuntana Destination 1",
         "fr": "Tourner légèrement à droite en direction de Destination 1",
         "he": "פנה קלה ימינה לכיוון Destination 1",
         "id": "Lakukan agak ke kanan menuju Destination 1",

--- a/test/fixtures/v5/turn/slight_right_name.json
+++ b/test/fixtures/v5/turn/slight_right_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu dekstreten al Way Name",
         "es": "Sigue levemente a la derecha en Way Name",
         "es-ES": "Gira ligeramente a la derecha por Way Name",
+        "fi": "Käänny loivasti oikeaan tielle Way Name",
         "fr": "Tourner légèrement à droite sur Way Name",
         "he": "פנה קלה ימינה על Way Name",
         "id": "Lakukan agak ke kanan ke arah Way Name",

--- a/test/fixtures/v5/turn/straight_default.json
+++ b/test/fixtures/v5/turn/straight_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu rekten",
         "es": "Ve recto",
         "es-ES": "Continúa recto",
+        "fi": "Aja suoraan eteenpäin",
         "fr": "Aller tout droit",
         "he": "המשך ישר",
         "id": "Lurus",

--- a/test/fixtures/v5/turn/straight_destination.json
+++ b/test/fixtures/v5/turn/straight_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu rekten direkte al Destination 1",
         "es": "Ve recto hacia Destination 1",
         "es-ES": "Continúa recto hacia Destination 1",
+        "fi": "Aja suoraan eteenpäin suuntana Destination 1",
         "fr": "Aller tout droit en direction de Destination 1",
         "he": "המשך ישר לכיוון Destination 1",
         "id": "Lurus menuju Destination 1",

--- a/test/fixtures/v5/turn/straight_exit.json
+++ b/test/fixtures/v5/turn/straight_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu rekten al Way Name",
         "es": "Ve recto en Way Name",
         "es-ES": "Continúa recto por Way Name",
+        "fi": "Aja suoraan eteenpäin tielle Way Name",
         "fr": "Aller tout droit sur Way Name",
         "he": "המשך ישר לWay Name",
         "id": "Lurus arah Way Name",

--- a/test/fixtures/v5/turn/straight_exit_destination.json
+++ b/test/fixtures/v5/turn/straight_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu rekten direkte al Destination 1",
         "es": "Ve recto hacia Destination 1",
         "es-ES": "Continúa recto hacia Destination 1",
+        "fi": "Aja suoraan eteenpäin suuntana Destination 1",
         "fr": "Aller tout droit en direction de Destination 1",
         "he": "המשך ישר לכיוון Destination 1",
         "id": "Lurus menuju Destination 1",

--- a/test/fixtures/v5/turn/straight_name.json
+++ b/test/fixtures/v5/turn/straight_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu rekten al Way Name",
         "es": "Ve recto en Way Name",
         "es-ES": "Continúa recto por Way Name",
+        "fi": "Aja suoraan eteenpäin tielle Way Name",
         "fr": "Aller tout droit sur Way Name",
         "he": "המשך ישר לWay Name",
         "id": "Lurus arah Way Name",

--- a/test/fixtures/v5/turn/uturn_default.json
+++ b/test/fixtures/v5/turn/uturn_default.json
@@ -14,6 +14,7 @@
         "eo": "Veturu turniĝu malantaŭen",
         "es": "Sigue cambio de sentido",
         "es-ES": "Gira cambio de sentido",
+        "fi": "Käänny U-käännös",
         "fr": "Tourner demi-tour",
         "he": "פנה פניית פרסה",
         "id": "Lakukan putar balik",

--- a/test/fixtures/v5/turn/uturn_destination.json
+++ b/test/fixtures/v5/turn/uturn_destination.json
@@ -15,6 +15,7 @@
         "eo": "Veturu turniĝu malantaŭen direkte al Destination 1",
         "es": "Sigue cambio de sentido hacia Destination 1",
         "es-ES": "Gira cambio de sentido hacia Destination 1",
+        "fi": "Käänny U-käännös suuntana Destination 1",
         "fr": "Tourner demi-tour en direction de Destination 1",
         "he": "פנה פניית פרסה לכיוון Destination 1",
         "id": "Lakukan putar balik menuju Destination 1",

--- a/test/fixtures/v5/turn/uturn_exit.json
+++ b/test/fixtures/v5/turn/uturn_exit.json
@@ -15,6 +15,7 @@
         "eo": "Veturu turniĝu malantaŭen al Way Name",
         "es": "Sigue cambio de sentido en Way Name",
         "es-ES": "Gira cambio de sentido por Way Name",
+        "fi": "Käänny U-käännös tielle Way Name",
         "fr": "Tourner demi-tour sur Way Name",
         "he": "פנה פניית פרסה על Way Name",
         "id": "Lakukan putar balik ke arah Way Name",

--- a/test/fixtures/v5/turn/uturn_exit_destination.json
+++ b/test/fixtures/v5/turn/uturn_exit_destination.json
@@ -16,6 +16,7 @@
         "eo": "Veturu turniĝu malantaŭen direkte al Destination 1",
         "es": "Sigue cambio de sentido hacia Destination 1",
         "es-ES": "Gira cambio de sentido hacia Destination 1",
+        "fi": "Käänny U-käännös suuntana Destination 1",
         "fr": "Tourner demi-tour en direction de Destination 1",
         "he": "פנה פניית פרסה לכיוון Destination 1",
         "id": "Lakukan putar balik menuju Destination 1",

--- a/test/fixtures/v5/turn/uturn_name.json
+++ b/test/fixtures/v5/turn/uturn_name.json
@@ -14,6 +14,7 @@
         "eo": "Veturu turniĝu malantaŭen al Way Name",
         "es": "Sigue cambio de sentido en Way Name",
         "es-ES": "Gira cambio de sentido por Way Name",
+        "fi": "Käänny U-käännös tielle Way Name",
         "fr": "Tourner demi-tour sur Way Name",
         "he": "פנה פניית פרסה על Way Name",
         "id": "Lakukan putar balik ke arah Way Name",

--- a/test/fixtures/v5/use_lane/o.json
+++ b/test/fixtures/v5/use_lane/o.json
@@ -39,6 +39,7 @@
         "eo": "Pluu rekten",
         "es": "Continúa recto",
         "es-ES": "Continúa recto",
+        "fi": "Jatka suoraan eteenpäin",
         "fr": "Continuer tout droit",
         "he": "המשך ישר",
         "id": "Lurus terus",

--- a/test/fixtures/v5/use_lane/ooo.json
+++ b/test/fixtures/v5/use_lane/ooo.json
@@ -51,6 +51,7 @@
         "eo": "Pluu rekten",
         "es": "Continúa recto",
         "es-ES": "Continúa recto",
+        "fi": "Jatka suoraan eteenpäin",
         "fr": "Continuer tout droit",
         "he": "המשך ישר",
         "id": "Lurus terus",

--- a/test/fixtures/v5/use_lane/oooxxo.json
+++ b/test/fixtures/v5/use_lane/oooxxo.json
@@ -69,6 +69,7 @@
         "eo": "Veturu dekstre aŭ maldekstre",
         "es": "Mantente a la izquierda o derecha",
         "es-ES": "Mantente a la izquierda o a la derecha",
+        "fi": "Pysy vasemmalla tai oikealla",
         "fr": "Rester à gauche ou à droite",
         "he": "היצמד לימין או לשמאל",
         "id": "Tetap di kiri atau kanan",

--- a/test/fixtures/v5/use_lane/oox.json
+++ b/test/fixtures/v5/use_lane/oox.json
@@ -51,6 +51,7 @@
         "eo": "Veturu maldekstre",
         "es": "Mantente a la izquierda",
         "es-ES": "Mantente a la izquierda",
+        "fi": "Pysy vasemmalla",
         "fr": "Serrer à gauche",
         "he": "היצמד לשמאל",
         "id": "Tetap di kiri",

--- a/test/fixtures/v5/use_lane/ooxx.json
+++ b/test/fixtures/v5/use_lane/ooxx.json
@@ -57,6 +57,7 @@
         "eo": "Veturu maldekstre",
         "es": "Mantente a la izquierda",
         "es-ES": "Mantente a la izquierda",
+        "fi": "Pysy vasemmalla",
         "fr": "Serrer à gauche",
         "he": "היצמד לשמאל",
         "id": "Tetap di kiri",

--- a/test/fixtures/v5/use_lane/oxo.json
+++ b/test/fixtures/v5/use_lane/oxo.json
@@ -51,6 +51,7 @@
         "eo": "Veturu dekstre aŭ maldekstre",
         "es": "Mantente a la izquierda o derecha",
         "es-ES": "Mantente a la izquierda o a la derecha",
+        "fi": "Pysy vasemmalla tai oikealla",
         "fr": "Rester à gauche ou à droite",
         "he": "היצמד לימין או לשמאל",
         "id": "Tetap di kiri atau kanan",

--- a/test/fixtures/v5/use_lane/xoo.json
+++ b/test/fixtures/v5/use_lane/xoo.json
@@ -51,6 +51,7 @@
         "eo": "Veturu dekstre",
         "es": "Mantente a la derecha",
         "es-ES": "Mantente a la derecha",
+        "fi": "Pysy oikealla",
         "fr": "Serrer à droite",
         "he": "היצמד לימין",
         "id": "Tetap di kanan",

--- a/test/fixtures/v5/use_lane/xox.json
+++ b/test/fixtures/v5/use_lane/xox.json
@@ -51,6 +51,7 @@
         "eo": "Veturu meze",
         "es": "Mantente en el medio",
         "es-ES": "Mantente en el medio",
+        "fi": "Pysy keskellä",
         "fr": "Rester au milieu",
         "he": "המשך בנתיב האמצעי",
         "id": "Tetap di tengah",

--- a/test/fixtures/v5/use_lane/xxoo.json
+++ b/test/fixtures/v5/use_lane/xxoo.json
@@ -57,6 +57,7 @@
         "eo": "Veturu dekstre",
         "es": "Mantente a la derecha",
         "es-ES": "Mantente a la derecha",
+        "fi": "Pysy oikealla",
         "fr": "Serrer à droite",
         "he": "היצמד לימין",
         "id": "Tetap di kanan",

--- a/test/fixtures/v5/use_lane/xxooxx.json
+++ b/test/fixtures/v5/use_lane/xxooxx.json
@@ -69,6 +69,7 @@
         "eo": "Veturu meze",
         "es": "Mantente en el medio",
         "es-ES": "Mantente en el medio",
+        "fi": "Pysy keskellä",
         "fr": "Rester au milieu",
         "he": "המשך בנתיב האמצעי",
         "id": "Tetap di tengah",

--- a/test/fixtures/v5/use_lane/xxoxo.json
+++ b/test/fixtures/v5/use_lane/xxoxo.json
@@ -63,6 +63,7 @@
         "eo": "Pluu rekten",
         "es": "Continúa recto",
         "es-ES": "Continúa recto",
+        "fi": "Jatka suoraan eteenpäin",
         "fr": "Continuer tout droit",
         "he": "המשך ישר",
         "id": "Lurus terus",


### PR DESCRIPTION
Proposing Finnish translations. I continued the translations mentioned in issue #223.

This commit has issues, not all the translations are very fluent. Consider this version for review, but there's definitely room for improvement. I also post this here so that it gets visibility and perhaps some people can help in improving this.

This is the best I can do with just Transifex, but some of these aren't very good Finnish. For example the modifier `left` is translated as `vasemmall(e/a)`. That's because the modifier is used in different contexts and a different form of the word would be needed. Roughly: "to the left" is "vasemmalle", "on the left" is "vasemmalla".

This and other issues can maybe be solved with the grammar system, but I haven't yet studied how that works.