### PR TITLE
Initial French grammar rules to insert articles to way names

### DIFF
--- a/languages.js
+++ b/languages.js
@@ -26,6 +26,7 @@ var instructionsVi = require('./languages/translations/vi.json');
 var instructionsZhHans = require('./languages/translations/zh-Hans.json');
 
 // Load all grammar files
+var grammarFr = require('./languages/grammar/fr.json');
 var grammarRu = require('./languages/grammar/ru.json');
 
 // Load all abbreviations files
@@ -76,6 +77,7 @@ var instructions = {
 
 // Create list of supported grammar
 var grammars = {
+    'fr': grammarFr,
     'ru': grammarRu
 };
 

--- a/languages/grammar/fr.json
+++ b/languages/grammar/fr.json
@@ -1,0 +1,10 @@
+{
+    "meta": {
+        "regExpFlags": "gi"
+    },
+    "v5": {
+        "article": [
+            ["^ Rue ", " la rue "]
+        ]
+    }
+}

--- a/languages/overrides/fr.js
+++ b/languages/overrides/fr.js
@@ -1,0 +1,35 @@
+// Add grammar option to {way_name} depending on phrase context
+
+var replaces = [
+    [' par +\{way_name\}', ' par {way_name:article}'], // eslint-disable-line no-useless-escape
+    [' rester +\{way_name\}', ' rester {way_name:article}'], // eslint-disable-line no-useless-escape
+    [' sur +\{way_name\}', ' sur {way_name:article}'] // eslint-disable-line no-useless-escape
+];
+
+function optionize(phrase) {
+    var result = phrase;
+    replaces.forEach(function(pattern) {
+        var re = new RegExp(pattern[0], 'gi');
+        result = result.replace(re, pattern[1]);
+    });
+
+    return result;
+}
+
+function iterate(values) {
+    Object.keys(values).forEach(function (key) {
+        var value = values[key];
+        if (typeof value === 'string') {
+            values[key] = optionize(value);
+        } else if (typeof value === 'object') {
+            iterate(value);
+        }
+    });
+}
+
+module.exports = function(content) {
+    // Iterate all content string values recursively
+    iterate(content.v5);
+
+    return content;
+};

--- a/languages/translations/fr.json
+++ b/languages/translations/fr.json
@@ -118,59 +118,59 @@
         "continue": {
             "default": {
                 "default": "Tourner {modifier}",
-                "name": "Tourner {modifier} pour rester {way_name}",
+                "name": "Tourner {modifier} pour rester {way_name:article}",
                 "destination": "Tourner {modifier} en direction de {destination}",
-                "exit": "Tourner {modifier} sur {way_name}"
+                "exit": "Tourner {modifier} sur {way_name:article}"
             },
             "straight": {
                 "default": "Continuer tout droit",
-                "name": "Continuer tout droit pour rester sur {way_name}",
+                "name": "Continuer tout droit pour rester sur {way_name:article}",
                 "destination": "Continuer tout droit en direction de {destination}",
                 "distance": "Continuer tout droit sur {distance}",
-                "namedistance": "Continuer sur {way_name} sur {distance}"
+                "namedistance": "Continuer sur {way_name:article} sur {distance}"
             },
             "sharp left": {
                 "default": "Braquer à gauche",
-                "name": "Braquer à gauche pour rester sur {way_name}",
+                "name": "Braquer à gauche pour rester sur {way_name:article}",
                 "destination": "Braquer à gauche en direction de {destination}"
             },
             "sharp right": {
                 "default": "Braquer à droite",
-                "name": "Braquer à droite pour rester sur {way_name}",
+                "name": "Braquer à droite pour rester sur {way_name:article}",
                 "destination": "Braquer à droite en direction de {destination}"
             },
             "slight left": {
                 "default": "S’aligner légèrement à gauche",
-                "name": "S’aligner légèrement à gauche pour rester sur {way_name}",
+                "name": "S’aligner légèrement à gauche pour rester sur {way_name:article}",
                 "destination": "S’aligner légèrement à gauche en direction de {destination}"
             },
             "slight right": {
                 "default": "S’aligner légèrement à droite",
-                "name": "S’aligner légèrement à droite pour rester sur {way_name}",
+                "name": "S’aligner légèrement à droite pour rester sur {way_name:article}",
                 "destination": "S’aligner légèrement à droite en direction de {destination}"
             },
             "uturn": {
                 "default": "Faire demi-tour",
-                "name": "Faire demi-tour et continuer sur {way_name}",
+                "name": "Faire demi-tour et continuer sur {way_name:article}",
                 "destination": "Faire demi-tour en direction de {destination}"
             }
         },
         "depart": {
             "default": {
                 "default": "Rouler vers {direction}",
-                "name": "Rouler vers {direction} sur {way_name}",
-                "namedistance": "Rouler vers {direction} sur {way_name} sur {distance}"
+                "name": "Rouler vers {direction} sur {way_name:article}",
+                "namedistance": "Rouler vers {direction} sur {way_name:article} sur {distance}"
             }
         },
         "end of road": {
             "default": {
                 "default": "Tourner {modifier}",
-                "name": "Tourner {modifier} sur {way_name}",
+                "name": "Tourner {modifier} sur {way_name:article}",
                 "destination": "Tourner {modifier} en direction de {destination}"
             },
             "straight": {
                 "default": "Continuer tout droit",
-                "name": "Continuer tout droit sur {way_name}",
+                "name": "Continuer tout droit sur {way_name:article}",
                 "destination": "Continuer tout droit en direction de {destination}"
             },
             "uturn": {
@@ -182,167 +182,167 @@
         "fork": {
             "default": {
                 "default": "Rester {modifier} à l’embranchement",
-                "name": "Rester {modifier} à l’embranchement sur {way_name}",
+                "name": "Rester {modifier} à l’embranchement sur {way_name:article}",
                 "destination": "Rester {modifier} à l’embranchement en direction de {destination}"
             },
             "slight left": {
                 "default": "Rester à gauche à l’embranchement",
-                "name": "Rester à gauche à l’embranchement sur {way_name}",
+                "name": "Rester à gauche à l’embranchement sur {way_name:article}",
                 "destination": "Rester à gauche à l’embranchement en direction de {destination}"
             },
             "slight right": {
                 "default": "Rester à droite à l’embranchement",
-                "name": "Rester à droite à l’embranchement sur {way_name}",
+                "name": "Rester à droite à l’embranchement sur {way_name:article}",
                 "destination": "Rester à droite à l’embranchement en direction de {destination}"
             },
             "sharp left": {
                 "default": "Prendre franchement à gauche à l’embranchement",
-                "name": "Prendre franchement à gauche sur {way_name}",
+                "name": "Prendre franchement à gauche sur {way_name:article}",
                 "destination": "Prendre franchement à gauche en direction de {destination}"
             },
             "sharp right": {
                 "default": "Prendre franchement à droite à l’embranchement",
-                "name": "Prendre franchement à droite sur {way_name}",
+                "name": "Prendre franchement à droite sur {way_name:article}",
                 "destination": "Prendre franchement à droite en direction de {destination}"
             },
             "uturn": {
                 "default": "Faire demi-tour",
-                "name": "Faire demi-tour sur {way_name}",
+                "name": "Faire demi-tour sur {way_name:article}",
                 "destination": "Faire demi-tour en direction de {destination}"
             }
         },
         "merge": {
             "default": {
                 "default": "Rejoindre {modifier}",
-                "name": "Rejoindre {modifier} sur {way_name}",
+                "name": "Rejoindre {modifier} sur {way_name:article}",
                 "destination": "Rejoindre {modifier} en direction de {destination}"
             },
             "straight": {
                 "default": "S’insérer",
-                "name": "S’insérer sur {way_name}",
+                "name": "S’insérer sur {way_name:article}",
                 "destination": "S’insérer en direction de {destination}"
             },
             "slight left": {
                 "default": "S’insérer légèrement à gauche",
-                "name": "S’insérer légèrement à gauche sur {way_name}",
+                "name": "S’insérer légèrement à gauche sur {way_name:article}",
                 "destination": "S’insérer légèrement à gauche en direction de {destination}"
             },
             "slight right": {
                 "default": "S’insérer légèrement à droite",
-                "name": "S’insérer légèrement à droite sur {way_name}",
+                "name": "S’insérer légèrement à droite sur {way_name:article}",
                 "destination": "S’insérer à droite en direction de {destination}"
             },
             "sharp left": {
                 "default": "S’insérer à gauche",
-                "name": "S’insérer à gauche sur {way_name}",
+                "name": "S’insérer à gauche sur {way_name:article}",
                 "destination": "S’insérer à gauche en direction de {destination}"
             },
             "sharp right": {
                 "default": "S’insérer à droite",
-                "name": "S’insérer à droite sur {way_name}",
+                "name": "S’insérer à droite sur {way_name:article}",
                 "destination": "S’insérer à droite en direction de {destination}"
             },
             "uturn": {
                 "default": "Faire demi-tour",
-                "name": "Faire demi-tour sur {way_name}",
+                "name": "Faire demi-tour sur {way_name:article}",
                 "destination": "Faire demi-tour en direction de {destination}"
             }
         },
         "new name": {
             "default": {
                 "default": "Continuer {modifier}",
-                "name": "Continuer {modifier} sur {way_name}",
+                "name": "Continuer {modifier} sur {way_name:article}",
                 "destination": "Continuer {modifier} en direction de {destination}"
             },
             "straight": {
                 "default": "Continuer tout droit",
-                "name": "Continuer tout droit sur {way_name}",
+                "name": "Continuer tout droit sur {way_name:article}",
                 "destination": "Continuer tout droit en direction de {destination}"
             },
             "sharp left": {
                 "default": "Prendre franchement à gauche",
-                "name": "Prendre franchement à gauche sur {way_name}",
+                "name": "Prendre franchement à gauche sur {way_name:article}",
                 "destination": "Prendre franchement à gauche en direction de {destination}"
             },
             "sharp right": {
                 "default": "Prendre franchement à droite",
-                "name": "Prendre franchement à droite sur {way_name}",
+                "name": "Prendre franchement à droite sur {way_name:article}",
                 "destination": "Prendre franchement à droite en direction de {destination}"
             },
             "slight left": {
                 "default": "Continuer légèrement à gauche",
-                "name": "Continuer légèrement à gauche sur {way_name}",
+                "name": "Continuer légèrement à gauche sur {way_name:article}",
                 "destination": "Continuer légèrement à gauche en direction de {destination}"
             },
             "slight right": {
                 "default": "Continuer légèrement à droite",
-                "name": "Continuer légèrement à droite sur {way_name}",
+                "name": "Continuer légèrement à droite sur {way_name:article}",
                 "destination": "Continuer légèrement à droite en direction de {destination}"
             },
             "uturn": {
                 "default": "Faire demi-tour",
-                "name": "Faire demi-tour sur {way_name}",
+                "name": "Faire demi-tour sur {way_name:article}",
                 "destination": "Faire demi-tour en direction de {destination}"
             }
         },
         "notification": {
             "default": {
                 "default": "Continuer {modifier}",
-                "name": "Continuer {modifier} sur {way_name}",
+                "name": "Continuer {modifier} sur {way_name:article}",
                 "destination": "Continuer {modifier} en direction de {destination}"
             },
             "uturn": {
                 "default": "Faire demi-tour",
-                "name": "Faire demi-tour sur {way_name}",
+                "name": "Faire demi-tour sur {way_name:article}",
                 "destination": "Faire demi-tour en direction de {destination}"
             }
         },
         "off ramp": {
             "default": {
                 "default": "Prendre la sortie",
-                "name": "Prendre la sortie sur {way_name}",
+                "name": "Prendre la sortie sur {way_name:article}",
                 "destination": "Prendre la sortie en direction de {destination}",
                 "exit": "Prendre la sortie {exit}",
                 "exit_destination": "Prendre la sortie {exit} en direction de {destination}"
             },
             "left": {
                 "default": "Prendre la sortie à gauche",
-                "name": "Prendre la sortie à gauche sur {way_name}",
+                "name": "Prendre la sortie à gauche sur {way_name:article}",
                 "destination": "Prendre la sortie à gauche en direction de {destination}",
                 "exit": "Prendre la sortie {exit} sur la gauche",
                 "exit_destination": "Prendre la sortie {exit} sur la gauche en direction de {destination}"
             },
             "right": {
                 "default": "Prendre la sortie à droite",
-                "name": "Prendre la sortie à droite sur {way_name}",
+                "name": "Prendre la sortie à droite sur {way_name:article}",
                 "destination": "Prendre la sortie à droite en direction de {destination}",
                 "exit": "Prendre la sortie {exit} sur la droite",
                 "exit_destination": "Prendre la sortie {exit} sur la droite en direction de {destination}"
             },
             "sharp left": {
                 "default": "Prendre la sortie à gauche",
-                "name": "Prendre la sortie à gauche sur {way_name}",
+                "name": "Prendre la sortie à gauche sur {way_name:article}",
                 "destination": "Prendre la sortie à gauche en direction de {destination}",
                 "exit": "Prendre la sortie {exit} sur la gauche",
                 "exit_destination": "Prendre la sortie {exit} sur la gauche en direction de {destination}"
             },
             "sharp right": {
                 "default": "Prendre la sortie à droite",
-                "name": "Prendre la sortie à droite sur {way_name}",
+                "name": "Prendre la sortie à droite sur {way_name:article}",
                 "destination": "Prendre la sortie à droite en direction de {destination}",
                 "exit": "Prendre la sortie {exit} sur la droite",
                 "exit_destination": "Prendre la sortie {exit} sur la droite en direction de {destination}"
             },
             "slight left": {
                 "default": "Prendre la sortie à gauche",
-                "name": "Prendre la sortie à gauche sur {way_name}",
+                "name": "Prendre la sortie à gauche sur {way_name:article}",
                 "destination": "Prendre la sortie à gauche en direction de {destination}",
                 "exit": "Prendre la sortie {exit} sur la gauche",
                 "exit_destination": "Prendre la sortie {exit} sur la gauche en direction de {destination}"
             },
             "slight right": {
                 "default": "Prendre la sortie à droite",
-                "name": "Prendre la sortie à droite sur {way_name}",
+                "name": "Prendre la sortie à droite sur {way_name:article}",
                 "destination": "Prendre la sortie à droite en direction de {destination}",
                 "exit": "Prendre la sortie {exit} sur la droite",
                 "exit_destination": "Prendre la sortie {exit} sur la droite en direction de {destination}"
@@ -351,37 +351,37 @@
         "on ramp": {
             "default": {
                 "default": "Prendre la sortie",
-                "name": "Prendre la sortie sur {way_name}",
+                "name": "Prendre la sortie sur {way_name:article}",
                 "destination": "Prendre la sortie en direction de {destination}"
             },
             "left": {
                 "default": "Prendre la sortie à gauche",
-                "name": "Prendre la sortie à gauche sur {way_name}",
+                "name": "Prendre la sortie à gauche sur {way_name:article}",
                 "destination": "Prendre la sortie à gauche en direction de {destination}"
             },
             "right": {
                 "default": "Prendre la sortie à droite",
-                "name": "Prendre la sortie à droite sur {way_name}",
+                "name": "Prendre la sortie à droite sur {way_name:article}",
                 "destination": "Prendre la sortie à droite en direction de {destination}"
             },
             "sharp left": {
                 "default": "Prendre la sortie à gauche",
-                "name": "Prendre la sortie à gauche sur {way_name}",
+                "name": "Prendre la sortie à gauche sur {way_name:article}",
                 "destination": "Prendre la sortie à gauche en direction de {destination}"
             },
             "sharp right": {
                 "default": "Prendre la sortie à droite",
-                "name": "Prendre la sortie à droite sur {way_name}",
+                "name": "Prendre la sortie à droite sur {way_name:article}",
                 "destination": "Prendre la sortie à droite en direction de {destination}"
             },
             "slight left": {
                 "default": "Prendre la sortie à gauche",
-                "name": "Prendre la sortie à gauche sur {way_name}",
+                "name": "Prendre la sortie à gauche sur {way_name:article}",
                 "destination": "Prendre la sortie à gauche en direction de {destination}"
             },
             "slight right": {
                 "default": "Prendre la sortie à droite",
-                "name": "Prendre la sortie à droite sur {way_name}",
+                "name": "Prendre la sortie à droite sur {way_name:article}",
                 "destination": "Prendre la sortie à droite en direction de {destination}"
             }
         },
@@ -389,22 +389,22 @@
             "default": {
                 "default": {
                     "default": "Prendre le rond-point",
-                    "name": "Prendre le rond-point et sortir sur {way_name}",
+                    "name": "Prendre le rond-point et sortir sur {way_name:article}",
                     "destination": "Prendre le rond-point et sortir en direction de {destination}"
                 },
                 "name": {
                     "default": "Prendre le rond-point {rotary_name}",
-                    "name": "Prendre le rond-point {rotary_name} et sortir par {way_name}",
+                    "name": "Prendre le rond-point {rotary_name} et sortir par {way_name:article}",
                     "destination": "Prendre le rond-point {rotary_name} et sortir en direction de {destination}"
                 },
                 "exit": {
                     "default": "Prendre le rond-point et prendre la {exit_number} sortie",
-                    "name": "Prendre le rond-point et prendre la {exit_number} sortie sur {way_name}",
+                    "name": "Prendre le rond-point et prendre la {exit_number} sortie sur {way_name:article}",
                     "destination": "Prendre le rond-point et prendre la {exit_number} sortie en direction de {destination}"
                 },
                 "name_exit": {
                     "default": "Prendre le rond-point {rotary_name} et prendre la {exit_number} sortie",
-                    "name": "Prendre le rond-point {rotary_name} et prendre la {exit_number} sortie sur {way_name}",
+                    "name": "Prendre le rond-point {rotary_name} et prendre la {exit_number} sortie sur {way_name:article}",
                     "destination": "Prendre le rond-point {rotary_name} et prendre la {exit_number} sortie en direction de {destination}"
                 }
             }
@@ -413,12 +413,12 @@
             "default": {
                 "exit": {
                     "default": "Prendre le rond-point et prendre la {exit_number} sortie",
-                    "name": "Prendre le rond-point et prendre la {exit_number} sortie sur {way_name}",
+                    "name": "Prendre le rond-point et prendre la {exit_number} sortie sur {way_name:article}",
                     "destination": "Prendre le rond-point et prendre la {exit_number} sortie en direction de {destination}"
                 },
                 "default": {
                     "default": "Prendre le rond-point",
-                    "name": "Prendre le rond-point et sortir sur {way_name}",
+                    "name": "Prendre le rond-point et sortir sur {way_name:article}",
                     "destination": "Prendre le rond-point et sortir en direction de {destination}"
                 }
             }
@@ -426,58 +426,58 @@
         "roundabout turn": {
             "default": {
                 "default": "Tourner {modifier}",
-                "name": "Tourner {modifier} sur {way_name}",
+                "name": "Tourner {modifier} sur {way_name:article}",
                 "destination": "Tourner {modifier} en direction de {destination}"
             },
             "left": {
                 "default": "Tourner à gauche",
-                "name": "Tourner à gauche sur {way_name}",
+                "name": "Tourner à gauche sur {way_name:article}",
                 "destination": "Tourner à gauche en direction de {destination}"
             },
             "right": {
                 "default": "Tourner à droite",
-                "name": "Tourner à droite sur {way_name}",
+                "name": "Tourner à droite sur {way_name:article}",
                 "destination": "Tourner à droite en direction de {destination}"
             },
             "straight": {
                 "default": "Continuer tout droit",
-                "name": "Continuer tout droit sur {way_name}",
+                "name": "Continuer tout droit sur {way_name:article}",
                 "destination": "Continuer tout droit en direction de {destination}"
             }
         },
         "exit roundabout": {
             "default": {
                 "default": "Sortir du rond-point",
-                "name": "Sortir du rond-point sur {way_name}",
+                "name": "Sortir du rond-point sur {way_name:article}",
                 "destination": "Sortir du rond-point en direction de {destination}"
             }
         },
         "exit rotary": {
             "default": {
                 "default": "Sortir du rond-point",
-                "name": "Sortir du rond-point sur {way_name}",
+                "name": "Sortir du rond-point sur {way_name:article}",
                 "destination": "Sortir du rond-point en direction de {destination}"
             }
         },
         "turn": {
             "default": {
                 "default": "Tourner {modifier}",
-                "name": "Tourner {modifier} sur {way_name}",
+                "name": "Tourner {modifier} sur {way_name:article}",
                 "destination": "Tourner {modifier} en direction de {destination}"
             },
             "left": {
                 "default": "Tourner à gauche",
-                "name": "Tourner à gauche sur {way_name}",
+                "name": "Tourner à gauche sur {way_name:article}",
                 "destination": "Tourner à gauche en direction de {destination}"
             },
             "right": {
                 "default": "Tourner à droite",
-                "name": "Tourner à droite sur {way_name}",
+                "name": "Tourner à droite sur {way_name:article}",
                 "destination": "Tourner à droite en direction de {destination}"
             },
             "straight": {
                 "default": "Aller tout droit",
-                "name": "Aller tout droit sur {way_name}",
+                "name": "Aller tout droit sur {way_name:article}",
                 "destination": "Aller tout droit en direction de {destination}"
             }
         },

--- a/test/grammar_test.js
+++ b/test/grammar_test.js
@@ -4,6 +4,9 @@ var instructions = require('../index.js');
 var languages = require('../languages.js');
 
 const grammarTests = {
+    'fr': [
+        ['Rue de Jarménil', 'article', 'la rue de Jarménil']
+    ],
     'ru': [
         ['Бармалеева улица', 'accusative', 'Бармалееву улицу'],
         ['Бармалеева улица', 'dative', 'Бармалеевой улице'],


### PR DESCRIPTION
# Issue

Initial French grammar rules prototype to insert articles to way names (#251).

Currently only `Rue` status street name is supported:
![french articles](https://user-images.githubusercontent.com/4529411/41585667-40d5065a-739a-11e8-9a30-896f26a8887b.png)

## Tasklist

 - [ ] Add other status street names handling (?)
 - [ ] Add changelog entry
 - [x] Test with osrm-frontend
 - [ ] Review

## Requirements / Relations

New `languages/overrides/fr.js` script adds `article` option to most `way_name` keywords during translations export from Transifex, `languages/grammar/fr.json` contains regular expressions (currently one) to process street names, changed `languages.js` loads and registers that French expressions file. `test/grammar_test.js` is extended with test for French.
