### PR TITLE
Improve article matching in French instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file. For change 
 - Added a Japanese localization. [#277](https://github.com/Project-OSRM/osrm-text-instructions/pull/277)
 - Added an Arabic localization. [#267](https://github.com/Project-OSRM/osrm-text-instructions/pull/267)
 - Added a Slovenian localization. [#264](https://github.com/Project-OSRM/osrm-text-instructions/pull/264)
-- Updated French grammar with 'chaussée' status street name. [#268](https://github.com/Project-OSRM/osrm-text-instructions/pull/268)
+- Updated French grammar with 'chaussée' status street name and better articles matching. [#268](https://github.com/Project-OSRM/osrm-text-instructions/pull/268)[#279](https://github.com/Project-OSRM/osrm-text-instructions/pull/279)
 
 ## 0.13.2 2018-08-13
 

--- a/languages/overrides/fr.js
+++ b/languages/overrides/fr.js
@@ -5,7 +5,7 @@ var replaces = [
     [' (le rond-point )?\{rotary_name\}', ' {rotary_name:rotary}'], // eslint-disable-line no-useless-escape
     [' fin (de )?(la route )?\{way_name\}', ' fin {way_name:preposition}'], // eslint-disable-line no-useless-escape
     [' \{way_name\}', ' {way_name:article}'], // eslint-disable-line no-useless-escape
-    [' (à )?\{waypoint_name\}', ' {waypoint_name:arrival}'] // eslint-disable-line no-useless-escape
+    [' (à +)?\{waypoint_name\}', ' {waypoint_name:arrival}'] // eslint-disable-line no-useless-escape
 ];
 
 function optionize(phrase) {

--- a/languages/translations/fr.json
+++ b/languages/translations/fr.json
@@ -77,7 +77,7 @@
                 "upcoming": "Vous arriverez à votre {nth} destination, sur la droite",
                 "short": "Vous êtes arrivé",
                 "short-upcoming": "Vous arriverez",
-                "named": "Vous êtes arrivé à  {waypoint_name:arrival}, sur la droite"
+                "named": "Vous êtes arrivé {waypoint_name:arrival}, sur la droite"
             },
             "sharp left": {
                 "default": "Vous êtes arrivé à votre {nth} destination, sur la gauche",

--- a/test/fixtures/v5/arrive_waypoint_name/right.json
+++ b/test/fixtures/v5/arrive_waypoint_name/right.json
@@ -15,7 +15,7 @@
         "es": "Has llegado a Somewhere, a la derecha",
         "es-ES": "Has llegado a Somewhere, a la derecha",
         "fi": "Olet saapunut määränpäähän Somewhere, joka on oikealla puolellasi",
-        "fr": "Vous êtes arrivé à à Somewhere, sur la droite",
+        "fr": "Vous êtes arrivé à Somewhere, sur la droite",
         "he": "הגעת אל Somewhere שלך מימינך",
         "hu": "Megérkezett a Somewhere célponthoz, a jobb oldalon",
         "id": "Anda telah tiba di Somewhere, di sebelah kanan",


### PR DESCRIPTION
# Issue

Match articles in French instructions with any number of whitespaces between article and `{waypoint_name}` to fix #275 issue.

## Tasklist

 - [x] Add changelog entry
 - [ ] Test with osrm-frontend (?)
 - [ ] Review

@1ec5, should I update change log for this 1 char change in French override script?