### PR TITLE
Rename traffic circle to roundabout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
+## master
+
+- Renamed “traffic circle” to “roundabout” in the English localization. [#285](https://github.com/Project-OSRM/osrm-text-instructions/pull/285)
+
 ## 0.13.3 2019-03-29
 
 - Added a Hungarian localization and grammar. [#274](https://github.com/Project-OSRM/osrm-text-instructions/pull/274)

--- a/languages/translations/en.json
+++ b/languages/translations/en.json
@@ -388,9 +388,9 @@
         "rotary": {
             "default": {
                 "default": {
-                    "default": "Enter the traffic circle",
-                    "name": "Enter the traffic circle and exit onto {way_name}",
-                    "destination": "Enter the traffic circle and exit towards {destination}"
+                    "default": "Enter the roundabout",
+                    "name": "Enter the roundabout and exit onto {way_name}",
+                    "destination": "Enter the roundabout and exit towards {destination}"
                 },
                 "name": {
                     "default": "Enter {rotary_name}",
@@ -398,9 +398,9 @@
                     "destination": "Enter {rotary_name} and exit towards {destination}"
                 },
                 "exit": {
-                    "default": "Enter the traffic circle and take the {exit_number} exit",
-                    "name": "Enter the traffic circle and take the {exit_number} exit onto {way_name}",
-                    "destination": "Enter the traffic circle and take the {exit_number} exit towards {destination}"
+                    "default": "Enter the roundabout and take the {exit_number} exit",
+                    "name": "Enter the roundabout and take the {exit_number} exit onto {way_name}",
+                    "destination": "Enter the roundabout and take the {exit_number} exit towards {destination}"
                 },
                 "name_exit": {
                     "default": "Enter {rotary_name} and take the {exit_number} exit",
@@ -412,14 +412,14 @@
         "roundabout": {
             "default": {
                 "exit": {
-                    "default": "Enter the traffic circle and take the {exit_number} exit",
-                    "name": "Enter the traffic circle and take the {exit_number} exit onto {way_name}",
-                    "destination": "Enter the traffic circle and take the {exit_number} exit towards {destination}"
+                    "default": "Enter the roundabout and take the {exit_number} exit",
+                    "name": "Enter the roundabout and take the {exit_number} exit onto {way_name}",
+                    "destination": "Enter the roundabout and take the {exit_number} exit towards {destination}"
                 },
                 "default": {
-                    "default": "Enter the traffic circle",
-                    "name": "Enter the traffic circle and exit onto {way_name}",
-                    "destination": "Enter the traffic circle and exit towards {destination}"
+                    "default": "Enter the roundabout",
+                    "name": "Enter the roundabout and exit onto {way_name}",
+                    "destination": "Enter the roundabout and exit towards {destination}"
                 }
             }
         },
@@ -447,16 +447,16 @@
         },
         "exit roundabout": {
             "default": {
-                "default": "Exit the traffic circle",
-                "name": "Exit the traffic circle onto {way_name}",
-                "destination": "Exit the traffic circle towards {destination}"
+                "default": "Exit the roundabout",
+                "name": "Exit the roundabout onto {way_name}",
+                "destination": "Exit the roundabout towards {destination}"
             }
         },
         "exit rotary": {
             "default": {
-                "default": "Exit the traffic circle",
-                "name": "Exit the traffic circle onto {way_name}",
-                "destination": "Exit the traffic circle towards {destination}"
+                "default": "Exit the roundabout",
+                "name": "Exit the roundabout onto {way_name}",
+                "destination": "Exit the roundabout towards {destination}"
             }
         },
         "turn": {

--- a/languages/translations/pt-BR.json
+++ b/languages/translations/pt-BR.json
@@ -448,15 +448,15 @@
         "exit roundabout": {
             "default": {
                 "default": "Saia da rotatória",
-                "name": "Exit the traffic circle onto {way_name}",
-                "destination": "Exit the traffic circle towards {destination}"
+                "name": "Exit the roundabout onto {way_name}",
+                "destination": "Exit the roundabout towards {destination}"
             }
         },
         "exit rotary": {
             "default": {
                 "default": "Saia da rotatória",
-                "name": "Exit the traffic circle onto {way_name}",
-                "destination": "Exit the traffic circle towards {destination}"
+                "name": "Exit the roundabout onto {way_name}",
+                "destination": "Exit the roundabout towards {destination}"
             }
         },
         "turn": {

--- a/test/fixtures/v5/exit_rotary/left_default.json
+++ b/test/fixtures/v5/exit_rotary/left_default.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من الدوّار",
         "da": "Forlad rundkørslen",
         "de": "Links abbiegen",
-        "en": "Exit the traffic circle",
+        "en": "Exit the roundabout",
         "eo": "Eliru trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",

--- a/test/fixtures/v5/exit_rotary/left_destination.json
+++ b/test/fixtures/v5/exit_rotary/left_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Links abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_rotary/left_destination.json
+++ b/test/fixtures/v5/exit_rotary/left_destination.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Skręć w lewo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_rotary/left_exit.json
+++ b/test/fixtures/v5/exit_rotary/left_exit.json
@@ -12,7 +12,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Links abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_rotary/left_exit.json
+++ b/test/fixtures/v5/exit_rotary/left_exit.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Skręć w lewo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_rotary/left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/left_exit_destination.json
@@ -29,7 +29,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Skręć w lewo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_rotary/left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/left_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Links abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_rotary/left_name.json
+++ b/test/fixtures/v5/exit_rotary/left_name.json
@@ -27,7 +27,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Skręć w lewo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_rotary/left_name.json
+++ b/test/fixtures/v5/exit_rotary/left_name.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Links abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_rotary/right_default.json
+++ b/test/fixtures/v5/exit_rotary/right_default.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من الدوّار",
         "da": "Forlad rundkørslen",
         "de": "Rechts abbiegen",
-        "en": "Exit the traffic circle",
+        "en": "Exit the roundabout",
         "eo": "Eliru trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",

--- a/test/fixtures/v5/exit_rotary/right_destination.json
+++ b/test/fixtures/v5/exit_rotary/right_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Rechts abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_rotary/right_destination.json
+++ b/test/fixtures/v5/exit_rotary/right_destination.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Skręć w prawo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_rotary/right_exit.json
+++ b/test/fixtures/v5/exit_rotary/right_exit.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Skręć w prawo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_rotary/right_exit.json
+++ b/test/fixtures/v5/exit_rotary/right_exit.json
@@ -12,7 +12,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Rechts abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_rotary/right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/right_exit_destination.json
@@ -29,7 +29,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Skręć w prawo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_rotary/right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/right_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Rechts abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_rotary/right_name.json
+++ b/test/fixtures/v5/exit_rotary/right_name.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Rechts abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_rotary/right_name.json
+++ b/test/fixtures/v5/exit_rotary/right_name.json
@@ -27,7 +27,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Skręć w prawo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_left_default.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_default.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من الدوّار",
         "da": "Forlad rundkørslen",
         "de": "Scharf links abbiegen",
-        "en": "Exit the traffic circle",
+        "en": "Exit the roundabout",
         "eo": "Eliru trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",

--- a/test/fixtures/v5/exit_rotary/sharp_left_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_destination.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Ostro w lewo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_left_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Scharf links abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_left_exit.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_exit.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Ostro w lewo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_left_exit.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_exit.json
@@ -12,7 +12,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Scharf links abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Scharf links abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_exit_destination.json
@@ -29,7 +29,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Ostro w lewo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_left_name.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_name.json
@@ -27,7 +27,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Ostro w lewo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_left_name.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_name.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Scharf links abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_right_default.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_default.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من الدوّار",
         "da": "Forlad rundkørslen",
         "de": "Scharf rechts abbiegen",
-        "en": "Exit the traffic circle",
+        "en": "Exit the roundabout",
         "eo": "Eliru trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",

--- a/test/fixtures/v5/exit_rotary/sharp_right_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_destination.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Ostro w prawo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_right_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Scharf rechts abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_right_exit.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_exit.json
@@ -12,7 +12,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Scharf rechts abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_right_exit.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_exit.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Ostro w prawo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Scharf rechts abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_exit_destination.json
@@ -29,7 +29,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Ostro w prawo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_rotary/sharp_right_name.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_name.json
@@ -27,7 +27,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Ostro w prawo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_rotary/sharp_right_name.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_name.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Scharf rechts abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_left_default.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_default.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من الدوّار",
         "da": "Forlad rundkørslen",
         "de": "Leicht links abbiegen",
-        "en": "Exit the traffic circle",
+        "en": "Exit the roundabout",
         "eo": "Eliru trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",

--- a/test/fixtures/v5/exit_rotary/slight_left_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Leicht links abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_left_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_destination.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Łagodnie w lewo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_left_exit.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_exit.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Łagodnie w lewo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_left_exit.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_exit.json
@@ -12,7 +12,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Leicht links abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Leicht links abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_left_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_exit_destination.json
@@ -29,7 +29,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Łagodnie w lewo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_left_name.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_name.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Leicht links abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_left_name.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_name.json
@@ -27,7 +27,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Łagodnie w lewo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_right_default.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_default.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من الدوّار",
         "da": "Forlad rundkørslen",
         "de": "Leicht rechts abbiegen",
-        "en": "Exit the traffic circle",
+        "en": "Exit the roundabout",
         "eo": "Eliru trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",

--- a/test/fixtures/v5/exit_rotary/slight_right_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Leicht rechts abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_right_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_destination.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Łagodnie w prawo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_right_exit.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_exit.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Łagodnie w prawo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_right_exit.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_exit.json
@@ -12,7 +12,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Leicht rechts abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Leicht rechts abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_right_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_exit_destination.json
@@ -29,7 +29,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Łagodnie w prawo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_rotary/slight_right_name.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_name.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Leicht rechts abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_rotary/slight_right_name.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_name.json
@@ -27,7 +27,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Łagodnie w prawo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_rotary/straight_default.json
+++ b/test/fixtures/v5/exit_rotary/straight_default.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من الدوّار",
         "da": "Forlad rundkørslen",
         "de": "Geradeaus weiterfahren",
-        "en": "Exit the traffic circle",
+        "en": "Exit the roundabout",
         "eo": "Eliru trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",

--- a/test/fixtures/v5/exit_rotary/straight_destination.json
+++ b/test/fixtures/v5/exit_rotary/straight_destination.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Jedź prosto w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_rotary/straight_destination.json
+++ b/test/fixtures/v5/exit_rotary/straight_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Geradeaus weiterfahren Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_rotary/straight_exit.json
+++ b/test/fixtures/v5/exit_rotary/straight_exit.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Jedź prosto na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_rotary/straight_exit.json
+++ b/test/fixtures/v5/exit_rotary/straight_exit.json
@@ -12,7 +12,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Geradeaus weiterfahren auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_rotary/straight_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/straight_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Geradeaus weiterfahren Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_rotary/straight_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/straight_exit_destination.json
@@ -29,7 +29,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Jedź prosto w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_rotary/straight_name.json
+++ b/test/fixtures/v5/exit_rotary/straight_name.json
@@ -27,7 +27,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Jedź prosto na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_rotary/straight_name.json
+++ b/test/fixtures/v5/exit_rotary/straight_name.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Geradeaus weiterfahren auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_rotary/uturn_default.json
+++ b/test/fixtures/v5/exit_rotary/uturn_default.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من الدوّار",
         "da": "Forlad rundkørslen",
         "de": "180°-Wendung abbiegen",
-        "en": "Exit the traffic circle",
+        "en": "Exit the roundabout",
         "eo": "Eliru trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",

--- a/test/fixtures/v5/exit_rotary/uturn_destination.json
+++ b/test/fixtures/v5/exit_rotary/uturn_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "180°-Wendung abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_rotary/uturn_destination.json
+++ b/test/fixtures/v5/exit_rotary/uturn_destination.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Zawróć w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_rotary/uturn_exit.json
+++ b/test/fixtures/v5/exit_rotary/uturn_exit.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Zawróć na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_rotary/uturn_exit.json
+++ b/test/fixtures/v5/exit_rotary/uturn_exit.json
@@ -12,7 +12,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "180°-Wendung abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_rotary/uturn_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/uturn_exit_destination.json
@@ -29,7 +29,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Zawróć w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_rotary/uturn_exit_destination.json
+++ b/test/fixtures/v5/exit_rotary/uturn_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "180°-Wendung abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_rotary/uturn_name.json
+++ b/test/fixtures/v5/exit_rotary/uturn_name.json
@@ -27,7 +27,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Zawróć na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_rotary/uturn_name.json
+++ b/test/fixtures/v5/exit_rotary/uturn_name.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "180°-Wendung abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_roundabout/left_default.json
+++ b/test/fixtures/v5/exit_roundabout/left_default.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران",
         "da": "Forlad rundkørslen",
         "de": "Links abbiegen",
-        "en": "Exit the traffic circle",
+        "en": "Exit the roundabout",
         "eo": "Elveturu trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",

--- a/test/fixtures/v5/exit_roundabout/left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/left_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Links abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_roundabout/left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/left_destination.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Skręć w lewo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_roundabout/left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/left_exit.json
@@ -12,7 +12,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Links abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_roundabout/left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/left_exit.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Skręć w lewo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_roundabout/left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/left_exit_destination.json
@@ -29,7 +29,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Skręć w lewo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_roundabout/left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/left_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Links abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_roundabout/left_name.json
+++ b/test/fixtures/v5/exit_roundabout/left_name.json
@@ -27,7 +27,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Skręć w lewo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_roundabout/left_name.json
+++ b/test/fixtures/v5/exit_roundabout/left_name.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Links abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_roundabout/right_default.json
+++ b/test/fixtures/v5/exit_roundabout/right_default.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران",
         "da": "Forlad rundkørslen",
         "de": "Rechts abbiegen",
-        "en": "Exit the traffic circle",
+        "en": "Exit the roundabout",
         "eo": "Elveturu trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",

--- a/test/fixtures/v5/exit_roundabout/right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/right_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Rechts abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_roundabout/right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/right_destination.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Skręć w prawo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_roundabout/right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/right_exit.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Skręć w prawo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_roundabout/right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/right_exit.json
@@ -12,7 +12,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Rechts abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_roundabout/right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/right_exit_destination.json
@@ -29,7 +29,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Skręć w prawo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_roundabout/right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/right_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Rechts abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_roundabout/right_name.json
+++ b/test/fixtures/v5/exit_roundabout/right_name.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Rechts abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_roundabout/right_name.json
+++ b/test/fixtures/v5/exit_roundabout/right_name.json
@@ -27,7 +27,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Skręć w prawo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_default.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_default.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران",
         "da": "Forlad rundkørslen",
         "de": "Scharf links abbiegen",
-        "en": "Exit the traffic circle",
+        "en": "Exit the roundabout",
         "eo": "Elveturu trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_destination.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Ostro w lewo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Scharf links abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_exit.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Ostro w lewo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_exit.json
@@ -12,7 +12,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Scharf links abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Scharf links abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_exit_destination.json
@@ -29,7 +29,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Ostro w lewo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_name.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_name.json
@@ -27,7 +27,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Ostro w lewo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_left_name.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_name.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Scharf links abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_default.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_default.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران",
         "da": "Forlad rundkørslen",
         "de": "Scharf rechts abbiegen",
-        "en": "Exit the traffic circle",
+        "en": "Exit the roundabout",
         "eo": "Elveturu trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_destination.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Ostro w prawo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Scharf rechts abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_exit.json
@@ -12,7 +12,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Scharf rechts abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_exit.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Ostro w prawo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Scharf rechts abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_exit_destination.json
@@ -29,7 +29,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Ostro w prawo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_name.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_name.json
@@ -27,7 +27,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Ostro w prawo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_roundabout/sharp_right_name.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_name.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Scharf rechts abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_left_default.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_default.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران",
         "da": "Forlad rundkørslen",
         "de": "Leicht links abbiegen",
-        "en": "Exit the traffic circle",
+        "en": "Exit the roundabout",
         "eo": "Elveturu trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",

--- a/test/fixtures/v5/exit_roundabout/slight_left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Leicht links abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_left_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_destination.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Łagodnie w lewo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_exit.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Łagodnie w lewo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_left_exit.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_exit.json
@@ -12,7 +12,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Leicht links abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Leicht links abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_left_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_exit_destination.json
@@ -29,7 +29,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Łagodnie w lewo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_left_name.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_name.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Leicht links abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_left_name.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_name.json
@@ -27,7 +27,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Łagodnie w lewo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_right_default.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_default.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران",
         "da": "Forlad rundkørslen",
         "de": "Leicht rechts abbiegen",
-        "en": "Exit the traffic circle",
+        "en": "Exit the roundabout",
         "eo": "Elveturu trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",

--- a/test/fixtures/v5/exit_roundabout/slight_right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Leicht rechts abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_right_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_destination.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Łagodnie w prawo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_exit.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Łagodnie w prawo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_right_exit.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_exit.json
@@ -12,7 +12,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Leicht rechts abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Leicht rechts abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_right_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_exit_destination.json
@@ -29,7 +29,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Łagodnie w prawo w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_roundabout/slight_right_name.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_name.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Leicht rechts abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_roundabout/slight_right_name.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_name.json
@@ -27,7 +27,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Łagodnie w prawo na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_roundabout/straight_default.json
+++ b/test/fixtures/v5/exit_roundabout/straight_default.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران",
         "da": "Forlad rundkørslen",
         "de": "Geradeaus weiterfahren",
-        "en": "Exit the traffic circle",
+        "en": "Exit the roundabout",
         "eo": "Elveturu trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",

--- a/test/fixtures/v5/exit_roundabout/straight_destination.json
+++ b/test/fixtures/v5/exit_roundabout/straight_destination.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Kontynuuj prosto w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_roundabout/straight_destination.json
+++ b/test/fixtures/v5/exit_roundabout/straight_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Geradeaus weiterfahren Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_roundabout/straight_exit.json
+++ b/test/fixtures/v5/exit_roundabout/straight_exit.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Kontynuuj prosto na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_roundabout/straight_exit.json
+++ b/test/fixtures/v5/exit_roundabout/straight_exit.json
@@ -12,7 +12,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Geradeaus weiterfahren auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_roundabout/straight_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/straight_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "Geradeaus weiterfahren Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_roundabout/straight_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/straight_exit_destination.json
@@ -29,7 +29,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Kontynuuj prosto w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_roundabout/straight_name.json
+++ b/test/fixtures/v5/exit_roundabout/straight_name.json
@@ -27,7 +27,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Kontynuuj prosto na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_roundabout/straight_name.json
+++ b/test/fixtures/v5/exit_roundabout/straight_name.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "Geradeaus weiterfahren auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_roundabout/uturn_default.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_default.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران",
         "da": "Forlad rundkørslen",
         "de": "180°-Wendung abbiegen",
-        "en": "Exit the traffic circle",
+        "en": "Exit the roundabout",
         "eo": "Elveturu trafikcirklegon",
         "es": "Sal la rotonda",
         "es-ES": "Sal la rotonda",

--- a/test/fixtures/v5/exit_roundabout/uturn_destination.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "180°-Wendung abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_roundabout/uturn_destination.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_destination.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Zawróć w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_roundabout/uturn_exit.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_exit.json
@@ -28,7 +28,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Zawróć na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_roundabout/uturn_exit.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_exit.json
@@ -12,7 +12,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "180°-Wendung abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/exit_roundabout/uturn_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_exit_destination.json
@@ -29,7 +29,7 @@
         "nl": "Verlaat de rotonde richting Destination 1",
         "no": "Kjør ut av rundkjøringen mot Destination 1",
         "pl": "Zawróć w kierunku Destination 1",
-        "pt-BR": "Exit the traffic circle towards Destination 1",
+        "pt-BR": "Exit the roundabout towards Destination 1",
         "pt-PT": "Saia da rotunda em direção a Destination 1",
         "ro": "Ieșiți din sensul giratoriu spre Destination 1",
         "ru": "Сверните с круговой развязки в направлении Destination 1",

--- a/test/fixtures/v5/exit_roundabout/uturn_exit_destination.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "اسلك مسار الخروج Destination 1",
         "da": "Forlad rundkørslen mod Destination 1",
         "de": "180°-Wendung abbiegen Richtung Destination 1",
-        "en": "Exit the traffic circle towards Destination 1",
+        "en": "Exit the roundabout towards Destination 1",
         "eo": "Elveturu trafikcirklegon direkte al Destination 1",
         "es": "Sal la rotonda hacia Destination 1",
         "es-ES": "Toma la salida hacia Destination 1",

--- a/test/fixtures/v5/exit_roundabout/uturn_name.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_name.json
@@ -27,7 +27,7 @@
         "nl": "Verlaat de rotonde en ga verder op Way Name",
         "no": "Kjør ut av rundkjøringen og inn på Way Name",
         "pl": "Zawróć na Way Name",
-        "pt-BR": "Exit the traffic circle onto Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
         "pt-PT": "Saia da rotunda para Way Name",
         "ro": "Ieșiți din sensul giratoriu pe Way Name",
         "ru": "Сверните с круговой развязки на Way Name",

--- a/test/fixtures/v5/exit_roundabout/uturn_name.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_name.json
@@ -11,7 +11,7 @@
         "ar": "اخرج من مسار الدوران على Way Name",
         "da": "Forlad rundkørslen ad Way Name",
         "de": "180°-Wendung abbiegen auf Way Name",
-        "en": "Exit the traffic circle onto Way Name",
+        "en": "Exit the roundabout onto Way Name",
         "eo": "Elveturu trafikcirklegon al Way Name",
         "es": "Sal la rotonda en Way Name",
         "es-ES": "Toma la salida por Way Name",

--- a/test/fixtures/v5/rotary/default_default.json
+++ b/test/fixtures/v5/rotary/default_default.json
@@ -10,7 +10,7 @@
         "ar": "اسلك مسار الدوران",
         "da": "Kør ind i rundkørslen",
         "de": "In den Kreisverkehr fahren",
-        "en": "Enter the traffic circle",
+        "en": "Enter the roundabout",
         "eo": "Enveturu trafikcirklegon",
         "es": "Entra en la rotonda",
         "es-ES": "Incorpórate en la rotonda",

--- a/test/fixtures/v5/rotary/default_destination.json
+++ b/test/fixtures/v5/rotary/default_destination.json
@@ -11,7 +11,7 @@
         "ar": "اسلك مسار الدوران واخرج باتجاه Destination 1",
         "da": "Tag rundkørslen og kør mod Destination 1",
         "de": "Im Kreisverkehr die Ausfahrt Richtung Destination 1 nehmen",
-        "en": "Enter the traffic circle and exit towards Destination 1",
+        "en": "Enter the roundabout and exit towards Destination 1",
         "eo": "Enveturu trafikcirklegon kaj elveturu direkte al Destination 1",
         "es": "Entra en la rotonda y sal hacia Destination 1",
         "es-ES": "En la rotonda sal hacia Destination 1",

--- a/test/fixtures/v5/rotary/default_exit.json
+++ b/test/fixtures/v5/rotary/default_exit.json
@@ -11,7 +11,7 @@
         "ar": "اسلك مسار الدوران واخرج على Way Name",
         "da": "Tag rundkørslen og kør fra ad Way Name",
         "de": "Im Kreisverkehr die Ausfahrt auf Way Name nehmen",
-        "en": "Enter the traffic circle and exit onto Way Name",
+        "en": "Enter the roundabout and exit onto Way Name",
         "eo": "Enveturu trafikcirklegon kaj elveturu al Way Name",
         "es": "Entra en la rotonda y sal en Way Name",
         "es-ES": "En la rotonda sal por Way Name",

--- a/test/fixtures/v5/rotary/default_exit_destination.json
+++ b/test/fixtures/v5/rotary/default_exit_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الدوران واخرج باتجاه Destination 1",
         "da": "Tag rundkørslen og kør mod Destination 1",
         "de": "Im Kreisverkehr die Ausfahrt Richtung Destination 1 nehmen",
-        "en": "Enter the traffic circle and exit towards Destination 1",
+        "en": "Enter the roundabout and exit towards Destination 1",
         "eo": "Enveturu trafikcirklegon kaj elveturu direkte al Destination 1",
         "es": "Entra en la rotonda y sal hacia Destination 1",
         "es-ES": "En la rotonda sal hacia Destination 1",

--- a/test/fixtures/v5/rotary/default_name.json
+++ b/test/fixtures/v5/rotary/default_name.json
@@ -10,7 +10,7 @@
         "ar": "اسلك مسار الدوران واخرج على Way Name",
         "da": "Tag rundkørslen og kør fra ad Way Name",
         "de": "Im Kreisverkehr die Ausfahrt auf Way Name nehmen",
-        "en": "Enter the traffic circle and exit onto Way Name",
+        "en": "Enter the roundabout and exit onto Way Name",
         "eo": "Enveturu trafikcirklegon kaj elveturu al Way Name",
         "es": "Entra en la rotonda y sal en Way Name",
         "es-ES": "En la rotonda sal por Way Name",

--- a/test/fixtures/v5/rotary/exit_10.json
+++ b/test/fixtures/v5/rotary/exit_10.json
@@ -11,7 +11,7 @@
         "ar": "اسلك مسار الدوران واتّبع المخرج العاشرة",
         "da": "Tag rundkørslen og forlad ved tiende afkørsel",
         "de": "Im Kreisverkehr die zehnte Ausfahrt nehmen",
-        "en": "Enter the traffic circle and take the 10th exit",
+        "en": "Enter the roundabout and take the 10th exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 10. elveturejo",
         "es": "Entra en la rotonda y toma la 10ª salida",
         "es-ES": "En la rotonda toma la 10ª salida",

--- a/test/fixtures/v5/rotary/exit_11.json
+++ b/test/fixtures/v5/rotary/exit_11.json
@@ -11,7 +11,7 @@
         "ar": "اسلك مسار الدوران واتّبع المخرج ",
         "da": "Tag rundkørslen og forlad ved afkørsel",
         "de": "Im Kreisverkehr die Ausfahrt nehmen",
-        "en": "Enter the traffic circle and take the exit",
+        "en": "Enter the roundabout and take the exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al elveturejo",
         "es": "Entra en la rotonda y toma la salida",
         "es-ES": "En la rotonda toma la salida",

--- a/test/fixtures/v5/rotary/exit_1_default.json
+++ b/test/fixtures/v5/rotary/exit_1_default.json
@@ -11,7 +11,7 @@
         "ar": "اسلك مسار الدوران واتّبع المخرج الأولى",
         "da": "Tag rundkørslen og forlad ved første afkørsel",
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen",
-        "en": "Enter the traffic circle and take the 1st exit",
+        "en": "Enter the roundabout and take the 1st exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo",
         "es": "Entra en la rotonda y toma la 1ª salida",
         "es-ES": "En la rotonda toma la 1ª salida",

--- a/test/fixtures/v5/rotary/exit_1_destination.json
+++ b/test/fixtures/v5/rotary/exit_1_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الدوران واتبع المخرج الأولى باتجاه Destination 1",
         "da": "Tag rundkørslen og forlad ved første afkørsel mod Destination 1",
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen Richtung Destination 1",
-        "en": "Enter the traffic circle and take the 1st exit towards Destination 1",
+        "en": "Enter the roundabout and take the 1st exit towards Destination 1",
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo direkte al Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "es-ES": "En la rotonda toma la 1ª salida hacia Destination 1",

--- a/test/fixtures/v5/rotary/exit_1_exit.json
+++ b/test/fixtures/v5/rotary/exit_1_exit.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الدوران واتبع المخرج الأولى على Way Name",
         "da": "Tag rundkørslen og forlad ved første afkørsel ad Way Name",
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen auf Way Name",
-        "en": "Enter the traffic circle and take the 1st exit onto Way Name",
+        "en": "Enter the roundabout and take the 1st exit onto Way Name",
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo al Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
         "es-ES": "En la rotonda toma la 1ª salida por Way Name",

--- a/test/fixtures/v5/rotary/exit_1_exit_destination.json
+++ b/test/fixtures/v5/rotary/exit_1_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "اسلك مسار الدوران واتبع المخرج الأولى باتجاه Destination 1",
         "da": "Tag rundkørslen og forlad ved første afkørsel mod Destination 1",
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen Richtung Destination 1",
-        "en": "Enter the traffic circle and take the 1st exit towards Destination 1",
+        "en": "Enter the roundabout and take the 1st exit towards Destination 1",
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo direkte al Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "es-ES": "En la rotonda toma la 1ª salida hacia Destination 1",

--- a/test/fixtures/v5/rotary/exit_1_name.json
+++ b/test/fixtures/v5/rotary/exit_1_name.json
@@ -11,7 +11,7 @@
         "ar": "اسلك مسار الدوران واتبع المخرج الأولى على Way Name",
         "da": "Tag rundkørslen og forlad ved første afkørsel ad Way Name",
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen auf Way Name",
-        "en": "Enter the traffic circle and take the 1st exit onto Way Name",
+        "en": "Enter the roundabout and take the 1st exit onto Way Name",
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo al Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
         "es-ES": "En la rotonda toma la 1ª salida por Way Name",

--- a/test/fixtures/v5/rotary/exit_2.json
+++ b/test/fixtures/v5/rotary/exit_2.json
@@ -11,7 +11,7 @@
         "ar": "اسلك مسار الدوران واتّبع المخرج الثانية",
         "da": "Tag rundkørslen og forlad ved anden afkørsel",
         "de": "Im Kreisverkehr die zweite Ausfahrt nehmen",
-        "en": "Enter the traffic circle and take the 2nd exit",
+        "en": "Enter the roundabout and take the 2nd exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 2. elveturejo",
         "es": "Entra en la rotonda y toma la 2ª salida",
         "es-ES": "En la rotonda toma la 2ª salida",

--- a/test/fixtures/v5/rotary/exit_3.json
+++ b/test/fixtures/v5/rotary/exit_3.json
@@ -11,7 +11,7 @@
         "ar": "اسلك مسار الدوران واتّبع المخرج الثالثة",
         "da": "Tag rundkørslen og forlad ved tredje afkørsel",
         "de": "Im Kreisverkehr die dritte Ausfahrt nehmen",
-        "en": "Enter the traffic circle and take the 3rd exit",
+        "en": "Enter the roundabout and take the 3rd exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 3. elveturejo",
         "es": "Entra en la rotonda y toma la 3ª salida",
         "es-ES": "En la rotonda toma la 3ª salida",

--- a/test/fixtures/v5/rotary/exit_4.json
+++ b/test/fixtures/v5/rotary/exit_4.json
@@ -11,7 +11,7 @@
         "ar": "اسلك مسار الدوران واتّبع المخرج الرابعة",
         "da": "Tag rundkørslen og forlad ved fjerde afkørsel",
         "de": "Im Kreisverkehr die vierte Ausfahrt nehmen",
-        "en": "Enter the traffic circle and take the 4th exit",
+        "en": "Enter the roundabout and take the 4th exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 4. elveturejo",
         "es": "Entra en la rotonda y toma la 4ª salida",
         "es-ES": "En la rotonda toma la 4ª salida",

--- a/test/fixtures/v5/rotary/exit_5.json
+++ b/test/fixtures/v5/rotary/exit_5.json
@@ -11,7 +11,7 @@
         "ar": "اسلك مسار الدوران واتّبع المخرج الخامسة",
         "da": "Tag rundkørslen og forlad ved femte afkørsel",
         "de": "Im Kreisverkehr die fünfte Ausfahrt nehmen",
-        "en": "Enter the traffic circle and take the 5th exit",
+        "en": "Enter the roundabout and take the 5th exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 5. elveturejo",
         "es": "Entra en la rotonda y toma la 5ª salida",
         "es-ES": "En la rotonda toma la 5ª salida",

--- a/test/fixtures/v5/rotary/exit_6.json
+++ b/test/fixtures/v5/rotary/exit_6.json
@@ -11,7 +11,7 @@
         "ar": "اسلك مسار الدوران واتّبع المخرج السادسة",
         "da": "Tag rundkørslen og forlad ved sjette afkørsel",
         "de": "Im Kreisverkehr die sechste Ausfahrt nehmen",
-        "en": "Enter the traffic circle and take the 6th exit",
+        "en": "Enter the roundabout and take the 6th exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 6. elveturejo",
         "es": "Entra en la rotonda y toma la 6ª salida",
         "es-ES": "En la rotonda toma la 6ª salida",

--- a/test/fixtures/v5/rotary/exit_7.json
+++ b/test/fixtures/v5/rotary/exit_7.json
@@ -11,7 +11,7 @@
         "ar": "اسلك مسار الدوران واتّبع المخرج السابعة",
         "da": "Tag rundkørslen og forlad ved syvende afkørsel",
         "de": "Im Kreisverkehr die siebente Ausfahrt nehmen",
-        "en": "Enter the traffic circle and take the 7th exit",
+        "en": "Enter the roundabout and take the 7th exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 7. elveturejo",
         "es": "Entra en la rotonda y toma la 7ª salida",
         "es-ES": "En la rotonda toma la 7ª salida",

--- a/test/fixtures/v5/rotary/exit_8.json
+++ b/test/fixtures/v5/rotary/exit_8.json
@@ -11,7 +11,7 @@
         "ar": "اسلك مسار الدوران واتّبع المخرج الثامنة",
         "da": "Tag rundkørslen og forlad ved ottende afkørsel",
         "de": "Im Kreisverkehr die achte Ausfahrt nehmen",
-        "en": "Enter the traffic circle and take the 8th exit",
+        "en": "Enter the roundabout and take the 8th exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 8. elveturejo",
         "es": "Entra en la rotonda y toma la 8ª salida",
         "es-ES": "En la rotonda toma la 8ª salida",

--- a/test/fixtures/v5/rotary/exit_9.json
+++ b/test/fixtures/v5/rotary/exit_9.json
@@ -11,7 +11,7 @@
         "ar": "اسلك مسار الدوران واتّبع المخرج التاسعة",
         "da": "Tag rundkørslen og forlad ved niende afkørsel",
         "de": "Im Kreisverkehr die neunte Ausfahrt nehmen",
-        "en": "Enter the traffic circle and take the 9th exit",
+        "en": "Enter the roundabout and take the 9th exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 9. elveturejo",
         "es": "Entra en la rotonda y toma la 9ª salida",
         "es-ES": "En la rotonda toma la 9ª salida",

--- a/test/fixtures/v5/roundabout/default_default.json
+++ b/test/fixtures/v5/roundabout/default_default.json
@@ -10,7 +10,7 @@
         "ar": "اسلك مسار الدوران",
         "da": "Kør ind i rundkørslen",
         "de": "In den Kreisverkehr fahren",
-        "en": "Enter the traffic circle",
+        "en": "Enter the roundabout",
         "eo": "Enveturu trafikcirklegon",
         "es": "Entra en la rotonda",
         "es-ES": "Incorpórate en la rotonda",

--- a/test/fixtures/v5/roundabout/default_destination.json
+++ b/test/fixtures/v5/roundabout/default_destination.json
@@ -11,7 +11,7 @@
         "ar": "اسلك مسار الدوران واخرج باتجاه Destination 1",
         "da": "Tag rundkørslen og kør mod Destination 1",
         "de": "Im Kreisverkehr die Ausfahrt Richtung Destination 1 nehmen",
-        "en": "Enter the traffic circle and exit towards Destination 1",
+        "en": "Enter the roundabout and exit towards Destination 1",
         "eo": "Enveturu trafikcirklegon kaj elveturu direkte al Destination 1",
         "es": "Entra en la rotonda y sal hacia Destination 1",
         "es-ES": "Incorpórate en la rotonda y sal hacia Destination 1",

--- a/test/fixtures/v5/roundabout/default_exit.json
+++ b/test/fixtures/v5/roundabout/default_exit.json
@@ -11,7 +11,7 @@
         "ar": "اسلك مسار الدوران واخرج على Way Name",
         "da": "Tag rundkørslen og kør fra ad Way Name",
         "de": "Im Kreisverkehr die Ausfahrt auf Way Name nehmen",
-        "en": "Enter the traffic circle and exit onto Way Name",
+        "en": "Enter the roundabout and exit onto Way Name",
         "eo": "Enveturu trafikcirklegon kaj elveturu al Way Name",
         "es": "Entra en la rotonda y sal en Way Name",
         "es-ES": "Incorpórate en la rotonda y sal en Way Name",

--- a/test/fixtures/v5/roundabout/default_exit_destination.json
+++ b/test/fixtures/v5/roundabout/default_exit_destination.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الدوران واخرج باتجاه Destination 1",
         "da": "Tag rundkørslen og kør mod Destination 1",
         "de": "Im Kreisverkehr die Ausfahrt Richtung Destination 1 nehmen",
-        "en": "Enter the traffic circle and exit towards Destination 1",
+        "en": "Enter the roundabout and exit towards Destination 1",
         "eo": "Enveturu trafikcirklegon kaj elveturu direkte al Destination 1",
         "es": "Entra en la rotonda y sal hacia Destination 1",
         "es-ES": "Incorpórate en la rotonda y sal hacia Destination 1",

--- a/test/fixtures/v5/roundabout/default_name.json
+++ b/test/fixtures/v5/roundabout/default_name.json
@@ -10,7 +10,7 @@
         "ar": "اسلك مسار الدوران واخرج على Way Name",
         "da": "Tag rundkørslen og kør fra ad Way Name",
         "de": "Im Kreisverkehr die Ausfahrt auf Way Name nehmen",
-        "en": "Enter the traffic circle and exit onto Way Name",
+        "en": "Enter the roundabout and exit onto Way Name",
         "eo": "Enveturu trafikcirklegon kaj elveturu al Way Name",
         "es": "Entra en la rotonda y sal en Way Name",
         "es-ES": "Incorpórate en la rotonda y sal en Way Name",

--- a/test/fixtures/v5/roundabout/exit_default.json
+++ b/test/fixtures/v5/roundabout/exit_default.json
@@ -11,7 +11,7 @@
         "ar": "ادخل مسار الدوران واسلك المخرج الأولى",
         "da": "Tag rundkørslen og forlad ved første afkørsel",
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen",
-        "en": "Enter the traffic circle and take the 1st exit",
+        "en": "Enter the roundabout and take the 1st exit",
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo",
         "es": "Entra en la rotonda y toma la 1ª salida",
         "es-ES": "En la rotonda toma la 1ª salida",

--- a/test/fixtures/v5/roundabout/exit_destination.json
+++ b/test/fixtures/v5/roundabout/exit_destination.json
@@ -12,7 +12,7 @@
         "ar": "ادخل مسار الدوران واسلك المخرج الأولى باتجاه Destination 1",
         "da": "Tag rundkørslen og forlad ved første afkørsel mod Destination 1",
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen Richtung Destination 1",
-        "en": "Enter the traffic circle and take the 1st exit towards Destination 1",
+        "en": "Enter the roundabout and take the 1st exit towards Destination 1",
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo direkte al Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "es-ES": "En la rotonda toma la 1ª salida hacia Destination 1",

--- a/test/fixtures/v5/roundabout/exit_exit.json
+++ b/test/fixtures/v5/roundabout/exit_exit.json
@@ -12,7 +12,7 @@
         "ar": "اسلك مسار الدوران واتبع المخرج الأولى على Way Name",
         "da": "Tag rundkørslen og forlad ved første afkørsel ad Way Name",
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen auf Way Name",
-        "en": "Enter the traffic circle and take the 1st exit onto Way Name",
+        "en": "Enter the roundabout and take the 1st exit onto Way Name",
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo al Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
         "es-ES": "En la rotonda toma la 1ª salida por Way Name",

--- a/test/fixtures/v5/roundabout/exit_exit_destination.json
+++ b/test/fixtures/v5/roundabout/exit_exit_destination.json
@@ -13,7 +13,7 @@
         "ar": "ادخل مسار الدوران واسلك المخرج الأولى باتجاه Destination 1",
         "da": "Tag rundkørslen og forlad ved første afkørsel mod Destination 1",
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen Richtung Destination 1",
-        "en": "Enter the traffic circle and take the 1st exit towards Destination 1",
+        "en": "Enter the roundabout and take the 1st exit towards Destination 1",
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo direkte al Destination 1",
         "es": "Entra en la rotonda y toma la 1ª salida hacia Destination 1",
         "es-ES": "En la rotonda toma la 1ª salida hacia Destination 1",

--- a/test/fixtures/v5/roundabout/exit_name.json
+++ b/test/fixtures/v5/roundabout/exit_name.json
@@ -11,7 +11,7 @@
         "ar": "اسلك مسار الدوران واتبع المخرج الأولى على Way Name",
         "da": "Tag rundkørslen og forlad ved første afkørsel ad Way Name",
         "de": "Im Kreisverkehr die erste Ausfahrt nehmen auf Way Name",
-        "en": "Enter the traffic circle and take the 1st exit onto Way Name",
+        "en": "Enter the roundabout and take the 1st exit onto Way Name",
         "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo al Way Name",
         "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
         "es-ES": "En la rotonda toma la 1ª salida por Way Name",


### PR DESCRIPTION
# Issue

The English localization now calls all circular junctions “roundabouts”. There is no longer a quaint [BosWash](https://github.com/Project-OSRM/osrm-text-instructions/issues/188#issuecomment-406827751) distinction between classical roundabouts as “traffic circles” and modern roundabouts as “roundabouts” (which in practice meant roundabouts were always called “traffic circles”).

Fixes #188 and reverts #179.

## Tasklist

 - [x] Modernize English vocabulary
 - [x] Add changelog entry
 - [ ] Test with osrm-frontend (?)
 - [ ] Review
 - [ ] Test drive around and around

## Requirements / Relations

Same as #256, plus one year and minus the American English overrides. If an American English localization mechanism is needed in the future, we can resurrect that part of #256.

/cc @danpaz @dgearhart