### PR TITLE
Release v0.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. For change 
 
 ## master
 
+
+## 0.13.4 2019-09-16
+
 - Added a Yoruba localization. [#284](https://github.com/Project-OSRM/osrm-text-instructions/pull/284)
 - Renamed “traffic circle” to “roundabout” in the English localization. [#285](https://github.com/Project-OSRM/osrm-text-instructions/pull/285)
 - Rewrote the Burmese localization. [#282](https://github.com/Project-OSRM/osrm-text-instructions/pull/282)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "OSRM Text Instructions",
   "url": "https://github.com/Project-OSRM/osrm-text-instructions.js",
   "homepage": "http://project-osrm.org",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "main": "./index.js",
   "license": "BSD-2-Clause",
   "bugs": {


### PR DESCRIPTION
## 0.13.4 2019-09-16

- Added a Yoruba localization. [#284](https://github.com/Project-OSRM/osrm-text-instructions/pull/284)
- Renamed “traffic circle” to “roundabout” in the English localization. [#285](https://github.com/Project-OSRM/osrm-text-instructions/pull/285)
- Rewrote the Burmese localization. [#282](https://github.com/Project-OSRM/osrm-text-instructions/pull/282)
- Fixed typographical errors in Italian. [#281](https://github.com/Project-OSRM/osrm-text-instructions/pull/281)
- Fixed grammatical errors in Danish. [#286](https://github.com/Project-OSRM/osrm-text-instructions/pull/286)