### PR TITLE
Update Japanese translations and add named intersections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file. For change 
 
 ## master
 
-- Update Japanese localization. [#290](https://github.com/Project-OSRM/osrm-text-instructions/pull/290)
+- Update Japanese localization, add named intersections. [#290](https://github.com/Project-OSRM/osrm-text-instructions/pull/290)
 
 ## 0.13.4 2019-09-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file. For change 
 
 ## master
 
+- Update Japanese localization. [#290](https://github.com/Project-OSRM/osrm-text-instructions/pull/290)
 
 ## 0.13.4 2019-09-16
 

--- a/index.js
+++ b/index.js
@@ -190,7 +190,14 @@ module.exports = function(version) {
             var wayName = this.getWayName(language, step, options);
 
             // Decide which instruction string to use
-            // Destination takes precedence over name
+            // In order of precedence:
+            //   - exit + destination signage
+            //   - destination signage
+            //   - exit signage
+            //   - junction name
+            //   - road name
+            //   - waypoint name (for arrive maneuver)
+            //   - default
             var instruction;
             if (step.destinations && step.exits && instructionObject.exit_destination) {
                 instruction = instructionObject.exit_destination;
@@ -198,6 +205,8 @@ module.exports = function(version) {
                 instruction = instructionObject.destination;
             } else if (step.exits && instructionObject.exit) {
                 instruction = instructionObject.exit;
+            } else if (step.junction_name && instructionObject.junction_name) {
+                instruction = instructionObject.junction_name;
             } else if (wayName && instructionObject.name) {
                 instruction = instructionObject.name;
             } else if (options.waypointName && instructionObject.named) {
@@ -230,7 +239,8 @@ module.exports = function(version) {
                 'modifier': instructions[language][version].constants.modifier[modifier],
                 'direction': this.directionFromDegree(language, step.maneuver.bearing_after),
                 'nth': nthWaypoint,
-                'waypoint_name': options.waypointName
+                'waypoint_name': options.waypointName,
+                'junction_name': (step.junction_name || '').split(';')[0]
             };
 
             return this.tokenize(language, instruction, replaceTokens, options);

--- a/languages/translations/ar.json
+++ b/languages/translations/ar.json
@@ -131,28 +131,33 @@
             },
             "sharp left": {
                 "default": "انعطف يساراً حاداً",
-                "name": "انعطف يساراً حاداً لتبقى على  {way_name}",
-                "destination": "انعطف يساراً حاداً نحو {destination}"
+                "name": "انعطف يساراً حاداً لتبقى على {way_name}",
+                "destination": "انعطف يساراً حاداً نحو {destination}",
+                "junction_name": "انعطف يساراً حاداً لتبقى على {junction_name}"
             },
             "sharp right": {
                 "default": "انعطف يمينا حاداً ",
                 "name": "انعطف يميناً حاداً لتبقى على {way_name}",
-                "destination": "انعطف يميناً حاداً نحو {destination}"
+                "destination": "انعطف يميناً حاداً نحو {destination}",
+                "junction_name": "انعطف يميناً حاداً لتبقى على {junction_name}"
             },
             "slight left": {
                 "default": "انعطف يساراً قليلاً",
-                "name": " انعطف يساراً قليلاً لتبقى على  {way_name} ",
-                "destination": "انعطف يساراً قليلاً نحو {destination}"
+                "name": "انعطف يساراً قليلاً لتبقى على {way_name}",
+                "destination": "انعطف يساراً قليلاً نحو {destination}",
+                "junction_name": "انعطف يساراً قليلاً لتبقى على {junction_name}"
             },
             "slight right": {
                 "default": "انعطف يميناً قليلاً",
                 "name": "انعطف يميناً قليلاً لتبقى على {way_name}",
-                "destination": "انعطف يميناً قليلاً نحو {destination} "
+                "destination": "انعطف يميناً قليلاً نحو {destination}",
+                "junction_name": "انعطف يميناً قليلاً نحو {junction_name}"
             },
             "uturn": {
                 "default": "انعطف دوراناً عكسياً",
                 "name": "انعطف دوراناً عكسياً  وتابع نحو {way_name}",
-                "destination": "انعطف دوراناً عكسياً نحو {destination}"
+                "destination": "انعطف دوراناً عكسياً نحو {destination}",
+                "junction_name": "انعطف دوراناً عكسياً  وتابع نحو {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "انعطف {modifier}ا",
                 "name": "انعطف {modifier}ا على {way_name}",
-                "destination": "انعطف {modifier}ا نحو {destination}"
+                "destination": "انعطف {modifier}ا نحو {destination}",
+                "junction_name": "انعطف {modifier}ا على {junction_name}"
             },
             "straight": {
                 "default": "تابع قدماً",
                 "name": "تابع إلى الأمام على {way_name}",
-                "destination": "تابع قدماً نحو {destination}"
+                "destination": "تابع قدماً نحو {destination}",
+                "junction_name": "تابع إلى الأمام على {junction_name}"
             },
             "uturn": {
                 "default": "انعطف دوراناً عكسياً عند نهاية الطريق",
                 "name": "انعطف دوراناً عكسياً على {way_name} عند نهاية الطريق",
-                "destination": "انعطف دوراناً عكسياً نحو {destination} عند نهاية الطريق"
+                "destination": "انعطف دوراناً عكسياً نحو {destination} عند نهاية الطريق",
+                "junction_name": "انعطف دوراناً عكسياً نحو {junction_name}"
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "انعطف نحو {modifier}",
                 "name": "انعطف {modifier} على {way_name}",
-                "destination": "انعطف {modifier} نحو {destination}"
+                "destination": "انعطف {modifier} نحو {destination}",
+                "junction_name": "انعطف {modifier} على {junction_name}"
             },
             "left": {
                 "default": "انعطف يسارا",
                 "name": "اسلك مسار الدوران يسارا على {way_name}",
-                "destination": "انعطف يسارا نحو {destination}"
+                "destination": "انعطف يسارا نحو {destination}",
+                "junction_name": "اسلك مسار الدوران يسارا على {junction_name}"
             },
             "right": {
                 "default": "انعطف يمينا",
                 "name": "اسلك مسار الدوران يمينا على {way_name}",
-                "destination": "انعطف يمينا نحو {destination}"
+                "destination": "انعطف يمينا نحو {destination}",
+                "junction_name": "اسلك مسار الدوران يمينا على {junction_name}"
             },
             "straight": {
                 "default": "انطلق قدما",
                 "name": "انطلق قدما على {way_name}",
-                "destination": "انطلق قدما نحو {destination}"
+                "destination": "انطلق قدما نحو {destination}",
+                "junction_name": "انطلق قدما على {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/da.json
+++ b/languages/translations/da.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Drej skarpt til venstre",
                 "name": "Drej skarpt til venstre videre ad {way_name}",
-                "destination": "Drej skarpt til venstre mod {destination}"
+                "destination": "Drej skarpt til venstre mod {destination}",
+                "junction_name": "Drej skarpt til venstre videre ved {junction_name}"
             },
             "sharp right": {
                 "default": "Drej skarpt til højre",
                 "name": "Drej skarpt til højre videre ad {way_name}",
-                "destination": "Drej skarpt til højre mod {destination}"
+                "destination": "Drej skarpt til højre mod {destination}",
+                "junction_name": "Drej skarpt til højre videre ved {junction_name}"
             },
             "slight left": {
                 "default": "Drej let til venstre",
                 "name": "Drej let til venstre videre ad {way_name}",
-                "destination": "Drej let til venstre mod {destination}"
+                "destination": "Drej let til venstre mod {destination}",
+                "junction_name": "Drej let til venstre videre ved {junction_name}"
             },
             "slight right": {
                 "default": "Drej let til højre",
                 "name": "Drej let til højre videre ad {way_name}",
-                "destination": "Drej let til højre mod {destination}"
+                "destination": "Drej let til højre mod {destination}",
+                "junction_name": "Drej let til højre videre ved {junction_name}"
             },
             "uturn": {
                 "default": "Foretag en U-vending",
                 "name": "Foretag en U-vending tilbage ad {way_name}",
-                "destination": "Foretag en U-vending mod {destination}"
+                "destination": "Foretag en U-vending mod {destination}",
+                "junction_name": "Foretag en U-vending tilbage ved {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "{modifier:turn}",
                 "name": "{modifier:turn} ad {way_name}",
-                "destination": "{modifier:turn} mod {destination}"
+                "destination": "{modifier:turn} mod {destination}",
+                "junction_name": "{modifier:turn} ved {junction_name}"
             },
             "straight": {
                 "default": "Fortsæt ligeud",
                 "name": "Fortsæt ligeud ad {way_name}",
-                "destination": "Fortsæt ligeud mod {destination}"
+                "destination": "Fortsæt ligeud mod {destination}",
+                "junction_name": "Fortsæt ligeud ved {junction_name}"
             },
             "uturn": {
                 "default": "Foretag en U-vending for enden af vejen",
                 "name": "Foretag en U-vending ad {way_name} for enden af vejen",
-                "destination": "Foretag en U-vending mod {destination} for enden af vejen"
+                "destination": "Foretag en U-vending mod {destination} for enden af vejen",
+                "junction_name": "Foretag en U-vending ved {junction_name}"
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "{modifier:turn}",
                 "name": "{modifier:turn} ad {way_name}",
-                "destination": "{modifier:turn} mod {destination}"
+                "destination": "{modifier:turn} mod {destination}",
+                "junction_name": "{modifier:turn} ved {junction_name}"
             },
             "left": {
                 "default": "Drej til venstre",
                 "name": "Drej til venstre ad {way_name}",
-                "destination": "Drej til venstre mod {destination}"
+                "destination": "Drej til venstre mod {destination}",
+                "junction_name": "Drej til venstre ved {junction_name}"
             },
             "right": {
                 "default": "Drej til højre",
                 "name": "Drej til højre ad {way_name}",
-                "destination": "Drej til højre mod {destination}"
+                "destination": "Drej til højre mod {destination}",
+                "junction_name": "Drej til højre ved {junction_name}"
             },
             "straight": {
                 "default": "Kør ligeud",
                 "name": "Kør ligeud ad {way_name}",
-                "destination": "Kør ligeud mod {destination}"
+                "destination": "Kør ligeud mod {destination}",
+                "junction_name": "Kør ligeud ved {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/de.json
+++ b/languages/translations/de.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Scharf links",
                 "name": "Scharf links weiterfahren auf {way_name}",
-                "destination": "Scharf links Richtung {destination}"
+                "destination": "Scharf links Richtung {destination}",
+                "junction_name": "Scharf links weiterfahren an {junction_name}"
             },
             "sharp right": {
                 "default": "Scharf rechts",
                 "name": "Scharf rechts weiterfahren auf {way_name}",
-                "destination": "Scharf rechts Richtung {destination}"
+                "destination": "Scharf rechts Richtung {destination}",
+                "junction_name": "Scharf rechts weiterfahren an {junction_name}"
             },
             "slight left": {
                 "default": "Leicht links",
                 "name": "Leicht links weiter auf {way_name}",
-                "destination": "Leicht links weiter Richtung {destination}"
+                "destination": "Leicht links weiter Richtung {destination}",
+                "junction_name": "Leicht links weiter an {junction_name}"
             },
             "slight right": {
                 "default": "Leicht rechts weiter",
                 "name": "Leicht rechts weiter auf {way_name}",
-                "destination": "Leicht rechts weiter Richtung {destination}"
+                "destination": "Leicht rechts weiter Richtung {destination}",
+                "junction_name": "Leicht rechts weiter an {junction_name}"
             },
             "uturn": {
                 "default": "180°-Wendung",
                 "name": "180°-Wendung auf {way_name}",
-                "destination": "180°-Wendung Richtung {destination}"
+                "destination": "180°-Wendung Richtung {destination}",
+                "junction_name": "180°-Wendung an {junction_name}"
             }
         },
         "depart": {
@@ -166,24 +171,27 @@
             "default": {
                 "default": "{modifier} abbiegen",
                 "name": "{modifier} abbiegen auf {way_name}",
-                "destination": "{modifier} abbiegen Richtung {destination}"
+                "destination": "{modifier} abbiegen Richtung {destination}",
+                "junction_name": "{modifier} abbiegen an {junction_name}"
             },
             "straight": {
                 "default": "Geradeaus weiterfahren",
                 "name": "Geradeaus weiterfahren auf {way_name}",
-                "destination": "Geradeaus weiterfahren Richtung {destination}"
+                "destination": "Geradeaus weiterfahren Richtung {destination}",
+                "junction_name": "Geradeaus weiterfahren an {junction_name}"
             },
             "uturn": {
                 "default": "180°-Wendung am Ende der Straße",
                 "name": "180°-Wendung auf {way_name} am Ende der Straße",
-                "destination": "180°-Wendung Richtung {destination} am Ende der Straße"
+                "destination": "180°-Wendung Richtung {destination} am Ende der Straße",
+                "junction_name": "180°-Wendung an {junction_name}"
             }
         },
         "fork": {
             "default": {
                 "default": "{modifier} halten an der Gabelung",
                 "name": "{modifier} halten an der Gabelung auf {way_name}",
-                "destination": "{modifier}  halten an der Gabelung Richtung {destination}"
+                "destination": "{modifier} halten an der Gabelung Richtung {destination}"
             },
             "slight left": {
                 "default": "Links halten an der Gabelung",
@@ -493,22 +501,26 @@
             "default": {
                 "default": "{modifier} abbiegen",
                 "name": "{modifier} abbiegen auf {way_name}",
-                "destination": "{modifier} abbiegen Richtung {destination}"
+                "destination": "{modifier} abbiegen Richtung {destination}",
+                "junction_name": "Make a {modifier} at {junction_name}"
             },
             "left": {
                 "default": "Links abbiegen",
                 "name": "Links abbiegen auf {way_name}",
-                "destination": "Links abbiegen Richtung {destination}"
+                "destination": "Links abbiegen Richtung {destination}",
+                "junction_name": "Links abbiegen an {junction_name}"
             },
             "right": {
                 "default": "Rechts abbiegen",
                 "name": "Rechts abbiegen auf {way_name}",
-                "destination": "Rechts abbiegen Richtung {destination}"
+                "destination": "Rechts abbiegen Richtung {destination}",
+                "junction_name": "Rechts abbiegen an {junction_name}"
             },
             "straight": {
                 "default": "Geradeaus weiterfahren",
                 "name": "Geradeaus weiterfahren auf {way_name}",
-                "destination": "Geradeaus weiterfahren Richtung {destination}"
+                "destination": "Geradeaus weiterfahren Richtung {destination}",
+                "junction_name": "Geradeaus weiterfahren an {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/en.json
+++ b/languages/translations/en.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Make a sharp left",
                 "name": "Make a sharp left to stay on {way_name}",
-                "destination": "Make a sharp left towards {destination}"
+                "destination": "Make a sharp left towards {destination}",
+                "junction_name": "Make a sharp left at {junction_name}"
             },
             "sharp right": {
                 "default": "Make a sharp right",
                 "name": "Make a sharp right to stay on {way_name}",
-                "destination": "Make a sharp right towards {destination}"
+                "destination": "Make a sharp right towards {destination}",
+                "junction_name": "Make a sharp right at {junction_name}"
             },
             "slight left": {
                 "default": "Make a slight left",
                 "name": "Make a slight left to stay on {way_name}",
-                "destination": "Make a slight left towards {destination}"
+                "destination": "Make a slight left towards {destination}",
+                "junction_name": "Make a slight left at {junction_name}"
             },
             "slight right": {
                 "default": "Make a slight right",
                 "name": "Make a slight right to stay on {way_name}",
-                "destination": "Make a slight right towards {destination}"
+                "destination": "Make a slight right towards {destination}",
+                "junction_name": "Make a slight right at {junction_name}"
             },
             "uturn": {
                 "default": "Make a U-turn",
                 "name": "Make a U-turn and continue on {way_name}",
-                "destination": "Make a U-turn towards {destination}"
+                "destination": "Make a U-turn towards {destination}",
+                "junction_name": "Make a U-turn at {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Turn {modifier}",
                 "name": "Turn {modifier} onto {way_name}",
-                "destination": "Turn {modifier} towards {destination}"
+                "destination": "Turn {modifier} towards {destination}",
+                "junction_name": "Turn {modifier} at {junction_name}"
             },
             "straight": {
                 "default": "Continue straight",
                 "name": "Continue straight onto {way_name}",
-                "destination": "Continue straight towards {destination}"
+                "destination": "Continue straight towards {destination}",
+                "junction_name": "Continue straight at {junction_name}"
             },
             "uturn": {
                 "default": "Make a U-turn at the end of the road",
                 "name": "Make a U-turn onto {way_name} at the end of the road",
-                "destination": "Make a U-turn towards {destination} at the end of the road"
+                "destination": "Make a U-turn towards {destination} at the end of the road",
+                "junction_name": "Make a U-turn at {junction_name}"
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Make a {modifier}",
                 "name": "Make a {modifier} onto {way_name}",
-                "destination": "Make a {modifier} towards {destination}"
+                "destination": "Make a {modifier} towards {destination}",
+                "junction_name": "Make a {modifier} at {junction_name}"
             },
             "left": {
                 "default": "Turn left",
                 "name": "Turn left onto {way_name}",
-                "destination": "Turn left towards {destination}"
+                "destination": "Turn left towards {destination}",
+                "junction_name": "Turn left at {junction_name}"
             },
             "right": {
                 "default": "Turn right",
                 "name": "Turn right onto {way_name}",
-                "destination": "Turn right towards {destination}"
+                "destination": "Turn right towards {destination}",
+                "junction_name": "Turn right at {junction_name}"
             },
             "straight": {
                 "default": "Go straight",
                 "name": "Go straight onto {way_name}",
-                "destination": "Go straight towards {destination}"
+                "destination": "Go straight towards {destination}",
+                "junction_name": "Go straight at {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/eo.json
+++ b/languages/translations/eo.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Turniĝu ege maldekstren",
                 "name": "Turniĝu ege maldekstren al {way_name}",
-                "destination": "Turniĝu ege maldekstren direkte al {destination}"
+                "destination": "Turniĝu ege maldekstren direkte al {destination}",
+                "junction_name": "Turniĝu ege maldekstren ĉe {junction_name}"
             },
             "sharp right": {
                 "default": "Turniĝu ege dekstren",
                 "name": "Turniĝu ege dekstren al {way_name}",
-                "destination": "Turniĝu ege dekstren direkte al {destination}"
+                "destination": "Turniĝu ege dekstren direkte al {destination}",
+                "junction_name": "Turniĝu ege dekstren ĉe {junction_name}"
             },
             "slight left": {
                 "default": "Turniĝu ete maldekstren",
                 "name": "Turniĝu ete maldekstren al {way_name}",
-                "destination": "Turniĝu ete maldekstren direkte al {destination}"
+                "destination": "Turniĝu ete maldekstren direkte al {destination}",
+                "junction_name": "Turniĝu ete maldekstren ĉe {junction_name}"
             },
             "slight right": {
                 "default": "Turniĝu ete dekstren",
                 "name": "Turniĝu ete dekstren al {way_name}",
-                "destination": "Turniĝu ete dekstren direkte al {destination}"
+                "destination": "Turniĝu ete dekstren direkte al {destination}",
+                "junction_name": "Turniĝu ete dekstren ĉe {junction_name}"
             },
             "uturn": {
                 "default": "Turniĝu malantaŭen",
                 "name": "Turniĝu malantaŭen al {way_name}",
-                "destination": "Turniĝu malantaŭen direkte al {destination}"
+                "destination": "Turniĝu malantaŭen direkte al {destination}",
+                "junction_name": "Turniĝu malantaŭen ĉe {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Veturu {modifier}",
                 "name": "Veturu {modifier} direkte al {way_name}",
-                "destination": "Veturu {modifier} direkte al {destination}"
+                "destination": "Veturu {modifier} direkte al {destination}",
+                "junction_name": "Veturu {modifier} ĉe {junction_name}"
             },
             "straight": {
                 "default": "Veturu rekten",
                 "name": "Veturu rekten al {way_name}",
-                "destination": "Veturu rekten direkte al {destination}"
+                "destination": "Veturu rekten direkte al {destination}",
+                "junction_name": "Veturu rekten ĉe {junction_name}"
             },
             "uturn": {
                 "default": "Turniĝu malantaŭen ĉe fino de la vojo",
                 "name": "Turniĝu malantaŭen al {way_name} ĉe fino de la vojo",
-                "destination": "Turniĝu malantaŭen direkte al {destination} ĉe fino de la vojo"
+                "destination": "Turniĝu malantaŭen direkte al {destination} ĉe fino de la vojo",
+                "junction_name": "Turniĝu malantaŭen ĉe {junction_name}"
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Veturu {modifier}",
                 "name": "Veturu {modifier} al {way_name}",
-                "destination": "Veturu {modifier} direkte al {destination}"
+                "destination": "Veturu {modifier} direkte al {destination}",
+                "junction_name": "Veturu {modifier} ĉe {junction_name}"
             },
             "left": {
                 "default": "Turniĝu maldekstren",
                 "name": "Turniĝu maldekstren al {way_name}",
-                "destination": "Turniĝu maldekstren direkte al {destination}"
+                "destination": "Turniĝu maldekstren direkte al {destination}",
+                "junction_name": "Turniĝu maldekstren ĉe {junction_name}"
             },
             "right": {
                 "default": "Turniĝu dekstren",
                 "name": "Turniĝu dekstren al {way_name}",
-                "destination": "Turniĝu dekstren direkte al {destination}"
+                "destination": "Turniĝu dekstren direkte al {destination}",
+                "junction_name": "Turniĝu dekstren ĉe {junction_name}"
             },
             "straight": {
                 "default": "Veturu rekten",
                 "name": "Veturu rekten al {way_name}",
-                "destination": "Veturu rekten direkte al {destination}"
+                "destination": "Veturu rekten direkte al {destination}",
+                "junction_name": "Veturu rekten ĉe {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/es-ES.json
+++ b/languages/translations/es-ES.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Gire a la izquierda",
                 "name": "Gire a la izquierda en {way_name}",
-                "destination": "Gire a la izquierda hacia {destination}"
+                "destination": "Gire a la izquierda hacia {destination}",
+                "junction_name": "Gire a la izquierda en {junction_name}"
             },
             "sharp right": {
                 "default": "Gire a la derecha",
                 "name": "Gire a la derecha en {way_name}",
-                "destination": "Gire a la derecha hacia {destination}"
+                "destination": "Gire a la derecha hacia {destination}",
+                "junction_name": "Gire a la derecha en {junction_name}"
             },
             "slight left": {
                 "default": "Gire a la izquierda",
                 "name": "Doble levemente a la izquierda en {way_name}",
-                "destination": "Gire a la izquierda hacia {destination}"
+                "destination": "Gire a la izquierda hacia {destination}",
+                "junction_name": "Doble levemente a la izquierda en {junction_name}"
             },
             "slight right": {
                 "default": "Gire a la izquierda",
                 "name": "Doble levemente a la derecha en {way_name}",
-                "destination": "Gire a la izquierda hacia {destination}"
+                "destination": "Gire a la izquierda hacia {destination}",
+                "junction_name": "Doble levemente a la derecha en {junction_name}"
             },
             "uturn": {
                 "default": "Haz un cambio de sentido",
                 "name": "Haz un cambio de sentido y continúa en {way_name}",
-                "destination": "Haz un cambio de sentido hacia {destination}"
+                "destination": "Haz un cambio de sentido hacia {destination}",
+                "junction_name": "Haz un cambio de sentido en {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Al final de la calle gira {modifier}",
                 "name": "Al final de la calle gira {modifier} por {way_name}",
-                "destination": "Al final de la calle gira {modifier} hacia {destination}"
+                "destination": "Al final de la calle gira {modifier} hacia {destination}",
+                "junction_name": "Al final de la calle gira {modifier} en {junction_name}"
             },
             "straight": {
                 "default": "Al final de la calle continúa recto",
                 "name": "Al final de la calle continúa recto por {way_name}",
-                "destination": "Al final de la calle continúa recto hacia {destination}"
+                "destination": "Al final de la calle continúa recto hacia {destination}",
+                "junction_name": "Al final de la calle continúa recto en {junction_name}"
             },
             "uturn": {
                 "default": "Al final de la calle haz un cambio de sentido",
                 "name": "Al final de la calle haz un cambio de sentido en {way_name}",
-                "destination": "Al final de la calle haz un cambio de sentido hacia {destination}"
+                "destination": "Al final de la calle haz un cambio de sentido hacia {destination}",
+                "junction_name": "Haz un cambio de sentido en {junction_name}"
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Gira {modifier}",
                 "name": "Gira {modifier} por {way_name}",
-                "destination": "Gira {modifier} hacia {destination}"
+                "destination": "Gira {modifier} hacia {destination}",
+                "junction_name": "Gira {modifier} en {junction_name}"
             },
             "left": {
                 "default": "Gira a la izquierda",
                 "name": "Gira a la izquierda por {way_name}",
-                "destination": "Gira a la izquierda hacia {destination}"
+                "destination": "Gira a la izquierda hacia {destination}",
+                "junction_name": "Gira a la izquierda en {junction_name}"
             },
             "right": {
                 "default": "Gira a la derecha",
                 "name": "Gira a la derecha por {way_name}",
-                "destination": "Gira a la derecha hacia {destination}"
+                "destination": "Gira a la derecha hacia {destination}",
+                "junction_name": "Gira a la derecha en junction_name}"
             },
             "straight": {
                 "default": "Continúa recto",
                 "name": "Continúa recto por {way_name}",
-                "destination": "Continúa recto hacia {destination}"
+                "destination": "Continúa recto hacia {destination}",
+                "junction_name": "Continúa recto en {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/es.json
+++ b/languages/translations/es.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Gira a la izquierda",
                 "name": "Gira a la izquierda en {way_name}",
-                "destination": "Gira a la izquierda hacia {destination}"
+                "destination": "Gira a la izquierda hacia {destination}",
+                "junction_name": "Gira a la izquierda en {junction_name}"
             },
             "sharp right": {
                 "default": "Gira a la derecha",
                 "name": "Gira a la derecha en {way_name}",
-                "destination": "Gira a la derecha hacia {destination}"
+                "destination": "Gira a la derecha hacia {destination}",
+                "junction_name": "Gira a la derecha en {junction_name}"
             },
             "slight left": {
                 "default": "Gira a la izquierda",
                 "name": "Dobla levemente a la izquierda en {way_name}",
-                "destination": "Gira a la izquierda hacia {destination}"
+                "destination": "Gira a la izquierda hacia {destination}",
+                "junction_name": "Dobla levemente a la izquierda en {junction_name}"
             },
             "slight right": {
                 "default": "Gira a la izquierda",
                 "name": "Dobla levemente a la derecha en {way_name}",
-                "destination": "Gira a la izquierda hacia {destination}"
+                "destination": "Gira a la izquierda hacia {destination}",
+                "junction_name": "Dobla levemente a la derecha en {junction_name}"
             },
             "uturn": {
                 "default": "Haz un cambio de sentido",
                 "name": "Haz un cambio de sentido y continúa en {way_name}",
-                "destination": "Haz un cambio de sentido hacia {destination}"
+                "destination": "Haz un cambio de sentido hacia {destination}",
+                "junction_name": "Haz un cambio de sentido en {junction_name}"
             }
         },
         "depart": {
@@ -164,24 +169,27 @@
         },
         "end of road": {
             "default": {
-                "default": "Gira  a {modifier}",
+                "default": "Gira a {modifier}",
                 "name": "Gira a {modifier} en {way_name}",
-                "destination": "Gira a {modifier} hacia {destination}"
+                "destination": "Gira a {modifier} hacia {destination}",
+                "junction_name": "Gira a {modifier} en {junction_name}"
             },
             "straight": {
                 "default": "Continúa recto",
                 "name": "Continúa recto en {way_name}",
-                "destination": "Continúa recto hacia {destination}"
+                "destination": "Continúa recto hacia {destination}",
+                "junction_name": "Continúa recto en {junction_name}"
             },
             "uturn": {
                 "default": "Haz un cambio de sentido al final de la via",
                 "name": "Haz un cambio de sentido en {way_name} al final de la via",
-                "destination": "Haz un cambio de sentido hacia {destination} al final de la via"
+                "destination": "Haz un cambio de sentido hacia {destination} al final de la via",
+                "junction_name": "Haz un cambio de sentido en {junction_name}"
             }
         },
         "fork": {
             "default": {
-                "default": "Mantente  {modifier} en el cruza",
+                "default": "Mantente {modifier} en el cruza",
                 "name": "Mantente {modifier} en {way_name}",
                 "destination": "Mantente {modifier} hacia {destination}"
             },
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Sigue {modifier}",
                 "name": "Sigue {modifier} en {way_name}",
-                "destination": "Sigue {modifier} hacia {destination}"
+                "destination": "Sigue {modifier} hacia {destination}",
+                "junction_name": "Sigue {modifier} en {junction_name}"
             },
             "left": {
                 "default": "Gira a la izquierda",
                 "name": "Gira a la izquierda en {way_name}",
-                "destination": "Gira a la izquierda hacia {destination}"
+                "destination": "Gira a la izquierda hacia {destination}",
+                "junction_name": "Gira a la izquierda en {junction_name}"
             },
             "right": {
                 "default": "Gira a la derecha",
                 "name": "Gira a la derecha en {way_name}",
-                "destination": "Gira a la derecha hacia {destination}"
+                "destination": "Gira a la derecha hacia {destination}",
+                "junction_name": "Gira a la derecha en {junction_name}"
             },
             "straight": {
                 "default": "Ve recto",
                 "name": "Ve recto en {way_name}",
-                "destination": "Ve recto hacia {destination}"
+                "destination": "Ve recto hacia {destination}",
+                "junction_name": "Ve recto en {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/fi.json
+++ b/languages/translations/fi.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Jatka jyrkästi vasempaan",
                 "name": "Jatka jyrkästi vasempaan pysyäksesi tiellä {way_name}",
-                "destination": "Jatka jyrkästi vasempaan suuntana {destination}"
+                "destination": "Jatka jyrkästi vasempaan suuntana {destination}",
+                "junction_name": "Jatka jyrkästi vasempaan tielle {junction_name}"
             },
             "sharp right": {
                 "default": "Jatka jyrkästi oikeaan",
                 "name": "Jatka jyrkästi oikeaan pysyäksesi tiellä {way_name}",
-                "destination": "Jatka jyrkästi oikeaan suuntana {destination}"
+                "destination": "Jatka jyrkästi oikeaan suuntana {destination}",
+                "junction_name": "Jatka jyrkästi oikeaan tielle {junction_name}"
             },
             "slight left": {
                 "default": "Jatka loivasti vasempaan",
                 "name": "Jatka loivasti vasempaan pysyäksesi tiellä {way_name}",
-                "destination": "Jatka loivasti vasempaan suuntana {destination}"
+                "destination": "Jatka loivasti vasempaan suuntana {destination}",
+                "junction_name": "Jatka loivasti vasempaan tielle {junction_name}"
             },
             "slight right": {
                 "default": "Jatka loivasti oikeaan",
                 "name": "Jatka loivasti oikeaan pysyäksesi tiellä {way_name}",
-                "destination": "Jatka loivasti oikeaan suuntana {destination}"
+                "destination": "Jatka loivasti oikeaan suuntana {destination}",
+                "junction_name": "Jatka loivasti oikeaan tielle {junction_name}"
             },
             "uturn": {
                 "default": "Tee U-käännös",
                 "name": "Tee U-käännös ja jatka tietä {way_name}",
-                "destination": "Tee U-käännös suuntana {destination}"
+                "destination": "Tee U-käännös suuntana {destination}",
+                "junction_name": "Tee U-käännös tielle {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Käänny {modifier}",
                 "name": "Käänny {modifier} tielle {way_name}",
-                "destination": "Käänny {modifier} suuntana {destination}"
+                "destination": "Käänny {modifier} suuntana {destination}",
+                "junction_name": "Käänny {modifier} tielle {junction_name}"
             },
             "straight": {
                 "default": "Jatka suoraan eteenpäin",
                 "name": "Jatka suoraan eteenpäin tielle {way_name}",
-                "destination": "Jatka suoraan eteenpäin suuntana {destination}"
+                "destination": "Jatka suoraan eteenpäin suuntana {destination}",
+                "junction_name": "Jatka suoraan eteenpäin tielle {junction_name}"
             },
             "uturn": {
                 "default": "Tien päässä tee U-käännös",
                 "name": "Tien päässä tee U-käännös tielle {way_name}",
-                "destination": "Tien päässä tee U-käännös suuntana {destination}"
+                "destination": "Tien päässä tee U-käännös suuntana {destination}",
+                "junction_name": "Tien päässä tee U-käännös tielle {junction_name}"
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Käänny {modifier}",
                 "name": "Käänny {modifier} tielle {way_name}",
-                "destination": "Käänny {modifier} suuntana {destination}"
+                "destination": "Käänny {modifier} suuntana {destination}",
+                "junction_name": "Käänny {modifier} {junction_name}"
             },
             "left": {
                 "default": "Käänny vasempaan",
                 "name": "Käänny vasempaan tielle {way_name}",
-                "destination": "Käänny vasempaan suuntana {destination}"
+                "destination": "Käänny vasempaan suuntana {destination}",
+                "junction_name": "Käänny vasemmalle {junction_name}"
             },
             "right": {
                 "default": "Käänny oikeaan",
                 "name": "Käänny oikeaan tielle {way_name}",
-                "destination": "Käänny oikeaan suuntana {destination}"
+                "destination": "Käänny oikeaan suuntana {destination}",
+                "junction_name": "Käänny oikealle {junction_name}"
             },
             "straight": {
                 "default": "Aja suoraan eteenpäin",
                 "name": "Aja suoraan eteenpäin tielle {way_name}",
-                "destination": "Aja suoraan eteenpäin suuntana {destination}"
+                "destination": "Aja suoraan eteenpäin suuntana {destination}",
+                "junction_name": "Aja suoraan eteenpäin {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/fr.json
+++ b/languages/translations/fr.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Tourner franchement à gauche",
                 "name": "Tourner franchement à gauche pour rester sur {way_name:article}",
-                "destination": "Tourner franchement à gauche en direction {destination:preposition}"
+                "destination": "Tourner franchement à gauche en direction {destination:preposition}",
+                "junction_name": "Tourner franchement à gauche en {junction_name}"
             },
             "sharp right": {
                 "default": "Tourner franchement à droite",
                 "name": "Tourner franchement à droite pour rester sur {way_name:article}",
-                "destination": "Tourner franchement à droite en direction {destination:preposition}"
+                "destination": "Tourner franchement à droite en direction {destination:preposition}",
+                "junction_name": "Tourner franchement à droite en {junction_name}"
             },
             "slight left": {
                 "default": "Tourner légèrement à gauche",
                 "name": "Tourner légèrement à gauche pour rester sur {way_name:article}",
-                "destination": "Tourner légèrement à gauche en direction {destination:preposition}"
+                "destination": "Tourner légèrement à gauche en direction {destination:preposition}",
+                "junction_name": "Tourner légèrement à gauche en {junction_name}"
             },
             "slight right": {
                 "default": "Tourner légèrement à droite",
                 "name": "Tourner légèrement à droite pour rester sur {way_name:article}",
-                "destination": "Tourner légèrement à droite en direction {destination:preposition}"
+                "destination": "Tourner légèrement à droite en direction {destination:preposition}",
+                "junction_name": "Tourner légèrement à droite en {junction_name}"
             },
             "uturn": {
                 "default": "Faire demi-tour",
                 "name": "Faire demi-tour et continuer sur {way_name:article}",
-                "destination": "Faire demi-tour en direction {destination:preposition}"
+                "destination": "Faire demi-tour en direction {destination:preposition}",
+                "junction_name": "Faire demi-tour en {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Tourner {modifier}",
                 "name": "Tourner {modifier} sur {way_name:article}",
-                "destination": "Tourner {modifier} en direction {destination:preposition}"
+                "destination": "Tourner {modifier} en direction {destination:preposition}",
+                "junction_name": "Tourner {modifier} en {junction_name}"
             },
             "straight": {
                 "default": "Continuer tout droit",
                 "name": "Continuer tout droit sur {way_name:article}",
-                "destination": "Continuer tout droit en direction {destination:preposition}"
+                "destination": "Continuer tout droit en direction {destination:preposition}",
+                "junction_name": "Continuer tout droit en {junction_name}"
             },
             "uturn": {
                 "default": "Faire demi-tour à la fin de la route",
                 "name": "Faire demi-tour à la fin {way_name:preposition}",
-                "destination": "Faire demi-tour à la fin de la route en direction {destination:preposition}"
+                "destination": "Faire demi-tour à la fin de la route en direction {destination:preposition}",
+                "junction_name": "Faire demi-tour en {junction_name}"
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Tourner {modifier}",
                 "name": "Tourner {modifier} sur {way_name:article}",
-                "destination": "Tourner {modifier} en direction {destination:preposition}"
+                "destination": "Tourner {modifier} en direction {destination:preposition}",
+                "junction_name": "Tourner {modifier} en {junction_name}"
             },
             "left": {
                 "default": "Tourner à gauche",
                 "name": "Tourner à gauche sur {way_name:article}",
-                "destination": "Tourner à gauche en direction {destination:preposition}"
+                "destination": "Tourner à gauche en direction {destination:preposition}",
+                "junction_name": "Tourner à gauche en {junction_name}"
             },
             "right": {
                 "default": "Tourner à droite",
                 "name": "Tourner à droite sur {way_name:article}",
-                "destination": "Tourner à droite en direction {destination:preposition}"
+                "destination": "Tourner à droite en direction {destination:preposition}",
+                "junction_name": "Tourner à droite en {junction_name}"
             },
             "straight": {
                 "default": "Aller tout droit",
                 "name": "Aller tout droit sur {way_name:article}",
-                "destination": "Aller tout droit en direction {destination:preposition}"
+                "destination": "Aller tout droit en direction {destination:preposition}",
+                "junction_name": "Aller tout droit en {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/he.json
+++ b/languages/translations/he.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "פנה בחדות שמאלה",
                 "name": "פנה בחדות שמאלה כדי להישאר על {way_name}",
-                "destination": "פנה בחדות שמאלה לכיוון {destination}"
+                "destination": "פנה בחדות שמאלה לכיוון {destination}",
+                "junction_name": "פנה בחדות שמאלה כדי להישאר על {junction_name}"
             },
             "sharp right": {
                 "default": "פנה בחדות ימינה",
                 "name": "פנה בחדות ימינה כדי להישאר על {way_name}",
-                "destination": "פנה בחדות ימינה לכיוון {destination}"
+                "destination": "פנה בחדות ימינה לכיוון {destination}",
+                "junction_name": "פנה בחדות ימינה כדי להישאר על {junction_name}"
             },
             "slight left": {
                 "default": "פנה קלות שמאלה",
                 "name": "פנה קלות שמאלה כדי להישאר על {way_name}",
-                "destination": "פנה קלות שמאלה לכיוון {destination}"
+                "destination": "פנה קלות שמאלה לכיוון {destination}",
+                "junction_name": "פנה קלות שמאלה כדי להישאר על {junction_name}"
             },
             "slight right": {
                 "default": "פנה קלות ימינה",
                 "name": "פנה קלות ימינה כדי להישאר על {way_name}",
-                "destination": "פנה קלות ימינה לכיוון {destination}"
+                "destination": "פנה קלות ימינה לכיוון {destination}",
+                "junction_name": "פנה קלות ימינה כדי להישאר על {junction_name}"
             },
             "uturn": {
                 "default": "פנה פניית פרסה",
                 "name": "פנה פניית פרסה והמשך על {way_name}",
-                "destination": "פנה פניית פרסה לכיוון {destination}"
+                "destination": "פנה פניית פרסה לכיוון {destination}",
+                "junction_name": "פנה פניית פרסה והמשך על {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "פנה {modifier}",
                 "name": "פנה {modifier} על {way_name}",
-                "destination": "פנה {modifier} לכיוון {destination}"
+                "destination": "פנה {modifier} לכיוון {destination}",
+                "junction_name": "פנה {modifier} על {junction_name}"
             },
             "straight": {
                 "default": "המשך ישר",
                 "name": "המשך ישר על {way_name}",
-                "destination": "המשך ישר לכיוון {destination}"
+                "destination": "המשך ישר לכיוון {destination}",
+                "junction_name": "המשך ישר על {junction_name}"
             },
             "uturn": {
                 "default": "פנה פניית פרסה בסוף הדרך",
                 "name": "פנה פניית פרסה על {way_name} בסוף הדרך",
-                "destination": "פנה פניית פרסה לכיוון {destination} בסוף הדרך"
+                "destination": "פנה פניית פרסה לכיוון {destination} בסוף הדרך",
+                "junction_name": "פנה פניית פרסה על {junction_name} בסוף הדרך"
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "פנה {modifier}",
                 "name": "פנה {modifier} על {way_name}",
-                "destination": "פנה {modifier} לכיוון {destination}"
+                "destination": "פנה {modifier} לכיוון {destination}",
+                "junction_name": "פנה {modifier} על {junction_name}"
             },
             "left": {
                 "default": "פנה שמאלה",
                 "name": "פנה שמאלה ל{way_name}",
-                "destination": "פנה שמאלה לכיוון {destination}"
+                "destination": "פנה שמאלה לכיוון {destination}",
+                "junction_name": "פנה שמאלה ל{junction_name}"
             },
             "right": {
                 "default": "פנה ימינה",
                 "name": "פנה ימינה ל{way_name}",
-                "destination": "פנה ימינה לכיוון {destination}"
+                "destination": "פנה ימינה לכיוון {destination}",
+                "junction_name": "פנה ימינה ל{junction_name}"
             },
             "straight": {
                 "default": "המשך ישר",
                 "name": "המשך ישר ל{way_name}",
-                "destination": "המשך ישר לכיוון {destination}"
+                "destination": "המשך ישר לכיוון {destination}",
+                "junction_name": "המשך ישר ל{junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/hu.json
+++ b/languages/translations/hu.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Forduljon élesen balra",
                 "name": "Forduljon élesen balra, majd maradjon {way_name:superessive}",
-                "destination": "Forduljon élesen balra {destination:sublative_toward}"
+                "destination": "Forduljon élesen balra {destination:sublative_toward}",
+                "junction_name": "Forduljon élesen balra az {junction_name}"
             },
             "sharp right": {
                 "default": "Forduljon élesen jobbra",
                 "name": "Forduljon élesen jobbra, majd maradjon {way_name:superessive}",
-                "destination": "Forduljon élesen balra {destination:sublative_toward}"
+                "destination": "Forduljon élesen balra {destination:sublative_toward}",
+                "junction_name": "Forduljon élesen jobbra az {junction_name}"
             },
             "slight left": {
                 "default": "Forduljon enyhén balra",
                 "name": "Forduljon enyhén balra, majd maradjon {way_name:superessive}",
-                "destination": "Forduljon enyhén balra {destination:sublative_toward}"
+                "destination": "Forduljon enyhén balra {destination:sublative_toward}",
+                "junction_name": "Forduljon enyhén balra az {junction_name}"
             },
             "slight right": {
                 "default": "Forduljon enyhén jobbra",
                 "name": "Forduljon enyhén jobbra, majd maradjon {way_name:superessive}",
-                "destination": "Forduljon enyhén jobbra {destination:sublative_toward}"
+                "destination": "Forduljon enyhén jobbra {destination:sublative_toward}",
+                "junction_name": "Forduljon enyhén jobbra az {junction_name}"
             },
             "uturn": {
                 "default": "Forduljon vissza",
                 "name": "Forduljon vissza, majd folytassa {way_name:superessive}",
-                "destination": "Forduljon vissza {destination:sublative_toward}"
+                "destination": "Forduljon vissza {destination:sublative_toward}",
+                "junction_name": "Forduljon vissza az {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Forduljon {modifier}",
                 "name": "Forduljon be {modifier} {way_name:sublative_toward}",
-                "destination": "Forduljon {modifier} {destination:sublative_to}"
+                "destination": "Forduljon {modifier} {destination:sublative_to}",
+                "junction_name": "Forduljon be {modifier} az {junction_name}"
             },
             "straight": {
                 "default": "Hajtson tovább egyenesen",
                 "name": "Hajtson tovább egyenesen {way_name:sublative_to}",
-                "destination": "Hajtson tovább egyenesen {destination:sublative_toward}"
+                "destination": "Hajtson tovább egyenesen {destination:sublative_toward}",
+                "junction_name": "Hajtson tovább egyenesen az {junction_name}"
             },
             "uturn": {
                 "default": "Forduljon vissza az út végén",
                 "name": "Forduljon vissza {way_name:article} végén",
-                "destination": "Forduljon vissza {destination:article} irányában az út végén"
+                "destination": "Forduljon vissza {destination:article} irányában az út végén",
+                "junction_name": "Forduljon vissza az {junction_name}"
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Forduljon {modifier}",
                 "name": "Forduljon be {modifier} {way_name:sublative_to}",
-                "destination": "Forduljon {modifier} {destination:sublative_toward}"
+                "destination": "Forduljon {modifier} {destination:sublative_toward}",
+                "junction_name": "Forduljon be {modifier} az {junction_name}"
             },
             "left": {
                 "default": "Forduljon balra",
                 "name": "Forduljon be balra {way_name:sublative_toward}",
-                "destination": "Forduljon balra {destination:sublative_toward}"
+                "destination": "Forduljon balra {destination:sublative_toward}",
+                "junction_name": "Forduljon be balra az {junction_name}"
             },
             "right": {
                 "default": "Forduljon jobbra",
                 "name": "Forduljon be jobbra {way_name:sublative_to}",
-                "destination": "Forduljon jobbra {destination:sublative_toward}"
+                "destination": "Forduljon jobbra {destination:sublative_toward}",
+                "junction_name": "Forduljon be jobbra az {junction_name}"
             },
             "straight": {
                 "default": "Hajtson egyenesen",
                 "name": "Hajtson egyenesen {way_name:sublative_to}",
-                "destination": "Hajtson egyenesen {destination:sublative_toward}"
+                "destination": "Hajtson egyenesen {destination:sublative_toward}",
+                "junction_name": "Hajtson egyenese az {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/id.json
+++ b/languages/translations/id.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Belok kiri tajam",
                 "name": "Make a sharp left to stay on {way_name}",
-                "destination": "Belok kiri tajam menuju {destination}"
+                "destination": "Belok kiri tajam menuju {destination}",
+                "junction_name": "Make a sharp left at {junction_name}"
             },
             "sharp right": {
                 "default": "Belok kanan tajam",
                 "name": "Make a sharp right to stay on {way_name}",
-                "destination": "Belok kanan tajam menuju {destination}"
+                "destination": "Belok kanan tajam menuju {destination}",
+                "junction_name": "Make a sharp right at {junction_name}"
             },
             "slight left": {
                 "default": "Tetap agak di kiri",
                 "name": "Tetap agak di kiri ke {way_name}",
-                "destination": "Tetap agak di kiri menuju {destination}"
+                "destination": "Tetap agak di kiri menuju {destination}",
+                "junction_name": "Make a slight left at {junction_name}"
             },
             "slight right": {
                 "default": "Tetap agak di kanan",
                 "name": "Tetap agak di kanan ke {way_name}",
-                "destination": "Tetap agak di kanan menuju {destination}"
+                "destination": "Tetap agak di kanan menuju {destination}",
+                "junction_name": "Make a slight right at {junction_name}"
             },
             "uturn": {
                 "default": "Putar balik",
                 "name": "Putar balik ke arah {way_name}",
-                "destination": "Putar balik menuju {destination}"
+                "destination": "Putar balik menuju {destination}",
+                "junction_name": "Make a U-turn at {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Belok {modifier}",
                 "name": "Belok {modifier} ke {way_name}",
-                "destination": "Belok {modifier} menuju {destination}"
+                "destination": "Belok {modifier} menuju {destination}",
+                "junction_name": "Turn {modifier} at {junction_name}"
             },
             "straight": {
                 "default": "Lurus terus",
                 "name": "Tetap lurus ke {way_name} ",
-                "destination": "Tetap lurus menuju {destination}"
+                "destination": "Tetap lurus menuju {destination}",
+                "junction_name": "Continue straight at {junction_name}"
             },
             "uturn": {
                 "default": "Putar balik di akhir jalan",
                 "name": "Putar balik di {way_name} di akhir jalan",
-                "destination": "Putar balik menuju {destination} di akhir jalan"
+                "destination": "Putar balik menuju {destination} di akhir jalan",
+                "junction_name": "Make a U-turn at {junction_name}"
             }
         },
         "fork": {
@@ -343,7 +351,7 @@
             "slight right": {
                 "default": "Ambil jalan melandai di sebelah kanan",
                 "name": "Ambil jalan melandai di sebelah kanan ke {way_name}",
-                "destination": "Ambil jalan melandai di sebelah kanan  menuju {destination}",
+                "destination": "Ambil jalan melandai di sebelah kanan menuju {destination}",
                 "exit": "Take exit {exit} on the right",
                 "exit_destination": "Take exit {exit} on the right towards {destination}"
             }
@@ -362,7 +370,7 @@
             "right": {
                 "default": "Ambil jalan melandai di sebelah kanan",
                 "name": "Ambil jalan melandai di sebelah kanan ke {way_name}",
-                "destination": "Ambil jalan melandai di sebelah kanan  menuju {destination}"
+                "destination": "Ambil jalan melandai di sebelah kanan menuju {destination}"
             },
             "sharp left": {
                 "default": "Ambil jalan yang melandai di sebelah kiri",
@@ -372,7 +380,7 @@
             "sharp right": {
                 "default": "Ambil jalan melandai di sebelah kanan",
                 "name": "Ambil jalan melandai di sebelah kanan ke {way_name}",
-                "destination": "Ambil jalan melandai di sebelah kanan  menuju {destination}"
+                "destination": "Ambil jalan melandai di sebelah kanan menuju {destination}"
             },
             "slight left": {
                 "default": "Ambil jalan yang melandai di sebelah kiri",
@@ -382,7 +390,7 @@
             "slight right": {
                 "default": "Ambil jalan melandai di sebelah kanan",
                 "name": "Ambil jalan melandai di sebelah kanan ke {way_name}",
-                "destination": "Ambil jalan melandai di sebelah kanan  menuju {destination}"
+                "destination": "Ambil jalan melandai di sebelah kanan menuju {destination}"
             }
         },
         "rotary": {
@@ -493,22 +501,26 @@
             "default": {
                 "default": "Lakukan {modifier}",
                 "name": "Lakukan {modifier} ke arah {way_name}",
-                "destination": "Lakukan {modifier} menuju {destination}"
+                "destination": "Lakukan {modifier} menuju {destination}",
+                "junction_name": "Make a {modifier} at {junction_name}"
             },
             "left": {
                 "default": "Belok kiri",
                 "name": "Belok kiri ke {way_name}",
-                "destination": "Belok kiri menuju {destination}"
+                "destination": "Belok kiri menuju {destination}",
+                "junction_name": "Turn left at {junction_name}"
             },
             "right": {
                 "default": "Belok kanan",
                 "name": "Belok kanan ke {way_name}",
-                "destination": "Belok kanan menuju {destination}"
+                "destination": "Belok kanan menuju {destination}",
+                "junction_name": "Turn right at {junction_name}"
             },
             "straight": {
                 "default": "Lurus",
                 "name": "Lurus arah {way_name}",
-                "destination": "Lurus menuju {destination}"
+                "destination": "Lurus menuju {destination}",
+                "junction_name": "Go straight at {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/it.json
+++ b/languages/translations/it.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Svolta a sinistra",
                 "name": "Fai una curva stretta a sinistra per stare su {way_name}",
-                "destination": "Svolta a sinistra verso {destination}"
+                "destination": "Svolta a sinistra verso {destination}",
+                "junction_name": "Fai una curva stretta a sinistra al {junction_name}"
             },
             "sharp right": {
                 "default": "Svolta a destra",
                 "name": "Fai una curva stretta a destra per stare su {way_name}",
-                "destination": "Svolta a destra verso {destination}"
+                "destination": "Svolta a destra verso {destination}",
+                "junction_name": "Fai una curva stretta a destra al {junction_name}"
             },
             "slight left": {
                 "default": "Fai una leggera curva a sinistra",
                 "name": "Fai una leggera curva a sinistra per stare su {way_name}",
-                "destination": "Fai una leggera curva a sinistra verso {destination}"
+                "destination": "Fai una leggera curva a sinistra verso {destination}",
+                "junction_name": "Fai una leggera curva a sinistra al {junction_name}"
             },
             "slight right": {
                 "default": "Fai una leggera curva a destra",
                 "name": "Fai una leggera curva a destra per stare su {way_name}",
-                "destination": "Fai una leggera curva a destra verso {destination}"
+                "destination": "Fai una leggera curva a destra verso {destination}",
+                "junction_name": "Fai una leggera curva a destra al {junction_name}"
             },
             "uturn": {
                 "default": "Fai un’inversione a U",
                 "name": "Fai un’inversione ad U poi continua su {way_name}",
-                "destination": "Fai un’inversione a U verso {destination}"
+                "destination": "Fai un’inversione a U verso {destination}",
+                "junction_name": "Fai un’inversione ad U al {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Gira a {modifier}",
                 "name": "Gira a {modifier} in {way_name}",
-                "destination": "Gira a {modifier} verso {destination}"
+                "destination": "Gira a {modifier} verso {destination}",
+                "junction_name": "Gira a {modifier} al {junction_name}"
             },
             "straight": {
                 "default": "Continua dritto",
                 "name": "Continua dritto in {way_name}",
-                "destination": "Continua dritto verso {destination}"
+                "destination": "Continua dritto verso {destination}",
+                "junction_name": "Continua dritto al {junction_name}"
             },
             "uturn": {
                 "default": "Fai un’inversione a U alla fine della strada",
                 "name": "Fai un’inversione a U in {way_name} alla fine della strada",
-                "destination": "Fai un’inversione a U verso {destination} alla fine della strada"
+                "destination": "Fai un’inversione a U verso {destination} alla fine della strada",
+                "junction_name": "Fai un’inversione a U al {junction_name}"
             }
         },
         "fork": {
@@ -303,14 +311,14 @@
                 "name": "Prendi la rampa in {way_name}",
                 "destination": "Prendi la rampa verso {destination}",
                 "exit": "Prendi l’uscita {exit}",
-                "exit_destination": "Prendi l’uscita  {exit} verso {destination}"
+                "exit_destination": "Prendi l’uscita {exit} verso {destination}"
             },
             "left": {
                 "default": "Prendi la rampa a sinistra",
                 "name": "Prendi la rampa a sinistra in {way_name}",
                 "destination": "Prendi la rampa a sinistra verso {destination}",
                 "exit": "Prendi l’uscita {exit} a sinistra",
-                "exit_destination": "Prendi la {exit}  uscita a sinistra verso {destination}"
+                "exit_destination": "Prendi la {exit} uscita a sinistra verso {destination}"
             },
             "right": {
                 "default": "Prendi la rampa a destra",
@@ -324,7 +332,7 @@
                 "name": "Prendi la rampa a sinistra in {way_name}",
                 "destination": "Prendi la rampa a sinistra verso {destination}",
                 "exit": "Prendi l’uscita {exit} a sinistra",
-                "exit_destination": "Prendi la {exit}  uscita a sinistra verso {destination}"
+                "exit_destination": "Prendi la {exit} uscita a sinistra verso {destination}"
             },
             "sharp right": {
                 "default": "Prendi la rampa a destra",
@@ -338,7 +346,7 @@
                 "name": "Prendi la rampa a sinistra in {way_name}",
                 "destination": "Prendi la rampa a sinistra verso {destination}",
                 "exit": "Prendi l’uscita {exit} a sinistra",
-                "exit_destination": "Prendi la {exit}  uscita a sinistra verso {destination}"
+                "exit_destination": "Prendi la {exit} uscita a sinistra verso {destination}"
             },
             "slight right": {
                 "default": "Prendi la rampa a destra",
@@ -405,7 +413,7 @@
                 "name_exit": {
                     "default": "Immèttitì in {rotary_name} e prendi la {exit_number} uscita",
                     "name": "Immèttitì in {rotary_name} e prendi la {exit_number} uscita in {way_name}",
-                    "destination": "Immèttitì in {rotary_name} e prendi la {exit_number}  uscita verso {destination}"
+                    "destination": "Immèttitì in {rotary_name} e prendi la {exit_number} uscita verso {destination}"
                 }
             }
         },
@@ -493,22 +501,26 @@
             "default": {
                 "default": "Gira a {modifier}",
                 "name": "Gira a {modifier} in {way_name}",
-                "destination": "Gira a {modifier} verso {destination}"
+                "destination": "Gira a {modifier} verso {destination}",
+                "junction_name": "Gira a {modifier} al {junction_name}"
             },
             "left": {
                 "default": "Svolta a sinistra",
                 "name": "Svolta a sinistra in {way_name}",
-                "destination": "Svolta a sinistra verso {destination}"
+                "destination": "Svolta a sinistra verso {destination}",
+                "junction_name": "Svolta a sinistra al {junction_name}"
             },
             "right": {
                 "default": "Gira a destra",
                 "name": "Svolta a destra in {way_name}",
-                "destination": "Svolta a destra verso {destination}"
+                "destination": "Svolta a destra verso {destination}",
+                "junction_name": "Svolta a destra al {junction_name}"
             },
             "straight": {
                 "default": "Prosegui dritto",
                 "name": "Continua su {way_name}",
-                "destination": "Continua verso {destination}"
+                "destination": "Continua verso {destination}",
+                "junction_name": "Prosegui dritto al {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/ja.json
+++ b/languages/translations/ja.json
@@ -299,53 +299,53 @@
         },
         "off ramp": {
             "default": {
-                "default": "出口です",
-                "name": "{way_name}方面、出口です",
-                "destination": "{destination}方面、出口です",
-                "exit": "{exit} 出口です",
-                "exit_destination": "{destination} 方面、{exit}　出口です"
+                "default": "出口に向かう",
+                "name": "{way_name}方面、出口に向かう",
+                "destination": "{destination}方面、出口に向かう",
+                "exit": "{exit} 出口に向かう",
+                "exit_destination": "{destination} 方面、{exit}　出口に向かう"
             },
             "left": {
-                "default": "左方向、出口です",
-                "name": "左方向、{way_name}方面、出口です",
-                "destination": "左方向、{destination}方面、出口です",
-                "exit": "左方向、{exit} 出口です",
-                "exit_destination": "左方向、{destination} 方面、{exit}　出口です"
+                "default": "左方向、出口に向かう",
+                "name": "左方向、{way_name}方面、出口に向かう",
+                "destination": "左方向、{destination}方面、出口に向かう",
+                "exit": "左方向、{exit} 出口に向かう",
+                "exit_destination": "左方向、{destination} 方面、{exit}　出口に向かう"
             },
             "right": {
-                "default": "右方向、出口です",
-                "name": "右方向、{way_name}方面、出口です",
-                "destination": "右方向、{destination}方面、出口です",
-                "exit": "右方向、{exit} 出口です",
-                "exit_destination": "右方向、{destination} 方面、{exit}　出口です"
+                "default": "右方向、出口に向かう",
+                "name": "右方向、{way_name}方面、出口に向かう",
+                "destination": "右方向、{destination}方面、出口に向かう",
+                "exit": "右方向、{exit} 出口に向かう",
+                "exit_destination": "右方向、{destination} 方面、{exit}　出口に向かう"
             },
             "sharp left": {
-                "default": "左方向、出口です",
-                "name": "左方向、{way_name}方面、出口です",
-                "destination": "左方向、{destination}方面、出口です",
-                "exit": "左方向、{exit} 出口です",
-                "exit_destination": "左方向、{destination} 方面、{exit}　出口です"
+                "default": "左方向、出口に向かう",
+                "name": "左方向、{way_name}方面、出口に向かう",
+                "destination": "左方向、{destination}方面、出口に向かう",
+                "exit": "左方向、{exit} 出口に向かう",
+                "exit_destination": "左方向、{destination} 方面、{exit}　出口に向かう"
             },
             "sharp right": {
-                "default": "右方向、出口です",
-                "name": "右方向、{way_name}方面、出口です",
-                "destination": "右方向、{destination}方面、出口です",
-                "exit": "右方向、{exit} 出口です",
-                "exit_destination": "右方向、{destination} 方面、{exit}　出口です"
+                "default": "右方向、出口に向かう",
+                "name": "右方向、{way_name}方面、出口に向かう",
+                "destination": "右方向、{destination}方面、出口に向かう",
+                "exit": "右方向、{exit} 出口に向かう",
+                "exit_destination": "右方向、{destination} 方面、{exit}　出口に向かう"
             },
             "slight left": {
-                "default": "左方向、出口です",
-                "name": "左方向、{way_name}方面、出口です",
-                "destination": "左方向、{destination}方面、出口です",
-                "exit": "左方向、{exit} 出口です",
-                "exit_destination": "左方向、{destination} 方面、{exit}　出口です"
+                "default": "左方向、出口に向かう",
+                "name": "左方向、{way_name}方面、出口に向かう",
+                "destination": "左方向、{destination}方面、出口に向かう",
+                "exit": "左方向、{exit} 出口に向かう",
+                "exit_destination": "左方向、{destination} 方面、{exit}　出口に向かう"
             },
             "slight right": {
-                "default": "右方向、出口です",
-                "name": "右方向、{way_name}方面、出口です",
-                "destination": "右方向、{destination}方面、出口です",
-                "exit": "右方向、{exit} 出口です",
-                "exit_destination": "右方向、{destination} 方面、{exit}　出口です"
+                "default": "右方向、出口に向かう",
+                "name": "右方向、{way_name}方面、出口に向かう",
+                "destination": "右方向、{destination}方面、出口に向かう",
+                "exit": "右方向、{exit} 出口に向かう",
+                "exit_destination": "右方向、{destination} 方面、{exit}　出口に向かう"
             }
         },
         "on ramp": {

--- a/languages/translations/ja.json
+++ b/languages/translations/ja.json
@@ -299,53 +299,53 @@
         },
         "off ramp": {
             "default": {
-                "default": "出口に向かう",
-                "name": "{way_name}方面、出口に向かう",
-                "destination": "{destination}方面、出口に向かう",
-                "exit": "{exit} 出口に向かう",
-                "exit_destination": "{destination} 方面、{exit}　出口に向かう"
+                "default": "出口です",
+                "name": "{way_name}方面、出口です",
+                "destination": "{destination}方面、出口です",
+                "exit": "{exit} 出口です",
+                "exit_destination": "{destination} 方面、{exit}　出口です"
             },
             "left": {
-                "default": "左方向、出口に向かう",
-                "name": "左方向、{way_name}方面、出口に向かう",
-                "destination": "左方向、{destination}方面、出口に向かう",
-                "exit": "左方向、{exit} 出口に向かう",
-                "exit_destination": "左方向、{destination} 方面、{exit}　出口に向かう"
+                "default": "左方向、出口です",
+                "name": "左方向、{way_name}方面、出口です",
+                "destination": "左方向、{destination}方面、出口です",
+                "exit": "左方向、{exit} 出口です",
+                "exit_destination": "左方向、{destination} 方面、{exit}　出口です"
             },
             "right": {
-                "default": "右方向、出口に向かう",
-                "name": "右方向、{way_name}方面、出口に向かう",
-                "destination": "右方向、{destination}方面、出口に向かう",
-                "exit": "右方向、{exit} 出口に向かう",
-                "exit_destination": "右方向、{destination} 方面、{exit}　出口に向かう"
+                "default": "右方向、出口です",
+                "name": "右方向、{way_name}方面、出口です",
+                "destination": "右方向、{destination}方面、出口です",
+                "exit": "右方向、{exit} 出口です",
+                "exit_destination": "右方向、{destination} 方面、{exit}　出口です"
             },
             "sharp left": {
-                "default": "左方向、出口に向かう",
-                "name": "左方向、{way_name}方面、出口に向かう",
-                "destination": "左方向、{destination}方面、出口に向かう",
-                "exit": "左方向、{exit} 出口に向かう",
-                "exit_destination": "左方向、{destination} 方面、{exit}　出口に向かう"
+                "default": "左方向、出口です",
+                "name": "左方向、{way_name}方面、出口です",
+                "destination": "左方向、{destination}方面、出口です",
+                "exit": "左方向、{exit} 出口です",
+                "exit_destination": "左方向、{destination} 方面、{exit}　出口です"
             },
             "sharp right": {
-                "default": "右方向、出口に向かう",
-                "name": "右方向、{way_name}方面、出口に向かう",
-                "destination": "右方向、{destination}方面、出口に向かう",
-                "exit": "右方向、{exit} 出口に向かう",
-                "exit_destination": "右方向、{destination} 方面、{exit}　出口に向かう"
+                "default": "右方向、出口です",
+                "name": "右方向、{way_name}方面、出口です",
+                "destination": "右方向、{destination}方面、出口です",
+                "exit": "右方向、{exit} 出口です",
+                "exit_destination": "右方向、{destination} 方面、{exit}　出口です"
             },
             "slight left": {
-                "default": "左方向、出口に向かう",
-                "name": "左方向、{way_name}方面、出口に向かう",
-                "destination": "左方向、{destination}方面、出口に向かう",
-                "exit": "左方向、{exit} 出口に向かう",
-                "exit_destination": "左方向、{destination} 方面、{exit}　出口に向かう"
+                "default": "左方向、出口です",
+                "name": "左方向、{way_name}方面、出口です",
+                "destination": "左方向、{destination}方面、出口です",
+                "exit": "左方向、{exit} 出口です",
+                "exit_destination": "左方向、{destination} 方面、{exit}　出口です"
             },
             "slight right": {
-                "default": "右方向、出口に向かう",
-                "name": "右方向、{way_name}方面、出口に向かう",
-                "destination": "右方向、{destination}方面、出口に向かう",
-                "exit": "右方向、{exit} 出口に向かう",
-                "exit_destination": "右方向、{destination} 方面、{exit}　出口に向かう"
+                "default": "右方向、出口です",
+                "name": "右方向、{way_name}方面、出口です",
+                "destination": "右方向、{destination}方面、出口です",
+                "exit": "右方向、{exit} 出口です",
+                "exit_destination": "右方向、{destination} 方面、{exit}　出口です"
             }
         },
         "on ramp": {

--- a/languages/translations/ja.json
+++ b/languages/translations/ja.json
@@ -29,8 +29,8 @@
             "modifier": {
                 "left": "左",
                 "right": "右",
-                "sharp left": "大きく左",
-                "sharp right": "大きく右",
+                "sharp left": "左戻る",
+                "sharp right": "右戻る",
                 "slight left": "斜め左",
                 "slight right": "斜め右",
                 "straight": "直進",

--- a/languages/translations/ja.json
+++ b/languages/translations/ja.json
@@ -299,90 +299,90 @@
         },
         "off ramp": {
             "default": {
-                "default": "ランプに向かう",
-                "name": "{way_name}に向けてランプに向かう",
-                "destination": "{destination}に向けてランプに向かう",
-                "exit": "{exit}出口に向かう",
-                "exit_destination": "{exit}出口を出て{destination}へ向かう"
+                "default": "出口です",
+                "name": "{way_name}方面、出口です",
+                "destination": "{destination}方面、出口です",
+                "exit": "{exit} 出口です",
+                "exit_destination": "{destination} 方面、{exit}　出口です"
             },
             "left": {
-                "default": "左方向のランプに向かう",
-                "name": "左方向のランプに向かい、{way_name}を進む",
-                "destination": "左方向のランプに向かい、その後{destination}へ向かう",
-                "exit": "左方向の{exit}出口を出る",
-                "exit_destination": "左方向の{exit}出口を出て{destination}へ向かう"
+                "default": "左方向、出口です",
+                "name": "左方向、{way_name}方面、出口です",
+                "destination": "左方向、{destination}方面、出口です",
+                "exit": "左方向、{exit} 出口です",
+                "exit_destination": "左方向、{destination} 方面、{exit}　出口です"
             },
             "right": {
-                "default": "右方向のランプに向かう",
-                "name": "右方向のランプに向かい、{way_name}を進む",
-                "destination": "右方向のランプに向かい、その後{destination}へ向かう",
-                "exit": "右方向の{exit}出口を出る",
-                "exit_destination": "右方向の{exit}出口を出て{destination}へ向かう"
+                "default": "右方向、出口です",
+                "name": "右方向、{way_name}方面、出口です",
+                "destination": "右方向、{destination}方面、出口です",
+                "exit": "右方向、{exit} 出口です",
+                "exit_destination": "右方向、{destination} 方面、{exit}　出口です"
             },
             "sharp left": {
-                "default": "左方向のランプに向かう",
-                "name": "左方向のランプに向かい、{way_name}を進む",
-                "destination": "左方向のランプに向かい、{destination}へ向かう",
-                "exit": "左方向の{exit}出口を出る",
-                "exit_destination": "左方向の{exit}出口を出て{destination}へ向かう"
+                "default": "左方向、出口です",
+                "name": "左方向、{way_name}方面、出口です",
+                "destination": "左方向、{destination}方面、出口です",
+                "exit": "左方向、{exit} 出口です",
+                "exit_destination": "左方向、{destination} 方面、{exit}　出口です"
             },
             "sharp right": {
-                "default": "右方向のランプに向かう",
-                "name": "右方向のランプに向かい、{way_name}を進む",
-                "destination": "右方向のランプに向かい、{destination}へ向かう",
-                "exit": "右方向の{exit}出口を出る",
-                "exit_destination": "右方向の{exit}出口を出て{destination}へ向かう"
+                "default": "右方向、出口です",
+                "name": "右方向、{way_name}方面、出口です",
+                "destination": "右方向、{destination}方面、出口です",
+                "exit": "右方向、{exit} 出口です",
+                "exit_destination": "右方向、{destination} 方面、{exit}　出口です"
             },
             "slight left": {
-                "default": "左方向のランプへ向かう",
-                "name": "左方向のランプに向かい、{way_name}を進む",
-                "destination": "左方向のランプに向かい、その後{destination}へ向かう",
-                "exit": "左方向の{exit}出口を出る",
-                "exit_destination": "左方向の{exit}出口を出て{destination}へ向かう"
+                "default": "左方向、出口です",
+                "name": "左方向、{way_name}方面、出口です",
+                "destination": "左方向、{destination}方面、出口です",
+                "exit": "左方向、{exit} 出口です",
+                "exit_destination": "左方向、{destination} 方面、{exit}　出口です"
             },
             "slight right": {
-                "default": "右方向のランプへ向かう",
-                "name": "右方向のランプに向かい、{way_name}を進む",
-                "destination": "右方向のランプに向かい、その後{destination}へ向かう",
-                "exit": "右方向の{exit}出口を出る",
-                "exit_destination": "右方向の{exit}出口を出て{destination}へ向かう"
+                "default": "右方向、出口です",
+                "name": "右方向、{way_name}方面、出口です",
+                "destination": "右方向、{destination}方面、出口です",
+                "exit": "右方向、{exit} 出口です",
+                "exit_destination": "右方向、{destination} 方面、{exit}　出口です"
             }
         },
         "on ramp": {
             "default": {
-                "default": "ランプへ向かう",
-                "name": "ランプへ向かい、{way_name}を進む",
-                "destination": "ランプに向かい、その後{destination}へ向かう"
+                "default": "入口です",
+                "name": "{way_name}方面、入口です",
+                "destination": "{destination}方面、入口です"
             },
             "left": {
-                "default": "左方向のランプへ向かう",
-                "name": "左方向のランプに向かい、{way_name}を進む",
-                "destination": "左方向のランプに向かい、その後{destination}へ向かう"
+                "default": "左方向、入口です",
+                "name": "左方向、{way_name}方面、入口です",
+                "destination": "左方向、{destination}方面、入口です"
             },
             "right": {
-                "default": "右方向のランプへ向かう",
-                "name": "右方向のランプに向かい、{way_name}を進む",
-                "destination": "右方向のランプに向かい、その後{destination}へ向かう"
+                "default": "右方向、入口です",
+                "name": "右方向、{way_name}方面、入口です",
+                "destination": "右方向、{destination}方面、入口です"
             },
             "sharp left": {
-                "default": "左方向のランプへ向かう",
-                "name": "左方向のランプに向かい、{way_name}を進む",
-                "destination": "左方向のランプに向かい、その後{destination}へ向かう"
+                "default": "左方向、入口です",
+                "name": "左方向、{way_name}方面、入口です",
+                "destination": "左方向、{destination}方面、入口です"
             },
             "sharp right": {
-                "default": "右方向のランプへ向かう",
-                "name": "右方向のランプに向かい、{way_name}を進む",
-                "destination": "右方向のランプに向かい、その後{destination}へ向かう"
+                "default": "右方向、入口です",
+                "name": "右方向、{way_name}方面、入口です",
+                "destination": "右方向、{destination}方面、入口です"
             },
             "slight left": {
-                "default": "左方向のランプへ向かう",
-                "name": "左方向のランプに向かい、{way_name}を進む",
-                "destination": "左方向のランプに向かい、その後{destination}へ向かう"
+                "default": "左方向、入口です",
+                "name": "左方向、{way_name}方面、入口です",
+                "destination": "左方向、{destination}方面、入口です"
             },
             "slight right": {
-                "default": "右方向のランプへ向かう",
-                "name": "右方向のランプに向かい、{way_name}を進む",
-                "destination": "右方向のランプに向かい、その後{destination}へ向かう"
+                "default": "右方向、入口です",
+                "name": "右方向、{way_name}方面、入口です",
+                "destination": "右方向、{destination}方面、入口です"
             }
         },
         "rotary": {

--- a/languages/translations/ja.json
+++ b/languages/translations/ja.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "大きく左に曲がる",
                 "name": "大きく左に曲がり、{way_name}を進む",
-                "destination": "大きく左に曲がり、{destination}へ向かう"
+                "destination": "大きく左に曲がり、{destination}へ向かう",
+                "junction_name": "{junction_name}を左戻るです"
             },
             "sharp right": {
                 "default": "大きく右に曲がる",
                 "name": "大きく右に曲がり、{way_name}を進む",
-                "destination": "大きく右に曲がり、{destination}へ向かう"
+                "destination": "大きく右に曲がり、{destination}へ向かう",
+                "junction_name": "{junction_name}を右戻るです"
             },
             "slight left": {
                 "default": "斜め左に曲がる",
                 "name": "斜め左に曲がり、{way_name}を進む",
-                "destination": "斜め左に曲がり、{destination}へ向かう"
+                "destination": "斜め左に曲がり、{destination}へ向かう",
+                "junction_name": "{junction_name}を斜め左です"
             },
             "slight right": {
                 "default": "斜め右に曲がる",
                 "name": "斜め右に曲がり、{way_name}を進む",
-                "destination": "斜め右に曲がり、{destination}へ向かう"
+                "destination": "斜め右に曲がり、{destination}へ向かう",
+                "junction_name": "{junction_name}を斜め右です"
             },
             "uturn": {
                 "default": "Uターンする",
                 "name": "Uターンし、{way_name}を進む",
-                "destination": "Uターンし、{destination}へ向かう"
+                "destination": "Uターンし、{destination}へ向かう",
+                "junction_name": "{junction_name}をUターン"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "{modifier}に曲がる",
                 "name": "{modifier}に曲がり、{way_name}を進む",
-                "destination": "{modifier}に曲がり、{destination}へ向かう"
+                "destination": "{modifier}に曲がり、{destination}へ向かう",
+                "junction_name": "{junction_name}を{modifier}です"
             },
             "straight": {
                 "default": "直進する",
                 "name": "{way_name}を直進する",
-                "destination": "直進し、{destination}へ向かう"
+                "destination": "直進し、{destination}へ向かう",
+                "junction_name": "{junction_name}を直進です"
             },
             "uturn": {
                 "default": "突き当りでUターンする",
                 "name": "{way_name}の突き当りでUターンする",
-                "destination": "突き当たりでUターンし、{destination}へ向かう"
+                "destination": "突き当たりでUターンし、{destination}へ向かう",
+                "junction_name": "{junction_name}の突き当りでUターンする"
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "{modifier}に向かう",
                 "name": "{modifier}に向かい、{way_name}を進む",
-                "destination": "{modifier}に向かい、その後{destination}へ向かう"
+                "destination": "{modifier}に向かい、その後{destination}へ向かう",
+                "junction_name": "{junction_name}を{modifier}です"
             },
             "left": {
                 "default": "左折する",
                 "name": "左折して{way_name}を進む",
-                "destination": "左折して{destination}へ向かう"
+                "destination": "左折して{destination}へ向かう",
+                "junction_name": "{junction_name}を左折です"
             },
             "right": {
                 "default": "右折する",
                 "name": "右折して{way_name}を進む",
-                "destination": "右折して{destination}へ向かう"
+                "destination": "右折して{destination}へ向かう",
+                "junction_name": "{junction_name}を右折です"
             },
             "straight": {
                 "default": "直進する",
                 "name": "{way_name}を直進する",
-                "destination": "{destination}に向けて直進する"
+                "destination": "{destination}に向けて直進する",
+                "junction_name": "{junction_name}を直進です"
             }
         },
         "use lane": {

--- a/languages/translations/ko.json
+++ b/languages/translations/ko.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "급좌회전 하세요.",
                 "name": "급좌회전 하신 후 {way_name}로 가세요.",
-                "destination": "급좌회전 하신 후 {destination}로 가세요."
+                "destination": "급좌회전 하신 후 {destination}로 가세요.",
+                "junction_name": "{junction_name}에서 급좌회전."
             },
             "sharp right": {
                 "default": "급우회전 하세요.",
                 "name": "급우회전 하고 {way_name}로 가세요.",
-                "destination": "급우회전 하신 후 {destination}로 가세요."
+                "destination": "급우회전 하신 후 {destination}로 가세요.",
+                "junction_name": "{junction_name}에서 급우회전."
             },
             "slight left": {
                 "default": "약간 좌회전하세요.",
                 "name": "약간 좌회전 하고 {way_name}로 가세요.",
-                "destination": "약간 좌회전 하신 후 {destination}로 가세요."
+                "destination": "약간 좌회전 하신 후 {destination}로 가세요.",
+                "junction_name": "{junction_name}에서 약간 좌회전."
             },
             "slight right": {
                 "default": "약간 우회전하세요.",
                 "name": "약간 우회전 하고 {way_name}로 가세요.",
-                "destination": "약간 우회전 하신 후 {destination}로 가세요."
+                "destination": "약간 우회전 하신 후 {destination}로 가세요.",
+                "junction_name": "{junction_name}에서 약간 우회전."
             },
             "uturn": {
                 "default": "유턴 하세요",
                 "name": "유턴해서 {way_name}로 가세요.",
-                "destination": "유턴하신 후 {destination}로 가세요."
+                "destination": "유턴하신 후 {destination}로 가세요.",
+                "junction_name": "{junction_name}에서 유턴 하세요."
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "{modifier} 회전하세요.",
                 "name": "{modifier}회전하고 {way_name}로 가세요.",
-                "destination": "{modifier}회전 하신 후 {destination}로 가세요."
+                "destination": "{modifier}회전 하신 후 {destination}로 가세요.",
+                "junction_name": "{junction_name}에서 {modifier} 회전하세요."
             },
             "straight": {
                 "default": "계속 직진해 주세요.",
                 "name": "{way_name}로 계속 직진해 주세요.",
-                "destination": "{destination}까지 직진해 주세요."
+                "destination": "{destination}까지 직진해 주세요.",
+                "junction_name": "{junction_name}에서 계속 직진해 주세요."
             },
             "uturn": {
                 "default": "도로 끝까지 가서 유턴해 주세요.",
                 "name": "도로 끝까지 가서 유턴해서 {way_name}로 가세요.",
-                "destination": "도로 끝까지 가서 유턴해서 {destination} 까지 가세요."
+                "destination": "도로 끝까지 가서 유턴해서 {destination} 까지 가세요.",
+                "junction_name": "{junction_name}에서 유턴 하세요."
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "{modifier} 하세요.",
                 "name": "{modifier} 하시고 {way_name}로 가세요.",
-                "destination": "{modifier} 하시고 {destination}까지 가세요."
+                "destination": "{modifier} 하시고 {destination}까지 가세요.",
+                "junction_name": "{junction_name}에서 {modifier} 하세요."
             },
             "left": {
                 "default": "좌회전 하세요.",
                 "name": "좌회전 하시고 {way_name}로 가세요.",
-                "destination": "좌회전 하시고 {destination}까지 가세요."
+                "destination": "좌회전 하시고 {destination}까지 가세요.",
+                "junction_name": "{junction_name}에서 좌회전."
             },
             "right": {
                 "default": "우회전 하세요.",
                 "name": "우회전 하시고 {way_name}로 가세요.",
-                "destination": "우회전 하시고 {destination}까지 가세요."
+                "destination": "우회전 하시고 {destination}까지 가세요.",
+                "junction_name": "{junction_name}에서 우회전."
             },
             "straight": {
                 "default": "직진 하세요.",
                 "name": "직진하시고 {way_name}로 가세요.",
-                "destination": "직진하시고 {destination}까지 가세요."
+                "destination": "직진하시고 {destination}까지 가세요.",
+                "junction_name": "{junction_name}에서 직진 하세요."
             }
         },
         "use lane": {

--- a/languages/translations/my.json
+++ b/languages/translations/my.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "ဘယ်ဘက်ထောင့်ချိုးကွေ့ပါ",
                 "name": "{way_name}ပေါ်တွင်နေရန် ဘယ်ဘက်ထောင့်ချိုးကွေ့ပါ",
-                "destination": "{destination}ဆီသို့ ဘယ်ဘက်ထောင့်ချိုးကွေ့ပါ"
+                "destination": "{destination}ဆီသို့ ဘယ်ဘက်ထောင့်ချိုးကွေ့ပါ",
+                "junction_name": "{junction_name}ပေါ်တွင်နေရန် ဘယ်ဘက်ထောင့်ချိုးကွေ့ပါ"
             },
             "sharp right": {
                 "default": "ညာဘက် ထောင့်ချိုးကွေ့ပါ",
                 "name": "{way_name}ပေါ်တွင်နေရန် ညာဘက်ထောင့်ချိုးကွေ့ပါ",
-                "destination": "{destination}ဆီသို့ ညာဘက်ထောင့်ချိုးကွေ့ပါ"
+                "destination": "{destination}ဆီသို့ ညာဘက်ထောင့်ချိုးကွေ့ပါ",
+                "junction_name": "{junction_name}ပေါ်တွင်နေရန် ညာဘက်ထောင့်ချိုးကွေ့ပါ"
             },
             "slight left": {
                 "default": "ဘယ်ဘက် အနည်းငယ်ကွေ့ပါ",
                 "name": "{way_name}ပေါ်တွင်နေရန် ဘယ်ဘက်အနည်းငယ်ကွေ့ပါ",
-                "destination": "{destination}ဆီသို့ ဘယ်ဘက်အနည်းငယ်ချိုးကွေ့ပါ"
+                "destination": "{destination}ဆီသို့ ဘယ်ဘက်အနည်းငယ်ချိုးကွေ့ပါ",
+                "junction_name": "{junction_name}ပေါ်တွင်နေရန် ဘယ်ဘက်အနည်းငယ်ကွေ့ပါ"
             },
             "slight right": {
                 "default": "ညာဘက် အနည်းငယ်ချိုးကွေ့ပါ",
                 "name": "{way_name}ပေါ်တွင်နေရန် ညာဘက်အနည်းငယ်ကွေ့ပါ",
-                "destination": "{destination}ဆီသို့ ညာဘက်အနည်းငယ်ချိုးကွေ့ပါ"
+                "destination": "{destination}ဆီသို့ ညာဘက်အနည်းငယ်ချိုးကွေ့ပါ",
+                "junction_name": "{junction_name}ပေါ်တွင်နေရန် ညာဘက်အနည်းငယ်ကွေ့ပါ"
             },
             "uturn": {
                 "default": "ဂ-ကွေ့ ကွေ့ပါ",
                 "name": "{way_name}လမ်းဘက်သို့ ဂ-ကွေ့ကွေ့ပြီးဆက်သွားပါ",
-                "destination": "{destination}ဆီသို့ ဂကွေ့ချိုးကွေ့ပါ"
+                "destination": "{destination}ဆီသို့ ဂကွေ့ချိုးကွေ့ပါ",
+                "junction_name": "{junction_name}လမ်းဘက်သို့ ဂ-ကွေ့ကွေ့ပြီးဆက်သွားပါ"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "{modifier}သို့လှည့်ပါ",
                 "name": "{way_name}​ပေါ်သို့ {modifier}ကိုလှည့်ပါ",
-                "destination": "{destination}ဆီသို့ {modifier}ကို လှည့်ပါ"
+                "destination": "{destination}ဆီသို့ {modifier}ကို လှည့်ပါ",
+                "junction_name": "{junction_name}​ပေါ်သို့ {modifier}ကိုလှည့်ပါ"
             },
             "straight": {
                 "default": "ဖြောင့်ဖြောင့်တန်းတန်း ဆက်သွားပါ",
                 "name": "{way_name}​ပေါ်သို့တည့်တည့်ဆက်သွားပါ",
-                "destination": "{destination}ဆီသို့တည့်တည့်ဆက်သွားပါ"
+                "destination": "{destination}ဆီသို့တည့်တည့်ဆက်သွားပါ",
+                "junction_name": "{junction_name}​ပေါ်သို့တည့်တည့်ဆက်သွားပါ"
             },
             "uturn": {
                 "default": "လမ်းအဆုံးတွင် ဂ-ကွေ့ကွေ့ပါ",
                 "name": "လမ်းအဆုံးတွင် {way_name}​ပေါ်သို့ဂ-ကွေ့ကွေ့ပါ",
-                "destination": "လမ်းအဆုံးတွင်{destination}ဆီသို့ ဂကွေ့ချိုးကွေ့ပါ"
+                "destination": "လမ်းအဆုံးတွင်{destination}ဆီသို့ ဂကွေ့ချိုးကွေ့ပါ",
+                "junction_name": "လမ်းအဆုံးတွင် {junction_name}​ပေါ်သို့ဂ-ကွေ့ကွေ့ပါ"
             }
         },
         "fork": {
@@ -462,23 +470,27 @@
         "turn": {
             "default": {
                 "default": "{modifier}ကိုလှည့်ပါ",
-                "name": "{modifier}ပေါ်သို့{way_name}ကိုဆက်သွားပါ ",
-                "destination": "{modifier}ဆီသို့{destination}ကို ဆက်သွားပါ "
+                "name": "{modifier}ပေါ်သို့{way_name}ကိုဆက်သွားပါ",
+                "destination": "{modifier}ဆီသို့{destination}ကို ဆက်သွားပါ ",
+                "junction_name": "{modifier}ပေါ်သို့{junction_name}ကိုဆက်သွားပါ"
             },
             "left": {
                 "default": "ဘယ်ဘက်သို့ပြန်လှည့်ပါ",
-                "name": "{way_name}ပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ ",
-                "destination": "{destination}ဘယ်ဘက်သို့ ကွေ့ပါ"
+                "name": "{way_name}ပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ",
+                "destination": "{destination}ဘယ်ဘက်သို့ ကွေ့ပါ",
+                "junction_name": "{junction_name}ပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ"
             },
             "right": {
                 "default": "ညာဘက်သို့ပြန်လှည့်ပါ",
-                "name": "{way_name}ပေါ်သို့ညာဘက်ကိုလာရောက်ပေါင်းဆုံပါ ",
-                "destination": "{destination}ညာဘက်သို့ ကွေ့ပါ"
+                "name": "{way_name}ပေါ်သို့ညာဘက်ကိုလာရောက်ပေါင်းဆုံပါ",
+                "destination": "{destination}ညာဘက်သို့ ကွေ့ပါ",
+                "junction_name": "{junction_name}ပေါ်သို့ညာဘက်ကိုလာရောက်ပေါင်းဆုံပါ"
             },
             "straight": {
                 "default": "တည့်တည့်သွားပါ",
                 "name": "{way_name}ပေါ်သို့တည့်တည့်သွားပါ",
-                "destination": "{destination}ဆီသို့တည့်တည့်သွားပါ"
+                "destination": "{destination}ဆီသို့တည့်တည့်သွားပါ",
+                "junction_name": "{junction_name}ပေါ်သို့တည့်တည့်သွားပါ"
             }
         },
         "use lane": {

--- a/languages/translations/nl.json
+++ b/languages/translations/nl.json
@@ -77,7 +77,7 @@
                 "upcoming": "Uw {nth} bestemming bevindt zich aan de rechterkant",
                 "short": "U bent gearriveerd",
                 "short-upcoming": "U zult aankomen",
-                "named": "U bent gearriveerd bij {waypoint_name}, de bestemming is aan de  rechterkant"
+                "named": "U bent gearriveerd bij {waypoint_name}, de bestemming is aan de rechterkant"
             },
             "sharp left": {
                 "default": "Je bent gearriveerd. De {nth} bestemming bevindt zich links.",
@@ -91,21 +91,21 @@
                 "upcoming": "Uw {nth} bestemming bevindt zich aan de rechterkant",
                 "short": "U bent gearriveerd",
                 "short-upcoming": "U zult aankomen",
-                "named": "U bent gearriveerd bij {waypoint_name},  de bestemming is aan de rechterkant"
+                "named": "U bent gearriveerd bij {waypoint_name}, de bestemming is aan de rechterkant"
             },
             "slight right": {
                 "default": "Je bent gearriveerd. De {nth} bestemming bevindt zich rechts.",
                 "upcoming": "Uw {nth} bestemming bevindt zich aan de rechterkant",
                 "short": "U bent gearriveerd",
                 "short-upcoming": "U zult aankomen",
-                "named": "U bent gearriveerd bij {waypoint_name},  de bestemming is aan de rechterkant"
+                "named": "U bent gearriveerd bij {waypoint_name}, de bestemming is aan de rechterkant"
             },
             "slight left": {
                 "default": "Je bent gearriveerd. De {nth} bestemming bevindt zich links.",
                 "upcoming": "Uw {nth} bestemming bevindt zich aan de linkerkant",
                 "short": "U bent gearriveerd",
                 "short-upcoming": "U zult aankomen",
-                "named": "U bent gearriveerd bij {waypoint_name},  de bestemming is aan de linkerkant"
+                "named": "U bent gearriveerd bij {waypoint_name}, de bestemming is aan de linkerkant"
             },
             "straight": {
                 "default": "Je bent gearriveerd. De {nth} bestemming bevindt zich voor je.",
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Linksaf",
                 "name": "Sla scherp links af om op {way_name} te blijven",
-                "destination": "Linksaf richting {destination}"
+                "destination": "Linksaf richting {destination}",
+                "junction_name": "Linksaf bij {junction_name}"
             },
             "sharp right": {
                 "default": "Rechtsaf",
                 "name": "Sla scherp rechts af om op {way_name} te blijven",
-                "destination": "Rechtsaf richting {destination}"
+                "destination": "Rechtsaf richting {destination}",
+                "junction_name": "Rechtsaf bij {junction_name}"
             },
             "slight left": {
                 "default": "Ga links",
                 "name": "Links afbuigen om op {way_name} te blijven",
-                "destination": "Rechts afbuigen om op {destination} te blijven"
+                "destination": "Rechts afbuigen om op {destination} te blijven",
+                "junction_name": "Ga links bij {junction_name}"
             },
             "slight right": {
                 "default": "Rechts afbuigen",
                 "name": "Rechts afbuigen om op {way_name} te blijven",
-                "destination": "Rechts afbuigen richting {destination}"
+                "destination": "Rechts afbuigen richting {destination}",
+                "junction_name": "Rechts afbuigen bij {junction_name}"
             },
             "uturn": {
                 "default": "Keer om",
                 "name": "Draai om en ga verder op {way_name}",
-                "destination": "Keer om richting {destination}"
+                "destination": "Keer om richting {destination}",
+                "junction_name": "Keer om bij {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Ga {modifier}",
                 "name": "Ga {modifier} naar {way_name}",
-                "destination": "Ga {modifier} richting {destination}"
+                "destination": "Ga {modifier} richting {destination}",
+                "junction_name": "Ga {modifier} bij {junction_name}"
             },
             "straight": {
                 "default": "Ga in de aangegeven richting",
                 "name": "Ga naar {way_name}",
-                "destination": "Ga richting {destination}"
+                "destination": "Ga richting {destination}",
+                "junction_name": "Ga rechtdoor bij {junction_name}"
             },
             "uturn": {
                 "default": "Keer om",
                 "name": "Keer om naar {way_name}",
-                "destination": "Keer om richting {destination}"
+                "destination": "Keer om richting {destination}",
+                "junction_name": "Keer om bij {junction_name}"
             }
         },
         "fork": {
@@ -201,7 +209,7 @@
                 "destination": "Neem een scherpe bocht naar links, richting {destination}"
             },
             "sharp right": {
-                "default": "Neem  op de splitsing, een scherpe bocht, naar rechts",
+                "default": "Neem op de splitsing, een scherpe bocht, naar rechts",
                 "name": "Neem een scherpe bocht naar rechts, tot aan {way_name}",
                 "destination": "Neem een scherpe bocht naar rechts, richting {destination}"
             },
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Ga {modifier}",
                 "name": "Ga {modifier} naar {way_name}",
-                "destination": "Ga {modifier} richting {destination}"
+                "destination": "Ga {modifier} richting {destination}",
+                "junction_name": "Ga {modifier} bij {junction_name}"
             },
             "left": {
                 "default": "Ga linksaf",
                 "name": "Ga linksaf naar {way_name}",
-                "destination": "Ga linksaf richting {destination}"
+                "destination": "Ga linksaf richting {destination}",
+                "junction_name": "Ga linksaf bij {junction_name}"
             },
             "right": {
                 "default": "Ga rechtsaf",
                 "name": "Ga rechtsaf naar {way_name}",
-                "destination": "Ga rechtsaf richting {destination}"
+                "destination": "Ga rechtsaf richting {destination}",
+                "junction_name": "Ga rechtsaf bij {junction_name}"
             },
             "straight": {
                 "default": "Ga rechtdoor",
                 "name": "Ga rechtdoor naar {way_name}",
-                "destination": "Ga rechtdoor richting {destination}"
+                "destination": "Ga rechtdoor richting {destination}",
+                "junction_name": "Ga rechtdoor bij {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/no.json
+++ b/languages/translations/no.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Sving skarpt til venstre",
                 "name": "Sving skarpt til venstre for å bli værende på {way_name}",
-                "destination": "Sving skarpt til venstre mot {destination}"
+                "destination": "Sving skarpt til venstre mot {destination}",
+                "junction_name": "Sving skarpt til venstre i {junction_name}"
             },
             "sharp right": {
                 "default": "Sving skarpt til høyre",
                 "name": "Sving skarpt til høyre for å bli værende på {way_name}",
-                "destination": "Sving skarpt mot {destination}"
+                "destination": "Sving skarpt mot {destination}",
+                "junction_name": "Sving skarpt til høyre i {junction_name}"
             },
             "slight left": {
                 "default": "Sving svakt til venstre",
                 "name": "Sving svakt til venstre for å bli værende på {way_name}",
-                "destination": "Sving svakt til venstre mot {destination}"
+                "destination": "Sving svakt til venstre mot {destination}",
+                "junction_name": "Sving svakt til venstre i {junction_name}"
             },
             "slight right": {
                 "default": "Sving svakt til høyre",
                 "name": "Sving svakt til høyre for å bli værende på {way_name}",
-                "destination": "Sving svakt til høyre mot {destination}"
+                "destination": "Sving svakt til høyre mot {destination}",
+                "junction_name": "Sving svakt til høyre i {junction_name}"
             },
             "uturn": {
                 "default": "Ta en U-sving",
                 "name": "Ta en U-sving og fortsett på {way_name}",
-                "destination": "Ta en U-sving mot {destination}"
+                "destination": "Ta en U-sving mot {destination}",
+                "junction_name": "Ta en U-sving i {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Sving {modifier}",
                 "name": "Ta til {modifier} inn på {way_name}",
-                "destination": "Sving {modifier} mot {destination}"
+                "destination": "Sving {modifier} mot {destination}",
+                "junction_name": "Sving {modifier} i {junction_name}"
             },
             "straight": {
                 "default": "Fortsett rett frem",
-                "name": "Fortsett rett frem til  {way_name}",
-                "destination": "Fortsett rett frem mot {destination}"
+                "name": "Fortsett rett frem til {way_name}",
+                "destination": "Fortsett rett frem mot {destination}",
+                "junction_name": "Fortsett rett frem i {junction_name}"
             },
             "uturn": {
                 "default": "Ta en U-sving i enden av veien",
                 "name": "Ta en U-sving til {way_name} i enden av veien",
-                "destination": "Ta en U-sving mot {destination} i enden av veien"
+                "destination": "Ta en U-sving mot {destination} i enden av veien",
+                "junction_name": "Ta en U-sving i {junction_name}"
             }
         },
         "fork": {
@@ -252,7 +260,7 @@
             "default": {
                 "default": "Fortsett {modifier}",
                 "name": "Fortsett {modifier} til {way_name}",
-                "destination": "Fortsett {modifier} mot  {destination}"
+                "destination": "Fortsett {modifier} mot {destination}"
             },
             "straight": {
                 "default": "Fortsett rett frem",
@@ -289,7 +297,7 @@
             "default": {
                 "default": "Fortsett {modifier}",
                 "name": "Fortsett {modifier} til {way_name}",
-                "destination": "Fortsett {modifier} mot  {destination}"
+                "destination": "Fortsett {modifier} mot {destination}"
             },
             "uturn": {
                 "default": "Ta en U-sving",
@@ -441,7 +449,7 @@
             },
             "straight": {
                 "default": "Fortsett rett frem",
-                "name": "Fortsett rett frem til  {way_name}",
+                "name": "Fortsett rett frem til {way_name}",
                 "destination": "Fortsett rett frem mot {destination}"
             }
         },
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Ta en {modifier}",
                 "name": "Ta en {modifier} inn på {way_name}",
-                "destination": "Ta en {modifier} mot {destination}"
+                "destination": "Ta en {modifier} mot {destination}",
+                "junction_name": "Ta en {modifier} i {junction_name}"
             },
             "left": {
                 "default": "Sving til venstre",
                 "name": "Sving til venstre inn på {way_name}",
-                "destination": "Sving til venstre mot {destination}"
+                "destination": "Sving til venstre mot {destination}",
+                "junction_name": "Sving til venstre i {junction_name}"
             },
             "right": {
                 "default": "Sving til høyre",
                 "name": "Sving til høyre inn på {way_name}",
-                "destination": "Sving til høyre mot {destination}"
+                "destination": "Sving til høyre mot {destination}",
+                "junction_name": "Sving til høyre i {junction_name}"
             },
             "straight": {
                 "default": "Kjør rett frem",
                 "name": "Kjør rett frem og inn på {way_name}",
-                "destination": "Kjør rett frem mot {destination}"
+                "destination": "Kjør rett frem mot {destination}",
+                "junction_name": "Kjør rett frem i {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/pl.json
+++ b/languages/translations/pl.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Skręć ostro w lewo",
                 "name": "Skręć w lewo w ostry zakręt, aby pozostać na {way_name}",
-                "destination": "Skręć ostro w lewo w kierunku {destination}"
+                "destination": "Skręć ostro w lewo w kierunku {destination}",
+                "junction_name": "Skręć ostro w lewo na {junction_name}"
             },
             "sharp right": {
                 "default": "Skręć ostro w prawo",
                 "name": "Skręć w prawo w ostry zakręt, aby pozostać na {way_name}",
-                "destination": "Skręć ostro w prawo w kierunku {destination}"
+                "destination": "Skręć ostro w prawo w kierunku {destination}",
+                "junction_name": "Skręć ostro w prawo na {junction_name}"
             },
             "slight left": {
                 "default": "Skręć w lewo w łagodny zakręt",
                 "name": "Skręć w lewo w łagodny zakręt, aby pozostać na {way_name}",
-                "destination": "Skręć w lewo w łagodny zakręt na {destination}"
+                "destination": "Skręć w lewo w łagodny zakręt na {destination}",
+                "junction_name": "Skręć w lewo w łagodny zakręt na {junction_name}"
             },
             "slight right": {
                 "default": "Skręć w prawo w łagodny zakręt",
                 "name": "Skręć w prawo w łagodny zakręt, aby pozostać na {way_name}",
-                "destination": "Skręć w prawo w łagodny zakręt na {destination}"
+                "destination": "Skręć w prawo w łagodny zakręt na {destination}",
+                "junction_name": "Skręć w prawo w łagodny zakręt na {junction_name}"
             },
             "uturn": {
                 "default": "Zawróć",
                 "name": "Zawróć i jedź dalej {way_name}",
-                "destination": "Zawróć w kierunku {destination}"
+                "destination": "Zawróć w kierunku {destination}",
+                "junction_name": "Zawróć na {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Skręć {modifier}",
                 "name": "Skręć {modifier} na {way_name}",
-                "destination": "Skręć {modifier} w kierunku {destination}"
+                "destination": "Skręć {modifier} w kierunku {destination}",
+                "junction_name": "Skręć {modifier} na {junction_name}"
             },
             "straight": {
                 "default": "Kontynuuj prosto",
                 "name": "Kontynuuj prosto na {way_name}",
-                "destination": "Kontynuuj prosto w kierunku {destination}"
+                "destination": "Kontynuuj prosto w kierunku {destination}",
+                "junction_name": "Kontynuuj prosto na {junction_name}"
             },
             "uturn": {
                 "default": "Zawróć na końcu ulicy",
                 "name": "Zawróć na końcu ulicy na {way_name}",
-                "destination": "Zawróć na końcu ulicy w kierunku {destination}"
+                "destination": "Zawróć na końcu ulicy w kierunku {destination}",
+                "junction_name": "Zawróć na {junction_name}"
             }
         },
         "fork": {
@@ -493,22 +501,26 @@
             "default": {
                 "default": "{modifier}",
                 "name": "{modifier} na {way_name}",
-                "destination": "{modifier} w kierunku {destination}"
+                "destination": "{modifier} w kierunku {destination}",
+                "junction_name": "{modifier} na {junction_name}"
             },
             "left": {
                 "default": "Skręć w lewo",
                 "name": "Skręć w lewo na {way_name}",
-                "destination": "Skręć w lewo w kierunku {destination}"
+                "destination": "Skręć w lewo w kierunku {destination}",
+                "junction_name": "Skręć w lewo na {junction_name}"
             },
             "right": {
                 "default": "Skręć w prawo",
                 "name": "Skręć w prawo na {way_name}",
-                "destination": "Skręć w prawo w kierunku {destination}"
+                "destination": "Skręć w prawo w kierunku {destination}",
+                "junction_name": "Skręć w prawo na {junction_name}"
             },
             "straight": {
                 "default": "Jedź prosto",
                 "name": "Jedź prosto na {way_name}",
-                "destination": "Jedź prosto w kierunku {destination}"
+                "destination": "Jedź prosto w kierunku {destination}",
+                "junction_name": "Jedź prosto na {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/pt-BR.json
+++ b/languages/translations/pt-BR.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Faça uma curva fechada a esquerda",
                 "name": "Faça uma curva fechada a esquerda para manter-se na {way_name}",
-                "destination": "Faça uma curva fechada a esquerda sentido {destination}"
+                "destination": "Faça uma curva fechada a esquerda sentido {destination}",
+                "junction_name": "Faça uma curva fechada a esquerda em {junction_name}"
             },
             "sharp right": {
                 "default": "Faça uma curva fechada a direita",
                 "name": "Faça uma curva fechada a direita para manter-se na {way_name}",
-                "destination": "Faça uma curva fechada a direita sentido {destination}"
+                "destination": "Faça uma curva fechada a direita sentido {destination}",
+                "junction_name": "Faça uma curva fechada a direita em {junction_name}"
             },
             "slight left": {
                 "default": "Faça uma curva suave a esquerda",
                 "name": "Faça uma curva suave a esquerda para manter-se na {way_name}",
-                "destination": "Faça uma curva suave a esquerda em direção a {destination}"
+                "destination": "Faça uma curva suave a esquerda em direção a {destination}",
+                "junction_name": "Faça uma curva suave a esquerda em {junction_name}"
             },
             "slight right": {
                 "default": "Faça uma curva suave a direita",
                 "name": "Faça uma curva suave a direita para manter-se na {way_name}",
-                "destination": "Faça uma curva suave a direita em direção a {destination}"
+                "destination": "Faça uma curva suave a direita em direção a {destination}",
+                "junction_name": "Faça uma curva suave a direita em {junction_name}"
             },
             "uturn": {
                 "default": "Faça o retorno",
                 "name": "Faça o retorno e continue em {way_name}",
-                "destination": "Faça o retorno sentido {destination}"
+                "destination": "Faça o retorno sentido {destination}",
+                "junction_name": "Faça o retorno em {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Vire {modifier}",
                 "name": "Vire {modifier} em {way_name}",
-                "destination": "Vire {modifier} sentido {destination}"
+                "destination": "Vire {modifier} sentido {destination}",
+                "junction_name": "Vire {modifier} em {junction_name}"
             },
             "straight": {
                 "default": "Continue em frente",
                 "name": "Continue em frente em {way_name}",
-                "destination": "Continue em frente sentido {destination}"
+                "destination": "Continue em frente sentido {destination}",
+                "junction_name": "Continue em frente em {junction_name}"
             },
             "uturn": {
                 "default": "Faça o retorno no fim da rua",
                 "name": "Faça o retorno em {way_name} no fim da rua",
-                "destination": "Faça o retorno sentido {destination} no fim da rua"
+                "destination": "Faça o retorno sentido {destination} no fim da rua",
+                "junction_name": "Faça o retorno em {junction_name}"
             }
         },
         "fork": {
@@ -310,7 +318,7 @@
                 "name": "Pegue a rampa à esquerda em {way_name}",
                 "destination": "Pegue a rampa à esquerda sentido {destination}",
                 "exit": "Pegue a saída {exit} à esquerda",
-                "exit_destination": "Pegue a saída {exit}  à esquerda em direção à {destination}"
+                "exit_destination": "Pegue a saída {exit} à esquerda em direção à {destination}"
             },
             "right": {
                 "default": "Pegue a rampa à direita",
@@ -324,7 +332,7 @@
                 "name": "Pegue a rampa à esquerda em {way_name}",
                 "destination": "Pegue a rampa à esquerda sentido {destination}",
                 "exit": "Pegue a saída {exit} à esquerda",
-                "exit_destination": "Pegue a saída {exit}  à esquerda em direção à {destination}"
+                "exit_destination": "Pegue a saída {exit} à esquerda em direção à {destination}"
             },
             "sharp right": {
                 "default": "Pegue a rampa à direita",
@@ -338,7 +346,7 @@
                 "name": "Pegue a rampa à esquerda em {way_name}",
                 "destination": "Pegue a rampa à esquerda sentido {destination}",
                 "exit": "Pegue a saída {exit} à esquerda",
-                "exit_destination": "Pegue a saída {exit}  à esquerda em direção à {destination}"
+                "exit_destination": "Pegue a saída {exit} à esquerda em direção à {destination}"
             },
             "slight right": {
                 "default": "Pegue a rampa à direita",
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Siga {modifier}",
                 "name": "Siga {modifier} em {way_name}",
-                "destination": "Siga {modifier} sentido {destination}"
+                "destination": "Siga {modifier} sentido {destination}",
+                "junction_name": "Siga {modifier} em {junction_name}"
             },
             "left": {
                 "default": "Vire à esquerda",
                 "name": "Vire à esquerda em {way_name}",
-                "destination": "Vire à esquerda sentido {destination}"
+                "destination": "Vire à esquerda sentido {destination}",
+                "junction_name": "Vire à esquerda em {junction_name}"
             },
             "right": {
                 "default": "Vire à direita",
                 "name": "Vire à direita em {way_name}",
-                "destination": "Vire à direita sentido {destination}"
+                "destination": "Vire à direita sentido {destination}",
+                "junction_name": "Vire à direita em {junction_name}"
             },
             "straight": {
                 "default": "Siga em frente",
                 "name": "Siga em frente em {way_name}",
-                "destination": "Siga em frente sentido {destination}"
+                "destination": "Siga em frente sentido {destination}",
+                "junction_name": "Siga em frente em {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/pt-PT.json
+++ b/languages/translations/pt-PT.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Vire acentuadamente à esquerda",
                 "name": "Vire acentuadamente à esquerda para se manter em {way_name}",
-                "destination": "Vire acentuadamente à esquerda em direção a {destination}"
+                "destination": "Vire acentuadamente à esquerda em direção a {destination}",
+                "junction_name": "Vire acentuadamente à esquerda em {junction_name}"
             },
             "sharp right": {
                 "default": "Vire acentuadamente à direita",
                 "name": "Vire acentuadamente à direita para se manter em {way_name}",
-                "destination": "Vire acentuadamente à direita em direção a {destination}"
+                "destination": "Vire acentuadamente à direita em direção a {destination}",
+                "junction_name": "Vire acentuadamente à direita em {junction_name}"
             },
             "slight left": {
                 "default": "Vire ligeiramente à esquerda",
                 "name": "Vire ligeiramente à esquerda para se manter em {way_name}",
-                "destination": "Vire ligeiramente à esquerda em direção a {destination}"
+                "destination": "Vire ligeiramente à esquerda em direção a {destination}",
+                "junction_name": "Vire ligeiramente à esquerda em {junction_name}"
             },
             "slight right": {
                 "default": "Vire ligeiramente à direita",
                 "name": "Vire ligeiramente à direita para se manter em {way_name}",
-                "destination": "Vire ligeiramente à direita em direção a {destination}"
+                "destination": "Vire ligeiramente à direita em direção a {destination}",
+                "junction_name": "Vire ligeiramente à direita em {junction_name}"
             },
             "uturn": {
                 "default": "Faça inversão de marcha",
                 "name": "Faça inversão de marcha e continue em {way_name}",
-                "destination": "Faça inversão de marcha em direção a {destination}"
+                "destination": "Faça inversão de marcha em direção a {destination}",
+                "junction_name": "Faça inversão de marcha em {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Vire {modifier}",
                 "name": "Vire {modifier} para {way_name}",
-                "destination": "Vire {modifier} em direção a {destination}"
+                "destination": "Vire {modifier} em direção a {destination}",
+                "junction_name": "Vire {modifier} em {junction_name}"
             },
             "straight": {
                 "default": "Continue em frente",
                 "name": "Continue em frente para {way_name}",
-                "destination": "Continue em frente em direção a {destination}"
+                "destination": "Continue em frente em direção a {destination}",
+                "junction_name": "Continue em frente em {junction_name}"
             },
             "uturn": {
                 "default": "No final da estrada faça uma inversão de marcha",
                 "name": "No final da estrada faça uma inversão de marcha para {way_name} ",
-                "destination": "No final da estrada faça uma inversão de marcha em direção a {destination}"
+                "destination": "No final da estrada faça uma inversão de marcha em direção a {destination}",
+                "junction_name": "Faça uma inversão de marcha em {junction_name}"
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Siga {modifier}",
                 "name": "Siga {modifier} para{way_name}",
-                "destination": "Siga {modifier} em direção a {destination}"
+                "destination": "Siga {modifier} em direção a {destination}",
+                "junction_name": "Siga {modifier} em {junction_name}"
             },
             "left": {
                 "default": "Vire à esquerda",
                 "name": "Vire à esquerda para {way_name}",
-                "destination": "Vire à esquerda em direção a {destination}"
+                "destination": "Vire à esquerda em direção a {destination}",
+                "junction_name": "Vire à esquerda em {junction_name}"
             },
             "right": {
                 "default": "Vire à direita",
                 "name": "Vire à direita para {way_name}",
-                "destination": "Vire à direita em direção a {destination}"
+                "destination": "Vire à direita em direção a {destination}",
+                "junction_name": "Vire à direita em {junction_name}"
             },
             "straight": {
                 "default": "Vá em frente",
                 "name": "Vá em frente para {way_name}",
-                "destination": "Vá em frente em direção a {destination}"
+                "destination": "Vá em frente em direção a {destination}",
+                "junction_name": "Vá em frente em {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/ro.json
+++ b/languages/translations/ro.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Virați puternic la stânga",
                 "name": "Virați puternic la stânga pe {way_name}",
-                "destination": "Virați puternic la stânga spre {destination}"
+                "destination": "Virați puternic la stânga spre {destination}",
+                "junction_name": "Virați puternic la stânga la {junction_name}"
             },
             "sharp right": {
                 "default": "Virați puternic la dreapta",
                 "name": "Virați puternic la dreapta pe {way_name}",
-                "destination": "Virați puternic la dreapta spre {destination}"
+                "destination": "Virați puternic la dreapta spre {destination}",
+                "junction_name": "Virați puternic la dreapta la {junction_name}"
             },
             "slight left": {
                 "default": "Virați ușor la stânga",
                 "name": "Virați ușor la stânga pe {way_name}",
-                "destination": "Virați ușor la stânga spre {destination}"
+                "destination": "Virați ușor la stânga spre {destination}",
+                "junction_name": "Virați ușor la stânga la {junction_name}"
             },
             "slight right": {
                 "default": "Virați ușor la dreapta",
                 "name": "Virați ușor la dreapta pe {way_name}",
-                "destination": "Virați ușor la dreapta spre {destination}"
+                "destination": "Virați ușor la dreapta spre {destination}",
+                "junction_name": "Virați ușor la dreapta la {junction_name}"
             },
             "uturn": {
                 "default": "Întoarceți-vă",
                 "name": "Întoarceți-vă și continuați pe {way_name}",
-                "destination": "Întoarceți-vă spre {destination}"
+                "destination": "Întoarceți-vă spre {destination}",
+                "junction_name": "Întoarceți-vă la {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Virați {modifier}",
                 "name": "Virați {modifier} pe {way_name}",
-                "destination": "Virați {modifier} spre {destination}"
+                "destination": "Virați {modifier} spre {destination}",
+                "junction_name": "Virați {modifier} la {junction_name}"
             },
             "straight": {
                 "default": "Continuați înainte",
                 "name": "Continuați înainte pe {way_name}",
-                "destination": "Continuați înainte spre {destination}"
+                "destination": "Continuați înainte spre {destination}",
+                "junction_name": "Continuați înainte la {junction_name}"
             },
             "uturn": {
                 "default": "Întoarceți-vă la sfârșitul drumului",
                 "name": "Întoarceți-vă pe {way_name} la sfârșitul drumului",
-                "destination": "Întoarceți-vă spre {destination} la sfârșitul drumului"
+                "destination": "Întoarceți-vă spre {destination} la sfârșitul drumului",
+                "junction_name": "Întoarceți-vă la {junction_name}"
             }
         },
         "fork": {
@@ -405,7 +413,7 @@
                 "name_exit": {
                     "default": "Intrați în {rotary_name} și urmați {exit_number} ieșire",
                     "name": "Intrați în {rotary_name} și urmați {exit_number} ieșire pe {way_name}",
-                    "destination": "Intrați în  {rotary_name} și urmați {exit_number} ieșire spre {destination}"
+                    "destination": "Intrați în {rotary_name} și urmați {exit_number} ieșire spre {destination}"
                 }
             }
         },
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Virați {modifier}",
                 "name": "Virați {modifier} pe {way_name}",
-                "destination": "Virați {modifier} spre {destination}"
+                "destination": "Virați {modifier} spre {destination}",
+                "junction_name": "Virați {modifier} la {junction_name}"
             },
             "left": {
                 "default": "Virați la stânga",
                 "name": "Virați la stânga pe {way_name}",
-                "destination": "Virați la stânga spre {destination}"
+                "destination": "Virați la stânga spre {destination}",
+                "junction_name": "Virați la stânga la {junction_name}"
             },
             "right": {
                 "default": "Virați la dreapta",
                 "name": "Virați la dreapta pe {way_name}",
-                "destination": "Virați la dreapta spre {destination}"
+                "destination": "Virați la dreapta spre {destination}",
+                "junction_name": "Virați la dreapta la {junction_name}"
             },
             "straight": {
                 "default": "Mergeți înainte",
                 "name": "Mergeți înainte pe {way_name}",
-                "destination": "Mergeți înainte spre {destination}"
+                "destination": "Mergeți înainte spre {destination}",
+                "junction_name": "Mergeți înainte la {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/ru.json
+++ b/languages/translations/ru.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Резко поверните налево",
                 "name": "Резко поверните налево на {way_name:accusative}",
-                "destination": "Резко поверните налево в направлении {destination}"
+                "destination": "Резко поверните налево в направлении {destination}",
+                "junction_name": "Резко поверните налево на {junction_name}"
             },
             "sharp right": {
                 "default": "Резко поверните направо",
                 "name": "Резко поверните направо на {way_name:accusative}",
-                "destination": "Резко поверните направо в направлении {destination}"
+                "destination": "Резко поверните направо в направлении {destination}",
+                "junction_name": "Резко поверните направо на {junction_name}"
             },
             "slight left": {
                 "default": "Плавно поверните налево",
                 "name": "Плавно поверните налево на {way_name:accusative}",
-                "destination": "Плавно поверните налево в направлении {destination}"
+                "destination": "Плавно поверните налево в направлении {destination}",
+                "junction_name": "Плавно поверните налево на {junction_name}"
             },
             "slight right": {
                 "default": "Плавно поверните направо",
                 "name": "Плавно поверните направо на {way_name:accusative}",
-                "destination": "Плавно поверните направо в направлении {destination}"
+                "destination": "Плавно поверните направо в направлении {destination}",
+                "junction_name": "Плавно поверните направо на {junction_name}"
             },
             "uturn": {
                 "default": "Развернитесь",
                 "name": "Развернитесь и продолжите движение по {way_name:dative}",
-                "destination": "Развернитесь в направлении {destination}"
+                "destination": "Развернитесь в направлении {destination}",
+                "junction_name": "Развернитесь и продолжите движение по {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Поверните {modifier}",
                 "name": "Поверните {modifier} на {way_name:accusative}",
-                "destination": "Поверните {modifier} в направлении {destination}"
+                "destination": "Поверните {modifier} в направлении {destination}",
+                "junction_name": "Поверните {modifier} на {junction_name}"
             },
             "straight": {
                 "default": "Двигайтесь прямо",
                 "name": "Двигайтесь прямо по {way_name:dative}",
-                "destination": "Двигайтесь прямо в направлении {destination}"
+                "destination": "Двигайтесь прямо в направлении {destination}",
+                "junction_name": "Двигайтесь прямо по {junction_name}"
             },
             "uturn": {
                 "default": "В конце дороги развернитесь",
                 "name": "Развернитесь в конце {way_name:genitive}",
-                "destination": "В конце дороги развернитесь в направлении {destination}"
+                "destination": "В конце дороги развернитесь в направлении {destination}",
+                "junction_name": "Развернитесь в конце {junction_name}"
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Двигайтесь {modifier}",
                 "name": "Двигайтесь {modifier} на {way_name:accusative}",
-                "destination": "Двигайтесь {modifier}  в направлении {destination}"
+                "destination": "Двигайтесь {modifier} в направлении {destination}",
+                "junction_name": "Двигайтесь {modifier} на {junction_name}"
             },
             "left": {
                 "default": "Поверните налево",
                 "name": "Поверните налево на {way_name:accusative}",
-                "destination": "Поверните налево в направлении {destination}"
+                "destination": "Поверните налево в направлении {destination}",
+                "junction_name": "Поверните налево на {junction_name}"
             },
             "right": {
                 "default": "Поверните направо",
                 "name": "Поверните направо на {way_name:accusative}",
-                "destination": "Поверните направо  в направлении {destination}"
+                "destination": "Поверните направо в направлении {destination}",
+                "junction_name": "Поверните направо на {junction_name}"
             },
             "straight": {
                 "default": "Двигайтесь прямо",
                 "name": "Двигайтесь по {way_name:dative}",
-                "destination": "Двигайтесь в направлении {destination}"
+                "destination": "Двигайтесь в направлении {destination}",
+                "junction_name": "Двигайтесь по {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/sl.json
+++ b/languages/translations/sl.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Zavijte ostro levo",
                 "name": "Zavijte ostro levo, da ostanete na {way_name}",
-                "destination": "Zavijte ostro levo v smeri proti {destination}"
+                "destination": "Zavijte ostro levo v smeri proti {destination}",
+                "junction_name": "Zavijte ostro levo na {junction_name}"
             },
             "sharp right": {
                 "default": "Zavijte ostro desno",
                 "name": "Zavijte ostro desno, da ostanete na {way_name}",
-                "destination": "Zavijte ostro desno v smeri proti {destination}"
+                "destination": "Zavijte ostro desno v smeri proti {destination}",
+                "junction_name": "Zavijte ostro desno na {junction_name}"
             },
             "slight left": {
                 "default": "Zavijte rahlo levo",
                 "name": "Zavijte rahlo levo, da ostanete na {way_name}",
-                "destination": "Zavijte rahlo levo v smeri proti {destination}"
+                "destination": "Zavijte rahlo levo v smeri proti {destination}",
+                "junction_name": "Zavijte rahlo levo na {junction_name}"
             },
             "slight right": {
                 "default": "Zavijte rahlo desno",
                 "name": "Zavijte rahlo desno, da ostanete na {way_name}",
-                "destination": "Zavijte rahlo desno v smeri proti {destination}"
+                "destination": "Zavijte rahlo desno v smeri proti {destination}",
+                "junction_name": "Zavijte rahlo desno na {junction_name}"
             },
             "uturn": {
                 "default": "Polkrožno obrnite",
                 "name": "Polkrožno obrnite in nadaljujte po {way_name}",
-                "destination": "Polkrožno obrnite v smeri proti {destination}"
+                "destination": "Polkrožno obrnite v smeri proti {destination}",
+                "junction_name": "Polkrožno obrnite na {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Zavijte {modifier}",
                 "name": "Zavijte {modifier} na {way_name}",
-                "destination": "Zavijte {modifier} v smeri proti {destination}"
+                "destination": "Zavijte {modifier} v smeri proti {destination}",
+                "junction_name": "Zavijte {modifier} na {junction_name}"
             },
             "straight": {
                 "default": "Nadaljujte naravnost",
                 "name": "Nadaljujte naravnost na {way_name}",
-                "destination": "Nadaljujte naravnost v smeri proti {destination}"
+                "destination": "Nadaljujte naravnost v smeri proti {destination}",
+                "junction_name": "Nadaljujte naravnost na {junction_name}"
             },
             "uturn": {
                 "default": "Na koncu ceste polkrožno obrnite",
                 "name": "Na koncu ceste polkrožno obrnite na {way_name}",
-                "destination": "Na koncu ceste polkrožno obrnite v smeri proti {destination}"
+                "destination": "Na koncu ceste polkrožno obrnite v smeri proti {destination}",
+                "junction_name": "Polkrožno obrnite na {junction_name}"
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Zavijte {modifier}",
                 "name": "Zavijte {modifier} na {way_name}",
-                "destination": "Zavijte {modifier} v smeri proti {destination}"
+                "destination": "Zavijte {modifier} v smeri proti {destination}",
+                "junction_name": "Zavijte {modifier} na {junction_name}"
             },
             "left": {
                 "default": "Zavijte levo",
                 "name": "Zavijte levo na {way_name}",
-                "destination": "Zavijte levo v smeri proti {destination}"
+                "destination": "Zavijte levo v smeri proti {destination}",
+                "junction_name": "Zavijte levo na {junction_name}"
             },
             "right": {
                 "default": "Zavijte desno",
                 "name": "Zavijte desno na {way_name}",
-                "destination": "Zavijte desno v smeri proti {destination}"
+                "destination": "Zavijte desno v smeri proti {destination}",
+                "junction_name": "Zavijte desno na {junction_name}"
             },
             "straight": {
                 "default": "Peljite naravnost",
                 "name": "Peljite naravnost na {way_name}",
-                "destination": "Peljite naravnost v smeri proti {destination}"
+                "destination": "Peljite naravnost v smeri proti {destination}",
+                "junction_name": "Peljite naravnost na {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/sv.json
+++ b/languages/translations/sv.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Sväng vänster",
                 "name": "Sväng vänster och fortsätt på {way_name}",
-                "destination": "Sväng vänster mot {destination}"
+                "destination": "Sväng vänster mot {destination}",
+                "junction_name": "Sväng vänster vid {junction_name}"
             },
             "sharp right": {
                 "default": "Sväng höger",
                 "name": "Sväng höger och fortsätt på {way_name}",
-                "destination": "Sväng höger mot {destination}"
+                "destination": "Sväng höger mot {destination}",
+                "junction_name": "Sväng höger vid {junction_name}"
             },
             "slight left": {
                 "default": "Sväng vänster",
                 "name": "Sväng vänster och fortsätt på {way_name}",
-                "destination": "Sväng vänster mot {destination}"
+                "destination": "Sväng vänster mot {destination}",
+                "junction_name": "Sväng vänster vid {junction_name}"
             },
             "slight right": {
                 "default": "Sväng höger",
                 "name": "Sväng höger och fortsätt på {way_name}",
-                "destination": "Sväng höger mot {destination}"
+                "destination": "Sväng höger mot {destination}",
+                "junction_name": "Sväng höger vid {junction_name}"
             },
             "uturn": {
                 "default": "Gör en U-sväng",
                 "name": "Gör en U-sväng och fortsätt på {way_name}",
-                "destination": "Gör en U-sväng mot {destination}"
+                "destination": "Gör en U-sväng mot {destination}",
+                "junction_name": "Gör en U-sväng vid {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Sväng {modifier}",
                 "name": "Sväng {modifier} in på {way_name}",
-                "destination": "Sväng {modifier} mot {destination}"
+                "destination": "Sväng {modifier} mot {destination}",
+                "junction_name": "Sväng {modifier} vid {junction_name}"
             },
             "straight": {
                 "default": "Fortsätt rakt fram",
                 "name": "Fortsätt rakt fram in på {way_name}",
-                "destination": "Fortsätt rakt fram mot {destination}"
+                "destination": "Fortsätt rakt fram mot {destination}",
+                "junction_name": "Fortsätt rakt fram vid {junction_name}"
             },
             "uturn": {
                 "default": "Gör en U-sväng i slutet av vägen",
                 "name": "Gör en U-sväng in på {way_name} i slutet av vägen",
-                "destination": "Gör en U-sväng mot {destination} i slutet av vägen"
+                "destination": "Gör en U-sväng mot {destination} i slutet av vägen",
+                "junction_name": "Gör en U-sväng vid {junction_name}"
             }
         },
         "fork": {
@@ -404,7 +412,7 @@
                 },
                 "name_exit": {
                     "default": "I {rotary_name}, ta {exit_number} avfarten",
-                    "name": "I {rotary_name}, ta {exit_number}  avfarten in på {way_name}",
+                    "name": "I {rotary_name}, ta {exit_number} avfarten in på {way_name}",
                     "destination": "I {rotary_name}, ta {exit_number} avfarten mot {destination}"
                 }
             }
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Sväng {modifier}",
                 "name": "Sväng {modifier} in på {way_name}",
-                "destination": "Sväng {modifier} mot {destination}"
+                "destination": "Sväng {modifier} mot {destination}",
+                "junction_name": "Sväng {modifier} vid {junction_name}"
             },
             "left": {
                 "default": "Sväng vänster",
                 "name": "Sväng vänster in på {way_name}",
-                "destination": "Sväng vänster mot {destination}"
+                "destination": "Sväng vänster mot {destination}",
+                "junction_name": "Sväng vänster vid {junction_name}"
             },
             "right": {
                 "default": "Sväng höger",
                 "name": "Sväng höger in på {way_name}",
-                "destination": "Sväng höger mot {destination}"
+                "destination": "Sväng höger mot {destination}",
+                "junction_name": "Sväng höger vid {junction_name}"
             },
             "straight": {
                 "default": "Kör rakt fram",
                 "name": "Kör rakt fram in på {way_name}",
-                "destination": "Kör rakt fram mot {destination}"
+                "destination": "Kör rakt fram mot {destination}",
+                "junction_name": "Kör rakt fram vid {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/tr.json
+++ b/languages/translations/tr.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Sola keskin dönüş yap",
                 "name": "{way_name} üzerinde kalmak için sola keskin dönüş yap",
-                "destination": "{destination} istikametinde sola keskin dönüş yap"
+                "destination": "{destination} istikametinde sola keskin dönüş yap",
+                "junction_name": "{junction_name} konumunda sola keskin dönüş yap"
             },
             "sharp right": {
                 "default": "Sağa keskin dönüş yap",
                 "name": "{way_name} üzerinde kalmak için sağa keskin dönüş yap",
-                "destination": "{destination} istikametinde sağa keskin dönüş yap"
+                "destination": "{destination} istikametinde sağa keskin dönüş yap",
+                "junction_name": "{junction_name} konumunda sağa keskin dönüş yap"
             },
             "slight left": {
                 "default": "Sola hafif dönüş yap",
                 "name": "{way_name} üzerinde kalmak için sola hafif dönüş yap",
-                "destination": "{destination} istikametinde sola hafif dönüş yap"
+                "destination": "{destination} istikametinde sola hafif dönüş yap",
+                "junction_name": "{junction_name} konumunda sola hafif dönüş yap"
             },
             "slight right": {
                 "default": "Sağa hafif dönüş yap",
                 "name": "{way_name} üzerinde kalmak için sağa hafif dönüş yap",
-                "destination": "{destination} istikametinde sağa hafif dönüş yap"
+                "destination": "{destination} istikametinde sağa hafif dönüş yap",
+                "junction_name": "{junction_name} konumunda sağa hafif dönüş yap"
             },
             "uturn": {
                 "default": "U dönüşü yapın",
                 "name": "Bir U-dönüşü yap ve {way_name} devam et",
-                "destination": "{destination} istikametinde bir U-dönüşü yap"
+                "destination": "{destination} istikametinde bir U-dönüşü yap",
+                "junction_name": "{junction_name} konumunda U dönüşü yapın"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "{modifier} tarafa dönün",
                 "name": "{way_name} üzerinde {modifier} yöne dön",
-                "destination": "{destination} istikametinde {modifier} yöne dön"
+                "destination": "{destination} istikametinde {modifier} yöne dön",
+                "junction_name": "{junction_name} konumunda {modifier} tarafa dönün"
             },
             "straight": {
                 "default": "Düz devam edin",
                 "name": "{way_name} üzerinde düz devam et",
-                "destination": "{destination} istikametinde düz devam et"
+                "destination": "{destination} istikametinde düz devam et",
+                "junction_name": "{junction_name} konumunda düz devam et"
             },
             "uturn": {
                 "default": "Yolun sonunda U dönüşü yapın",
                 "name": "Yolun sonunda {way_name} üzerinde bir U-dönüşü yap",
-                "destination": "Yolun sonunda {destination} istikametinde bir U-dönüşü yap"
+                "destination": "Yolun sonunda {destination} istikametinde bir U-dönüşü yap",
+                "junction_name": "{junction_name} konumunda bir U-dönüşü yap"
             }
         },
         "fork": {
@@ -493,22 +501,26 @@
             "default": {
                 "default": "{modifier} yöne dön",
                 "name": "{way_name} üzerinde {modifier} yöne dön",
-                "destination": "{destination} istikametinde {modifier} yöne dön"
+                "destination": "{destination} istikametinde {modifier} yöne dön",
+                "junction_name": "{junction_name} konumunda {modifier} yöne dön"
             },
             "left": {
                 "default": "Sola dönün",
                 "name": "{way_name} üzerinde sola dön",
-                "destination": "{destination} istikametinde sola dön"
+                "destination": "{destination} istikametinde sola dön",
+                "junction_name": "{junction_name} konumunda sola dön"
             },
             "right": {
                 "default": "Sağa dönün",
                 "name": "{way_name} üzerinde sağa dön",
-                "destination": "{destination} istikametinde sağa dön"
+                "destination": "{destination} istikametinde sağa dön",
+                "junction_name": "{junction_name} konumunda sağa dön"
             },
             "straight": {
                 "default": "Düz git",
                 "name": "{way_name} üzerinde düz git",
-                "destination": "{destination} istikametinde düz git"
+                "destination": "{destination} istikametinde düz git",
+                "junction_name": "{junction_name} konumunda düz git"
             }
         },
         "use lane": {

--- a/languages/translations/uk.json
+++ b/languages/translations/uk.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Поверніть різко ліворуч",
                 "name": "Поверніть різко ліворуч щоб залишитись на {way_name}",
-                "destination": "Поверніть різко ліворуч у напрямку {destination}"
+                "destination": "Поверніть різко ліворуч у напрямку {destination}",
+                "junction_name": "Поверніть різко ліворуч щоб залишитись на {junction_name}"
             },
             "sharp right": {
                 "default": "Поверніть різко праворуч",
                 "name": "Поверніть різко праворуч щоб залишитись на {way_name}",
-                "destination": "Поверніть різко праворуч у напрямку {destination}"
+                "destination": "Поверніть різко праворуч у напрямку {destination}",
+                "junction_name": "Поверніть різко праворуч щоб залишитись на {junction_name}"
             },
             "slight left": {
                 "default": "Поверніть різко ліворуч",
                 "name": "Поверніть плавно ліворуч щоб залишитись на {way_name}",
-                "destination": "Поверніть плавно ліворуч у напрямку {destination}"
+                "destination": "Поверніть плавно ліворуч у напрямку {destination}",
+                "junction_name": "Поверніть плавно ліворуч щоб залишитись на {junction_name}"
             },
             "slight right": {
                 "default": "Поверніть плавно праворуч",
                 "name": "Поверніть плавно праворуч щоб залишитись на {way_name}",
-                "destination": "Поверніть плавно праворуч у напрямку {destination}"
+                "destination": "Поверніть плавно праворуч у напрямку {destination}",
+                "junction_name": "Поверніть плавно праворуч щоб залишитись на {junction_name}"
             },
             "uturn": {
                 "default": "Здійсніть розворот",
                 "name": "Здійсніть розворот та рухайтесь по {way_name}",
-                "destination": "Здійсніть розворот у напрямку {destination}"
+                "destination": "Здійсніть розворот у напрямку {destination}",
+                "junction_name": "Здійсніть розворот та рухайтесь по {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Поверніть {modifier}",
                 "name": "Поверніть {modifier} на {way_name}",
-                "destination": "Поверніть {modifier} у напрямку {destination}"
+                "destination": "Поверніть {modifier} у напрямку {destination}",
+                "junction_name": "Поверніть {modifier} на {junction_name}"
             },
             "straight": {
                 "default": "Продовжуйте рух прямо",
                 "name": "Продовжуйте рух прямо до {way_name}",
-                "destination": "Продовжуйте рух прямо у напрямку {destination}"
+                "destination": "Продовжуйте рух прямо у напрямку {destination}",
+                "junction_name": "Продовжуйте рух прямо до {junction_name}"
             },
             "uturn": {
                 "default": "Здійсніть розворот в кінці дороги",
                 "name": "Здійсніть розворот на {way_name} в кінці дороги",
-                "destination": "Здійсніть розворот у напрямку {destination} в кінці дороги"
+                "destination": "Здійсніть розворот у напрямку {destination} в кінці дороги",
+                "junction_name": "Здійсніть розворот на {junction_name}"
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Рухайтесь {modifier}",
                 "name": "Рухайтесь {modifier} на {way_name}",
-                "destination": "Рухайтесь {modifier} в напрямку {destination}"
+                "destination": "Рухайтесь {modifier} в напрямку {destination}",
+                "junction_name": "Make a {modifier} at {junction_name}"
             },
             "left": {
                 "default": "Поверніть ліворуч",
                 "name": "Поверніть ліворуч на {way_name}",
-                "destination": "Поверніть ліворуч у напрямку {destination}"
+                "destination": "Поверніть ліворуч у напрямку {destination}",
+                "junction_name": "Turn left at {junction_name}"
             },
             "right": {
                 "default": "Поверніть праворуч",
                 "name": "Поверніть праворуч на {way_name}",
-                "destination": "Поверніть праворуч у напрямку {destination}"
+                "destination": "Поверніть праворуч у напрямку {destination}",
+                "junction_name": "Turn right at {junction_name}"
             },
             "straight": {
                 "default": "Рухайтесь прямо",
                 "name": "Рухайтесь прямо по {way_name}",
-                "destination": "Рухайтесь прямо у напрямку {destination}"
+                "destination": "Рухайтесь прямо у напрямку {destination}",
+                "junction_name": "Go straight at {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/vi.json
+++ b/languages/translations/vi.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Quẹo gắt bên trái",
                 "name": "Quẹo gắt bên trái để chạy tiếp trên {way_name}",
-                "destination": "Quẹo gắt bên trái về {destination}"
+                "destination": "Quẹo gắt bên trái về {destination}",
+                "junction_name": "Quẹo gắt bên trái ở {junction_name}"
             },
             "sharp right": {
                 "default": "Quẹo gắt bên phải",
                 "name": "Quẹo gắt bên phải để chạy tiếp trên {way_name}",
-                "destination": "Quẹo gắt bên phải về {destination}"
+                "destination": "Quẹo gắt bên phải về {destination}",
+                "junction_name": "Quẹo gắt bên phải ở {junction_name}"
             },
             "slight left": {
                 "default": "Nghiêng về bên trái",
                 "name": "Nghiêng về bên trái để chạy tiếp trên {way_name}",
-                "destination": "Nghiêng về bên trái về {destination}"
+                "destination": "Nghiêng về bên trái về {destination}",
+                "junction_name": "Nghiêng về bên trái ở {junction_name}"
             },
             "slight right": {
                 "default": "Nghiêng về bên phải",
                 "name": "Nghiêng về bên phải để chạy tiếp trên {way_name}",
-                "destination": "Nghiêng về bên phải về {destination}"
+                "destination": "Nghiêng về bên phải về {destination}",
+                "junction_name": "Nghiêng về bên phải ở {junction_name}"
             },
             "uturn": {
                 "default": "Quẹo ngược lại",
                 "name": "Quẹo ngược lại trên {way_name}",
-                "destination": "Quẹo ngược về {destination}"
+                "destination": "Quẹo ngược về {destination}",
+                "junction_name": "Quẹo ngược lại ở {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Quẹo {modifier}",
                 "name": "Quẹo {modifier} vào {way_name}",
-                "destination": "Quẹo {modifier} về {destination}"
+                "destination": "Quẹo {modifier} về {destination}",
+                "junction_name": "Quẹo {modifier} ở {junction_name}"
             },
             "straight": {
                 "default": "Chạy thẳng",
                 "name": "Chạy tiếp trên {way_name}",
-                "destination": "Chạy tiếp về {destination}"
+                "destination": "Chạy tiếp về {destination}",
+                "junction_name": "Chạy thẳng ở {junction_name}"
             },
             "uturn": {
                 "default": "Quẹo ngược lại tại cuối đường",
                 "name": "Quẹo ngược vào {way_name} tại cuối đường",
-                "destination": "Quẹo ngược về {destination} tại cuối đường"
+                "destination": "Quẹo ngược về {destination} tại cuối đường",
+                "junction_name": "Quẹo ngược lại ở {junction_name}"
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Quẹo {modifier}",
                 "name": "Quẹo {modifier} vào {way_name}",
-                "destination": "Quẹo {modifier} về {destination}"
+                "destination": "Quẹo {modifier} về {destination}",
+                "junction_name": "Quẹo {modifier} ở {junction_name}"
             },
             "left": {
                 "default": "Quẹo trái",
                 "name": "Quẹo trái vào {way_name}",
-                "destination": "Quẹo trái về {destination}"
+                "destination": "Quẹo trái về {destination}",
+                "junction_name": "Quẹo trái ở {junction_name}"
             },
             "right": {
                 "default": "Quẹo phải",
                 "name": "Quẹo phải vào {way_name}",
-                "destination": "Quẹo phải về {destination}"
+                "destination": "Quẹo phải về {destination}",
+                "junction_name": "Quẹo phải ở {junction_name}"
             },
             "straight": {
                 "default": "Chạy thẳng",
                 "name": "Chạy thẳng vào {way_name}",
-                "destination": "Chạy thẳng về {destination}"
+                "destination": "Chạy thẳng về {destination}",
+                "junction_name": "Chạy thẳng ở {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/yo.json
+++ b/languages/translations/yo.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "Ṣe kan osi osi",
                 "name": "Ṣe ọpa didasilẹ lati duro si {way_name}",
-                "destination": "Ṣe idasilẹ mimu si ọna {destination}"
+                "destination": "Ṣe idasilẹ mimu si ọna {destination}",
+                "junction_name": "Ṣe kan osi ni {junction_name}"
             },
             "sharp right": {
                 "default": "Ṣe idasilẹ to dara",
                 "name": "Ṣe idasilẹ to dara lati duro si {way_name}",
-                "destination": "Ṣe didasilẹ si ọtun si ọna {destination}"
+                "destination": "Ṣe didasilẹ si ọtun si ọna {destination}",
+                "junction_name": "Ṣe idasilẹ to dara ni {junction_name}"
             },
             "slight left": {
                 "default": "Ṣe diẹ osi",
                 "name": "Ṣe diẹ si osi lati duro si {way_name}",
-                "destination": "Ṣe diẹ si apa osi si ọna {destination}"
+                "destination": "Ṣe diẹ si apa osi si ọna {destination}",
+                "junction_name": "Ṣe diẹ osi ni {junction_name}"
             },
             "slight right": {
                 "default": "Ṣe diẹ diẹ si ọtun",
                 "name": "Ṣe diẹ si ọtun lati duro si {way_name}",
-                "destination": "Ṣe diẹ si ọtun si ọna {destination}"
+                "destination": "Ṣe diẹ si ọtun si ọna {destination}",
+                "junction_name": "Ṣe diẹ diẹ si ọtun ni {junction_name}"
             },
             "uturn": {
                 "default": "Ṣe ayipada U",
                 "name": "Ṣe ayipada U ati tẹsiwaju {way_name}",
-                "destination": "Ṣe ọna U-ọna si ọna {destination}"
+                "destination": "Ṣe ọna U-ọna si ọna {destination}",
+                "junction_name": "Ṣe ayipada U ni {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "Tan-an {modifier}",
                 "name": "Tan-an {modifier} pẹlẹpẹlẹ {way_name}",
-                "destination": "Tan-an {modifier} si ọna {destination}"
+                "destination": "Tan-an {modifier} si ọna {destination}",
+                "junction_name": "Tan-an {modifier} ni {junction_name}"
             },
             "straight": {
                 "default": "Tẹsiwaju ni gígùn",
                 "name": "Tesiwaju tẹsiwaju lẹsẹkẹsẹ {way_name}",
-                "destination": "Tesiwaju si ọna ọtun {destination}"
+                "destination": "Tesiwaju si ọna ọtun {destination}",
+                "junction_name": "Tẹsiwaju ni gígùn ni {junction_name}"
             },
             "uturn": {
                 "default": "Ṣe a-ẹ-yipada ni opin ọna",
                 "name": "Ṣe U-tan pẹlẹpẹlẹ {way_name} ni opin ọna",
-                "destination": "Ṣe ọna U-ọna si ọna {destination} ni opin ọna"
+                "destination": "Ṣe ọna U-ọna si ọna {destination} ni opin ọna",
+                "junction_name": "Ṣe ayipada U ni {junction_name}"
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "Ṣe a {modifier}",
                 "name": "Ṣe a {modifier} pẹlẹpẹlẹ {way_name}",
-                "destination": "Ṣe a {modifier} si ọna {destination}"
+                "destination": "Ṣe a {modifier} si ọna {destination}",
+                "junction_name": "Ṣe a {modifier} ni {junction_name}"
             },
             "left": {
                 "default": "Ya si apa osi",
                 "name": "Tan apa osi pẹlẹpẹlẹ {way_name}",
-                "destination": "Tan apa osi si ọna {destination}"
+                "destination": "Tan apa osi si ọna {destination}",
+                "junction_name": "Ya si apa osi ni {junction_name}"
             },
             "right": {
                 "default": "Ya sowo otun",
                 "name": "Tan ọtun si {way_name}",
-                "destination": "Tan-ọtun si ọna {destination}"
+                "destination": "Tan-ọtun si ọna {destination}",
+                "junction_name": "Ya sowo otun ni {junction_name}"
             },
             "straight": {
                 "default": "Rin taara",
                 "name": "Lọ si pẹkipẹki {way_name}",
-                "destination": "Lọ taara si ọna {destination}"
+                "destination": "Lọ taara si ọna {destination}",
+                "junction_name": "Rin taara ni {junction_name}"
             }
         },
         "use lane": {

--- a/languages/translations/zh-Hans.json
+++ b/languages/translations/zh-Hans.json
@@ -132,27 +132,32 @@
             "sharp left": {
                 "default": "前方左急转弯",
                 "name": "前方左急转弯，继续在{way_name}上行驶",
-                "destination": "左急转弯，前往{destination}"
+                "destination": "左急转弯，前往{destination}",
+                "junction_name": "Make a sharp left at {junction_name}"
             },
             "sharp right": {
                 "default": "前方右急转弯",
                 "name": "前方右急转弯，继续在{way_name}上行驶",
-                "destination": "右急转弯，前往{destination}"
+                "destination": "右急转弯，前往{destination}",
+                "junction_name": "Make a sharp right at {junction_name}"
             },
             "slight left": {
                 "default": "前方稍向左转",
                 "name": "前方稍向左转，继续在{way_name}上行驶",
-                "destination": "稍向左转，前往{destination}"
+                "destination": "稍向左转，前往{destination}",
+                "junction_name": "Make a slight left at {junction_name}"
             },
             "slight right": {
                 "default": "前方稍向右转",
                 "name": "前方稍向右转，继续在{way_name}上行驶",
-                "destination": "前方稍向右转，前往{destination}"
+                "destination": "前方稍向右转，前往{destination}",
+                "junction_name": "Make a slight right at {junction_name}"
             },
             "uturn": {
                 "default": "前方调头",
                 "name": "前方调头，继续在{way_name}上行驶",
-                "destination": "前方调头，前往{destination}"
+                "destination": "前方调头，前往{destination}",
+                "junction_name": "Make a U-turn at {junction_name}"
             }
         },
         "depart": {
@@ -166,17 +171,20 @@
             "default": {
                 "default": "{modifier}行驶",
                 "name": "{modifier}行驶，驶入{way_name}",
-                "destination": "{modifier}行驶，前往{destination}"
+                "destination": "{modifier}行驶，前往{destination}",
+                "junction_name": "Turn {modifier} at {junction_name}"
             },
             "straight": {
                 "default": "继续直行",
                 "name": "继续直行，驶入{way_name}",
-                "destination": "继续直行，前往{destination}"
+                "destination": "继续直行，前往{destination}",
+                "junction_name": "Continue straight at {junction_name}"
             },
             "uturn": {
                 "default": "在道路尽头调头",
                 "name": "在道路尽头调头驶入{way_name}",
-                "destination": "在道路尽头调头，前往{destination}"
+                "destination": "在道路尽头调头，前往{destination}",
+                "junction_name": "Make a U-turn at {junction_name} at the end of the road"
             }
         },
         "fork": {
@@ -463,22 +471,26 @@
             "default": {
                 "default": "{modifier}转弯",
                 "name": "{modifier}转弯，驶入{way_name}",
-                "destination": "{modifier}转弯，前往{destination}"
+                "destination": "{modifier}转弯，前往{destination}",
+                "junction_name": "Make a {modifier} at {junction_name}"
             },
             "left": {
                 "default": "左转",
                 "name": "左转，驶入{way_name}",
-                "destination": "左转，前往{destination}"
+                "destination": "左转，前往{destination}",
+                "junction_name": "Turn left at {junction_name}"
             },
             "right": {
                 "default": "右转",
                 "name": "右转，驶入{way_name}",
-                "destination": "右转，前往{destination}"
+                "destination": "右转，前往{destination}",
+                "junction_name": "Turn right at {junction_name}"
             },
             "straight": {
                 "default": "直行",
                 "name": "直行，驶入{way_name}",
-                "destination": "直行，前往{destination}"
+                "destination": "直行，前往{destination}",
+                "junction_name": "Go straight at {junction_name}"
             }
         },
         "use lane": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "OSRM Text Instructions",
   "url": "https://github.com/Project-OSRM/osrm-text-instructions.js",
   "homepage": "http://project-osrm.org",
-  "version": "0.14.0-beta.3",
+  "version": "0.14.0-beta.4",
   "main": "./index.js",
   "license": "BSD-2-Clause",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "OSRM Text Instructions",
   "url": "https://github.com/Project-OSRM/osrm-text-instructions.js",
   "homepage": "http://project-osrm.org",
-  "version": "0.13.4",
+  "version": "0.14.0-beta.3",
   "main": "./index.js",
   "license": "BSD-2-Clause",
   "bugs": {

--- a/test/fixtures/v5/continue/left_junction_name.json
+++ b/test/fixtures/v5/continue/left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يسارا لتبقى على Way Name",
+        "da": "Drej til venstre videre ad Way Name",
+        "de": "Links weiterfahren auf Way Name",
+        "en": "Turn left to stay on Way Name",
+        "eo": "Veturu maldekstren al Way Name",
+        "es": "Cruza a laizquierda en Way Name",
+        "es-ES": "Cruce a la izquierda en Way Name",
+        "fi": "Käänny vasemmall(e/a) pysyäksesi tiellä Way Name",
+        "fr": "Tourner à gauche pour rester sur Way Name",
+        "he": "פנה שמאלה כדי להישאר בWay Name",
+        "hu": "Forduljon balra és maradjon a Way Name szakaszon",
+        "id": "Terus kiri ke Way Name",
+        "it": "Gira a sinistra per stare su Way Name",
+        "ja": "左に曲がり、Way Nameを進む",
+        "ko": "좌회전 회전하고 Way Name로 직진해 주세요.",
+        "my": "Way Name​ပေါ်တွင်နေရန် ဘယ်ဘက်ကိုလှည့်ပါ",
+        "nl": "Sla links om op Way Name te blijven",
+        "no": "Ta til venstre for å bli værende på Way Name",
+        "pl": "Skręć w lewo, aby pozostać na Way Name",
+        "pt-BR": "Vire à esquerda para manter-se na Way Name",
+        "pt-PT": "Vire à esquerda para se manter em Way Name",
+        "ro": "Virați stânga pe Way Name",
+        "ru": "Двигайтесь налево по Way Name",
+        "sl": "Zavijte levo na Way Name",
+        "sv": "Sväng vänster och fortsätt på Way Name",
+        "tr": "Way Name üzerinde kalmak için sol yöne dön",
+        "uk": "Повернітьліворуч залишаючись на Way Name",
+        "vi": "Quẹo trái để chạy tiếp trên Way Name",
+        "yo": "Tan-an apa osi lati duro si Way Name",
+        "zh-Hans": "在Way Name上继续向左行驶"
+    }
+}

--- a/test/fixtures/v5/continue/right_junction_name.json
+++ b/test/fixtures/v5/continue/right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يمينا لتبقى على Way Name",
+        "da": "Drej til højre videre ad Way Name",
+        "de": "Rechts weiterfahren auf Way Name",
+        "en": "Turn right to stay on Way Name",
+        "eo": "Veturu dekstren al Way Name",
+        "es": "Cruza a laderecha en Way Name",
+        "es-ES": "Cruce a la derecha en Way Name",
+        "fi": "Käänny oikeall(e/a) pysyäksesi tiellä Way Name",
+        "fr": "Tourner à droite pour rester sur Way Name",
+        "he": "פנה ימינה כדי להישאר בWay Name",
+        "hu": "Forduljon jobbra és maradjon a Way Name szakaszon",
+        "id": "Terus kanan ke Way Name",
+        "it": "Gira a destra per stare su Way Name",
+        "ja": "右に曲がり、Way Nameを進む",
+        "ko": "우회전 회전하고 Way Name로 직진해 주세요.",
+        "my": "Way Name​ပေါ်တွင်နေရန် ညာဘက်ကိုလှည့်ပါ",
+        "nl": "Sla rechts om op Way Name te blijven",
+        "no": "Ta til høyre for å bli værende på Way Name",
+        "pl": "Skręć w prawo, aby pozostać na Way Name",
+        "pt-BR": "Vire à direita para manter-se na Way Name",
+        "pt-PT": "Vire à direita para se manter em Way Name",
+        "ro": "Virați dreapta pe Way Name",
+        "ru": "Двигайтесь направо по Way Name",
+        "sl": "Zavijte desno na Way Name",
+        "sv": "Sväng höger och fortsätt på Way Name",
+        "tr": "Way Name üzerinde kalmak için sağ yöne dön",
+        "uk": "Повернітьправоруч залишаючись на Way Name",
+        "vi": "Quẹo phải để chạy tiếp trên Way Name",
+        "yo": "Tan-an ọtun lati duro si Way Name",
+        "zh-Hans": "在Way Name上继续向右行驶"
+    }
+}

--- a/test/fixtures/v5/continue/sharp_left_junction_name.json
+++ b/test/fixtures/v5/continue/sharp_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يساراً حاداً لتبقى على Shibuya Crossing",
+        "da": "Drej skarpt til venstre videre ved Shibuya Crossing",
+        "de": "Scharf links weiterfahren an Shibuya Crossing",
+        "en": "Make a sharp left at Shibuya Crossing",
+        "eo": "Turniĝu ege maldekstren ĉe Shibuya Crossing",
+        "es": "Gira a la izquierda en Shibuya Crossing",
+        "es-ES": "Gire a la izquierda en Shibuya Crossing",
+        "fi": "Jatka jyrkästi vasempaan tielle Shibuya Crossing",
+        "fr": "Tourner franchement à gauche en Shibuya Crossing",
+        "he": "פנה בחדות שמאלה כדי להישאר על Shibuya Crossing",
+        "hu": "Forduljon élesen balra az Shibuya Crossing",
+        "id": "Make a sharp left at Shibuya Crossing",
+        "it": "Fai una curva stretta a sinistra al Shibuya Crossing",
+        "ja": "Shibuya Crossingを左戻るです",
+        "ko": "Shibuya Crossing에서 급좌회전.",
+        "my": "Shibuya Crossingပေါ်တွင်နေရန် ဘယ်ဘက်ထောင့်ချိုးကွေ့ပါ",
+        "nl": "Linksaf bij Shibuya Crossing",
+        "no": "Sving skarpt til venstre i Shibuya Crossing",
+        "pl": "Skręć ostro w lewo na Shibuya Crossing",
+        "pt-BR": "Faça uma curva fechada a esquerda em Shibuya Crossing",
+        "pt-PT": "Vire acentuadamente à esquerda em Shibuya Crossing",
+        "ro": "Virați puternic la stânga la Shibuya Crossing",
+        "ru": "Резко поверните налево на Shibuya Crossing",
+        "sl": "Zavijte ostro levo na Shibuya Crossing",
+        "sv": "Sväng vänster vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda sola keskin dönüş yap",
+        "uk": "Поверніть різко ліворуч щоб залишитись на Shibuya Crossing",
+        "vi": "Quẹo gắt bên trái ở Shibuya Crossing",
+        "yo": "Ṣe kan osi ni Shibuya Crossing",
+        "zh-Hans": "Make a sharp left at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/continue/sharp_right_junction_name.json
+++ b/test/fixtures/v5/continue/sharp_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يميناً حاداً لتبقى على Shibuya Crossing",
+        "da": "Drej skarpt til højre videre ved Shibuya Crossing",
+        "de": "Scharf rechts weiterfahren an Shibuya Crossing",
+        "en": "Make a sharp right at Shibuya Crossing",
+        "eo": "Turniĝu ege dekstren ĉe Shibuya Crossing",
+        "es": "Gira a la derecha en Shibuya Crossing",
+        "es-ES": "Gire a la derecha en Shibuya Crossing",
+        "fi": "Jatka jyrkästi oikeaan tielle Shibuya Crossing",
+        "fr": "Tourner franchement à droite en Shibuya Crossing",
+        "he": "פנה בחדות ימינה כדי להישאר על Shibuya Crossing",
+        "hu": "Forduljon élesen jobbra az Shibuya Crossing",
+        "id": "Make a sharp right at Shibuya Crossing",
+        "it": "Fai una curva stretta a destra al Shibuya Crossing",
+        "ja": "Shibuya Crossingを右戻るです",
+        "ko": "Shibuya Crossing에서 급우회전.",
+        "my": "Shibuya Crossingပေါ်တွင်နေရန် ညာဘက်ထောင့်ချိုးကွေ့ပါ",
+        "nl": "Rechtsaf bij Shibuya Crossing",
+        "no": "Sving skarpt til høyre i Shibuya Crossing",
+        "pl": "Skręć ostro w prawo na Shibuya Crossing",
+        "pt-BR": "Faça uma curva fechada a direita em Shibuya Crossing",
+        "pt-PT": "Vire acentuadamente à direita em Shibuya Crossing",
+        "ro": "Virați puternic la dreapta la Shibuya Crossing",
+        "ru": "Резко поверните направо на Shibuya Crossing",
+        "sl": "Zavijte ostro desno na Shibuya Crossing",
+        "sv": "Sväng höger vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda sağa keskin dönüş yap",
+        "uk": "Поверніть різко праворуч щоб залишитись на Shibuya Crossing",
+        "vi": "Quẹo gắt bên phải ở Shibuya Crossing",
+        "yo": "Ṣe idasilẹ to dara ni Shibuya Crossing",
+        "zh-Hans": "Make a sharp right at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/continue/slight_left_exit.json
+++ b/test/fixtures/v5/continue/slight_left_exit.json
@@ -9,7 +9,7 @@
         "exits": "4A;4B"
     },
     "instructions": {
-        "ar": " انعطف يساراً قليلاً لتبقى على Way Name ",
+        "ar": "انعطف يساراً قليلاً لتبقى على Way Name",
         "da": "Drej let til venstre videre ad Way Name",
         "de": "Leicht links weiter auf Way Name",
         "en": "Make a slight left to stay on Way Name",

--- a/test/fixtures/v5/continue/slight_left_junction_name.json
+++ b/test/fixtures/v5/continue/slight_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يساراً قليلاً لتبقى على Shibuya Crossing",
+        "da": "Drej let til venstre videre ved Shibuya Crossing",
+        "de": "Leicht links weiter an Shibuya Crossing",
+        "en": "Make a slight left at Shibuya Crossing",
+        "eo": "Turniĝu ete maldekstren ĉe Shibuya Crossing",
+        "es": "Dobla levemente a la izquierda en Shibuya Crossing",
+        "es-ES": "Doble levemente a la izquierda en Shibuya Crossing",
+        "fi": "Jatka loivasti vasempaan tielle Shibuya Crossing",
+        "fr": "Tourner légèrement à gauche en Shibuya Crossing",
+        "he": "פנה קלות שמאלה כדי להישאר על Shibuya Crossing",
+        "hu": "Forduljon enyhén balra az Shibuya Crossing",
+        "id": "Make a slight left at Shibuya Crossing",
+        "it": "Fai una leggera curva a sinistra al Shibuya Crossing",
+        "ja": "Shibuya Crossingを斜め左です",
+        "ko": "Shibuya Crossing에서 약간 좌회전.",
+        "my": "Shibuya Crossingပေါ်တွင်နေရန် ဘယ်ဘက်အနည်းငယ်ကွေ့ပါ",
+        "nl": "Ga links bij Shibuya Crossing",
+        "no": "Sving svakt til venstre i Shibuya Crossing",
+        "pl": "Skręć w lewo w łagodny zakręt na Shibuya Crossing",
+        "pt-BR": "Faça uma curva suave a esquerda em Shibuya Crossing",
+        "pt-PT": "Vire ligeiramente à esquerda em Shibuya Crossing",
+        "ro": "Virați ușor la stânga la Shibuya Crossing",
+        "ru": "Плавно поверните налево на Shibuya Crossing",
+        "sl": "Zavijte rahlo levo na Shibuya Crossing",
+        "sv": "Sväng vänster vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda sola hafif dönüş yap",
+        "uk": "Поверніть плавно ліворуч щоб залишитись на Shibuya Crossing",
+        "vi": "Nghiêng về bên trái ở Shibuya Crossing",
+        "yo": "Ṣe diẹ osi ni Shibuya Crossing",
+        "zh-Hans": "Make a slight left at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/continue/slight_left_name.json
+++ b/test/fixtures/v5/continue/slight_left_name.json
@@ -8,7 +8,7 @@
         "driving_side": "right"
     },
     "instructions": {
-        "ar": " انعطف يساراً قليلاً لتبقى على Way Name ",
+        "ar": "انعطف يساراً قليلاً لتبقى على Way Name",
         "da": "Drej let til venstre videre ad Way Name",
         "de": "Leicht links weiter auf Way Name",
         "en": "Make a slight left to stay on Way Name",

--- a/test/fixtures/v5/continue/slight_right_destination.json
+++ b/test/fixtures/v5/continue/slight_right_destination.json
@@ -9,7 +9,7 @@
         "destinations": "Destination 1,Destination 2"
     },
     "instructions": {
-        "ar": "انعطف يميناً قليلاً نحو Destination 1 ",
+        "ar": "انعطف يميناً قليلاً نحو Destination 1",
         "da": "Drej let til højre mod Destination 1",
         "de": "Leicht rechts weiter Richtung Destination 1",
         "en": "Make a slight right towards Destination 1",

--- a/test/fixtures/v5/continue/slight_right_exit_destination.json
+++ b/test/fixtures/v5/continue/slight_right_exit_destination.json
@@ -10,7 +10,7 @@
         "exits": "4A;4B"
     },
     "instructions": {
-        "ar": "انعطف يميناً قليلاً نحو Destination 1 ",
+        "ar": "انعطف يميناً قليلاً نحو Destination 1",
         "da": "Drej let til højre mod Destination 1",
         "de": "Leicht rechts weiter Richtung Destination 1",
         "en": "Make a slight right towards Destination 1",

--- a/test/fixtures/v5/continue/slight_right_junction_name.json
+++ b/test/fixtures/v5/continue/slight_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يميناً قليلاً نحو Shibuya Crossing",
+        "da": "Drej let til højre videre ved Shibuya Crossing",
+        "de": "Leicht rechts weiter an Shibuya Crossing",
+        "en": "Make a slight right at Shibuya Crossing",
+        "eo": "Turniĝu ete dekstren ĉe Shibuya Crossing",
+        "es": "Dobla levemente a la derecha en Shibuya Crossing",
+        "es-ES": "Doble levemente a la derecha en Shibuya Crossing",
+        "fi": "Jatka loivasti oikeaan tielle Shibuya Crossing",
+        "fr": "Tourner légèrement à droite en Shibuya Crossing",
+        "he": "פנה קלות ימינה כדי להישאר על Shibuya Crossing",
+        "hu": "Forduljon enyhén jobbra az Shibuya Crossing",
+        "id": "Make a slight right at Shibuya Crossing",
+        "it": "Fai una leggera curva a destra al Shibuya Crossing",
+        "ja": "Shibuya Crossingを斜め右です",
+        "ko": "Shibuya Crossing에서 약간 우회전.",
+        "my": "Shibuya Crossingပေါ်တွင်နေရန် ညာဘက်အနည်းငယ်ကွေ့ပါ",
+        "nl": "Rechts afbuigen bij Shibuya Crossing",
+        "no": "Sving svakt til høyre i Shibuya Crossing",
+        "pl": "Skręć w prawo w łagodny zakręt na Shibuya Crossing",
+        "pt-BR": "Faça uma curva suave a direita em Shibuya Crossing",
+        "pt-PT": "Vire ligeiramente à direita em Shibuya Crossing",
+        "ro": "Virați ușor la dreapta la Shibuya Crossing",
+        "ru": "Плавно поверните направо на Shibuya Crossing",
+        "sl": "Zavijte rahlo desno na Shibuya Crossing",
+        "sv": "Sväng höger vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda sağa hafif dönüş yap",
+        "uk": "Поверніть плавно праворуч щоб залишитись на Shibuya Crossing",
+        "vi": "Nghiêng về bên phải ở Shibuya Crossing",
+        "yo": "Ṣe diẹ diẹ si ọtun ni Shibuya Crossing",
+        "zh-Hans": "Make a slight right at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/continue/straight_junction_name.json
+++ b/test/fixtures/v5/continue/straight_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "تابع قدما لتبقى على Way Name",
+        "da": "Fortsæt ligeud ad Way Name",
+        "de": "Geradeaus weiterfahren auf Way Name",
+        "en": "Continue straight to stay on Way Name",
+        "eo": "Veturu rekten al Way Name",
+        "es": "Continúa en Way Name",
+        "es-ES": "Continúa en Way Name",
+        "fi": "Jatka suoraan pysyäksesi tiellä Way Name",
+        "fr": "Continuer tout droit pour rester sur Way Name",
+        "he": "המשך ישר כדי להישאר על Way Name",
+        "hu": "Hajtson tovább egyenesen a Way Name szakaszon",
+        "id": "Terus ke Way Name",
+        "it": "Continua dritto per stare su Way Name",
+        "ja": "Way Nameを直進する",
+        "ko": "Way Name 로 계속 직진해 주세요.",
+        "my": "Way Name​ပေါ်တွင်နေရန်တည်တည့်ဆက်သွာပါ",
+        "nl": "Blijf rechtdoor gaan op Way Name",
+        "no": "Fortsett rett frem for å bli værende på Way Name",
+        "pl": "Jedź dalej prosto, aby pozostać na Way Name",
+        "pt-BR": "Continue em frente para manter-se na Way Name",
+        "pt-PT": "Continue em frente para se manter em Way Name",
+        "ro": "Mergeți înainte pe Way Name",
+        "ru": "Продолжите движение по Way Name",
+        "sl": "Nadaljujte naravnost, da ostanete na Way Name",
+        "sv": "Kör rakt fram och fortsätt på Way Name",
+        "tr": "Way Name üzerinde kalmak için düz devam et",
+        "uk": "Продовжуйте рух прямо залишаючись на Way Name",
+        "vi": "Chạy tiếp trên Way Name",
+        "yo": "Tesiwaju ni gígùn lati duro si Way Name",
+        "zh-Hans": "在Way Name上继续直行"
+    }
+}

--- a/test/fixtures/v5/continue/uturn_junction_name.json
+++ b/test/fixtures/v5/continue/uturn_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف دوراناً عكسياً وتابع نحو Shibuya Crossing",
+        "da": "Foretag en U-vending tilbage ved Shibuya Crossing",
+        "de": "180°-Wendung an Shibuya Crossing",
+        "en": "Make a U-turn at Shibuya Crossing",
+        "eo": "Turniĝu malantaŭen ĉe Shibuya Crossing",
+        "es": "Haz un cambio de sentido en Shibuya Crossing",
+        "es-ES": "Haz un cambio de sentido en Shibuya Crossing",
+        "fi": "Tee U-käännös tielle Shibuya Crossing",
+        "fr": "Faire demi-tour en Shibuya Crossing",
+        "he": "פנה פניית פרסה והמשך על Shibuya Crossing",
+        "hu": "Forduljon vissza az Shibuya Crossing",
+        "id": "Make a U-turn at Shibuya Crossing",
+        "it": "Fai un’inversione ad U al Shibuya Crossing",
+        "ja": "Shibuya CrossingをUターン",
+        "ko": "Shibuya Crossing에서 유턴 하세요.",
+        "my": "Shibuya Crossingလမ်းဘက်သို့ ဂ-ကွေ့ကွေ့ပြီးဆက်သွားပါ",
+        "nl": "Keer om bij Shibuya Crossing",
+        "no": "Ta en U-sving i Shibuya Crossing",
+        "pl": "Zawróć na Shibuya Crossing",
+        "pt-BR": "Faça o retorno em Shibuya Crossing",
+        "pt-PT": "Faça inversão de marcha em Shibuya Crossing",
+        "ro": "Întoarceți-vă la Shibuya Crossing",
+        "ru": "Развернитесь и продолжите движение по Shibuya Crossing",
+        "sl": "Polkrožno obrnite na Shibuya Crossing",
+        "sv": "Gör en U-sväng vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda U dönüşü yapın",
+        "uk": "Здійсніть розворот та рухайтесь по Shibuya Crossing",
+        "vi": "Quẹo ngược lại ở Shibuya Crossing",
+        "yo": "Ṣe ayipada U ni Shibuya Crossing",
+        "zh-Hans": "Make a U-turn at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/depart/modifier_junction_name.json
+++ b/test/fixtures/v5/depart/modifier_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "bearing_after": 0,
+            "type": "depart",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "توجّه شمالاً نحو Way Name",
+        "da": "Kør mod nord ad Way Name",
+        "de": "Fahren Sie Richtung Norden auf Way Name",
+        "en": "Head north on Way Name",
+        "eo": "Direktiĝu norden al Way Name",
+        "es": "Ve a norte en Way Name",
+        "es-ES": "Dirígete al norte por Way Name",
+        "fi": "Aja tietä Way Name pohjoiseen",
+        "fr": "Se diriger vers le nord sur Way Name",
+        "he": "התכוונן צפון על Way Name",
+        "hu": "Hajtson az észak irányába a Way Name szakaszon",
+        "id": "Arah utara di Way Name",
+        "it": "Continua verso nord in Way Name",
+        "ja": "Way Nameを北に進む",
+        "ko": "북쪽 로 가서 Way Name 를 이용하세요. ",
+        "my": "မြောက်အရပ်ကို Way Nameအပေါ်တွင် ဦးတည်ပါ",
+        "nl": "Neem Way Name in noordelijke richting",
+        "no": "Kjør i retning nord på Way Name",
+        "pl": "Kieruj się północ na Way Name",
+        "pt-BR": "Siga norte em Way Name",
+        "pt-PT": "Dirija-se para norte em Way Name",
+        "ro": "Mergeți spre nord pe Way Name",
+        "ru": "Двигайтесь в северном направлении по Way Name",
+        "sl": "Peljite v smeri sever po Way Name",
+        "sv": "Kör åt norr på Way Name",
+        "tr": "Way Name üzerinde kuzey yöne git",
+        "uk": "Прямуйте на північ по Way Name",
+        "vi": "Đi về hướng bắc trên Way Name",
+        "yo": "Ori ariwa lori Way Name",
+        "zh-Hans": "出发向北，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/end_of_road/left_junction_name.json
+++ b/test/fixtures/v5/end_of_road/left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يسارا على Shibuya Crossing",
+        "da": "Drej til venstre ved Shibuya Crossing",
+        "de": "Links abbiegen an Shibuya Crossing",
+        "en": "Turn left at Shibuya Crossing",
+        "eo": "Veturu maldekstren ĉe Shibuya Crossing",
+        "es": "Gira a izquierda en Shibuya Crossing",
+        "es-ES": "Al final de la calle gira a la izquierda en Shibuya Crossing",
+        "fi": "Käänny vasemmall(e/a) tielle Shibuya Crossing",
+        "fr": "Tourner à gauche en Shibuya Crossing",
+        "he": "פנה שמאלה על Shibuya Crossing",
+        "hu": "Forduljon be balra az Shibuya Crossing",
+        "id": "Turn kiri at Shibuya Crossing",
+        "it": "Gira a sinistra al Shibuya Crossing",
+        "ja": "Shibuya Crossingを左です",
+        "ko": "Shibuya Crossing에서 좌회전 회전하세요.",
+        "my": "Shibuya Crossing​ပေါ်သို့ ဘယ်ဘက်ကိုလှည့်ပါ",
+        "nl": "Ga links bij Shibuya Crossing",
+        "no": "Sving venstre i Shibuya Crossing",
+        "pl": "Skręć lewo na Shibuya Crossing",
+        "pt-BR": "Vire à esquerda em Shibuya Crossing",
+        "pt-PT": "Vire à esquerda em Shibuya Crossing",
+        "ro": "Virați stânga la Shibuya Crossing",
+        "ru": "Поверните налево на Shibuya Crossing",
+        "sl": "Zavijte levo na Shibuya Crossing",
+        "sv": "Sväng vänster vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda sol tarafa dönün",
+        "uk": "Поверніть ліворуч на Shibuya Crossing",
+        "vi": "Quẹo trái ở Shibuya Crossing",
+        "yo": "Tan-an apa osi ni Shibuya Crossing",
+        "zh-Hans": "Turn 向左 at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/end_of_road/right_junction_name.json
+++ b/test/fixtures/v5/end_of_road/right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يمينا على Shibuya Crossing",
+        "da": "Drej til højre ved Shibuya Crossing",
+        "de": "Rechts abbiegen an Shibuya Crossing",
+        "en": "Turn right at Shibuya Crossing",
+        "eo": "Veturu dekstren ĉe Shibuya Crossing",
+        "es": "Gira a derecha en Shibuya Crossing",
+        "es-ES": "Al final de la calle gira a la derecha en Shibuya Crossing",
+        "fi": "Käänny oikeall(e/a) tielle Shibuya Crossing",
+        "fr": "Tourner à droite en Shibuya Crossing",
+        "he": "פנה ימינה על Shibuya Crossing",
+        "hu": "Forduljon be jobbra az Shibuya Crossing",
+        "id": "Turn kanan at Shibuya Crossing",
+        "it": "Gira a destra al Shibuya Crossing",
+        "ja": "Shibuya Crossingを右です",
+        "ko": "Shibuya Crossing에서 우회전 회전하세요.",
+        "my": "Shibuya Crossing​ပေါ်သို့ ညာဘက်ကိုလှည့်ပါ",
+        "nl": "Ga rechts bij Shibuya Crossing",
+        "no": "Sving høyre i Shibuya Crossing",
+        "pl": "Skręć prawo na Shibuya Crossing",
+        "pt-BR": "Vire à direita em Shibuya Crossing",
+        "pt-PT": "Vire à direita em Shibuya Crossing",
+        "ro": "Virați dreapta la Shibuya Crossing",
+        "ru": "Поверните направо на Shibuya Crossing",
+        "sl": "Zavijte desno na Shibuya Crossing",
+        "sv": "Sväng höger vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda sağ tarafa dönün",
+        "uk": "Поверніть праворуч на Shibuya Crossing",
+        "vi": "Quẹo phải ở Shibuya Crossing",
+        "yo": "Tan-an ọtun ni Shibuya Crossing",
+        "zh-Hans": "Turn 向右 at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/end_of_road/sharp_left_default.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_default.json
@@ -21,7 +21,7 @@
         "hu": "Forduljon élesen balra",
         "id": "Belok tajam kiri",
         "it": "Gira a sinistra",
-        "ja": "大きく左に曲がる",
+        "ja": "左戻るに曲がる",
         "ko": "바로좌회전 회전하세요.",
         "my": "ဘယ်ဘက် ထောင့်ချိုးသို့လှည့်ပါ",
         "nl": "Ga scherpe bocht naar links",

--- a/test/fixtures/v5/end_of_road/sharp_left_destination.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_destination.json
@@ -22,7 +22,7 @@
         "hu": "Forduljon élesen balra a Destination 1 felé",
         "id": "Belok tajam kiri menuju Destination 1",
         "it": "Gira a sinistra verso Destination 1",
-        "ja": "大きく左に曲がり、Destination 1へ向かう",
+        "ja": "左戻るに曲がり、Destination 1へ向かう",
         "ko": "바로좌회전회전 하신 후 Destination 1로 가세요.",
         "my": "Destination 1ဆီသို့ ဘယ်ဘက် ထောင့်ချိုးကို လှည့်ပါ",
         "nl": "Ga scherpe bocht naar links richting Destination 1",

--- a/test/fixtures/v5/end_of_road/sharp_left_exit.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_exit.json
@@ -22,7 +22,7 @@
         "hu": "Forduljon be élesen balra a Way Name irányába",
         "id": "Belok tajam kiri ke Way Name",
         "it": "Gira a sinistra in Way Name",
-        "ja": "大きく左に曲がり、Way Nameを進む",
+        "ja": "左戻るに曲がり、Way Nameを進む",
         "ko": "바로좌회전회전하고 Way Name로 가세요.",
         "my": "Way Name​ပေါ်သို့ ဘယ်ဘက် ထောင့်ချိုးကိုလှည့်ပါ",
         "nl": "Ga scherpe bocht naar links naar Way Name",

--- a/test/fixtures/v5/end_of_road/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Forduljon élesen balra a Destination 1 felé",
         "id": "Belok tajam kiri menuju Destination 1",
         "it": "Gira a sinistra verso Destination 1",
-        "ja": "大きく左に曲がり、Destination 1へ向かう",
+        "ja": "左戻るに曲がり、Destination 1へ向かう",
         "ko": "바로좌회전회전 하신 후 Destination 1로 가세요.",
         "my": "Destination 1ဆီသို့ ဘယ်ဘက် ထောင့်ချိုးကို လှည့်ပါ",
         "nl": "Ga scherpe bocht naar links richting Destination 1",

--- a/test/fixtures/v5/end_of_road/sharp_left_junction_name.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يسار حادا على Shibuya Crossing",
+        "da": "Drej skarpt til venstre ved Shibuya Crossing",
+        "de": "Scharf links abbiegen an Shibuya Crossing",
+        "en": "Turn sharp left at Shibuya Crossing",
+        "eo": "Veturu maldekstregen ĉe Shibuya Crossing",
+        "es": "Gira a cerrada a la izquierda en Shibuya Crossing",
+        "es-ES": "Al final de la calle gira cerrada a la izquierda en Shibuya Crossing",
+        "fi": "Käänny jyrkästi vasempaan tielle Shibuya Crossing",
+        "fr": "Tourner franchement à gauche en Shibuya Crossing",
+        "he": "פנה חדה שמאלה על Shibuya Crossing",
+        "hu": "Forduljon be élesen balra az Shibuya Crossing",
+        "id": "Turn tajam kiri at Shibuya Crossing",
+        "it": "Gira a sinistra al Shibuya Crossing",
+        "ja": "Shibuya Crossingを左戻るです",
+        "ko": "Shibuya Crossing에서 바로좌회전 회전하세요.",
+        "my": "Shibuya Crossing​ပေါ်သို့ ဘယ်ဘက် ထောင့်ချိုးကိုလှည့်ပါ",
+        "nl": "Ga scherpe bocht naar links bij Shibuya Crossing",
+        "no": "Sving skarp venstre i Shibuya Crossing",
+        "pl": "Skręć ostro w lewo na Shibuya Crossing",
+        "pt-BR": "Vire fechada à esquerda em Shibuya Crossing",
+        "pt-PT": "Vire acentuadamente à esquerda em Shibuya Crossing",
+        "ro": "Virați puternic stânga la Shibuya Crossing",
+        "ru": "Поверните налево на Shibuya Crossing",
+        "sl": "Zavijte ostro levo na Shibuya Crossing",
+        "sv": "Sväng vänster vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda keskin sol tarafa dönün",
+        "uk": "Поверніть різко ліворуч на Shibuya Crossing",
+        "vi": "Quẹo trái gắt ở Shibuya Crossing",
+        "yo": "Tan-an didasilẹ ni Shibuya Crossing",
+        "zh-Hans": "Turn 急向左 at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/end_of_road/sharp_left_name.json
+++ b/test/fixtures/v5/end_of_road/sharp_left_name.json
@@ -21,7 +21,7 @@
         "hu": "Forduljon be élesen balra a Way Name irányába",
         "id": "Belok tajam kiri ke Way Name",
         "it": "Gira a sinistra in Way Name",
-        "ja": "大きく左に曲がり、Way Nameを進む",
+        "ja": "左戻るに曲がり、Way Nameを進む",
         "ko": "바로좌회전회전하고 Way Name로 가세요.",
         "my": "Way Name​ပေါ်သို့ ဘယ်ဘက် ထောင့်ချိုးကိုလှည့်ပါ",
         "nl": "Ga scherpe bocht naar links naar Way Name",

--- a/test/fixtures/v5/end_of_road/sharp_right_default.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_default.json
@@ -21,7 +21,7 @@
         "hu": "Forduljon élesen jobbra",
         "id": "Belok tajam kanan",
         "it": "Gira a destra",
-        "ja": "大きく右に曲がる",
+        "ja": "右戻るに曲がる",
         "ko": "바로우회전 회전하세요.",
         "my": "ညာဘက် ထောင့်ချိုးသို့လှည့်ပါ",
         "nl": "Ga scherpe bocht naar rechts",

--- a/test/fixtures/v5/end_of_road/sharp_right_destination.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_destination.json
@@ -22,7 +22,7 @@
         "hu": "Forduljon élesen jobbra a Destination 1 felé",
         "id": "Belok tajam kanan menuju Destination 1",
         "it": "Gira a destra verso Destination 1",
-        "ja": "大きく右に曲がり、Destination 1へ向かう",
+        "ja": "右戻るに曲がり、Destination 1へ向かう",
         "ko": "바로우회전회전 하신 후 Destination 1로 가세요.",
         "my": "Destination 1ဆီသို့ ညာဘက် ထောင့်ချိုးကို လှည့်ပါ",
         "nl": "Ga scherpe bocht naar rechts richting Destination 1",

--- a/test/fixtures/v5/end_of_road/sharp_right_exit.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_exit.json
@@ -22,7 +22,7 @@
         "hu": "Forduljon be élesen jobbra a Way Name irányába",
         "id": "Belok tajam kanan ke Way Name",
         "it": "Gira a destra in Way Name",
-        "ja": "大きく右に曲がり、Way Nameを進む",
+        "ja": "右戻るに曲がり、Way Nameを進む",
         "ko": "바로우회전회전하고 Way Name로 가세요.",
         "my": "Way Name​ပေါ်သို့ ညာဘက် ထောင့်ချိုးကိုလှည့်ပါ",
         "nl": "Ga scherpe bocht naar rechts naar Way Name",

--- a/test/fixtures/v5/end_of_road/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Forduljon élesen jobbra a Destination 1 felé",
         "id": "Belok tajam kanan menuju Destination 1",
         "it": "Gira a destra verso Destination 1",
-        "ja": "大きく右に曲がり、Destination 1へ向かう",
+        "ja": "右戻るに曲がり、Destination 1へ向かう",
         "ko": "바로우회전회전 하신 후 Destination 1로 가세요.",
         "my": "Destination 1ဆီသို့ ညာဘက် ထောင့်ချိုးကို လှည့်ပါ",
         "nl": "Ga scherpe bocht naar rechts richting Destination 1",

--- a/test/fixtures/v5/end_of_road/sharp_right_junction_name.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يمين حادا على Shibuya Crossing",
+        "da": "Drej skarpt til højre ved Shibuya Crossing",
+        "de": "Scharf rechts abbiegen an Shibuya Crossing",
+        "en": "Turn sharp right at Shibuya Crossing",
+        "eo": "Veturu dekstregen ĉe Shibuya Crossing",
+        "es": "Gira a cerrada a la derecha en Shibuya Crossing",
+        "es-ES": "Al final de la calle gira cerrada a la derecha en Shibuya Crossing",
+        "fi": "Käänny jyrkästi oikeaan tielle Shibuya Crossing",
+        "fr": "Tourner franchement à droite en Shibuya Crossing",
+        "he": "פנה חדה ימינה על Shibuya Crossing",
+        "hu": "Forduljon be élesen jobbra az Shibuya Crossing",
+        "id": "Turn tajam kanan at Shibuya Crossing",
+        "it": "Gira a destra al Shibuya Crossing",
+        "ja": "Shibuya Crossingを右戻るです",
+        "ko": "Shibuya Crossing에서 바로우회전 회전하세요.",
+        "my": "Shibuya Crossing​ပေါ်သို့ ညာဘက် ထောင့်ချိုးကိုလှည့်ပါ",
+        "nl": "Ga scherpe bocht naar rechts bij Shibuya Crossing",
+        "no": "Sving skarp høyre i Shibuya Crossing",
+        "pl": "Skręć ostro w prawo na Shibuya Crossing",
+        "pt-BR": "Vire fechada à direita em Shibuya Crossing",
+        "pt-PT": "Vire acentuadamente à direita em Shibuya Crossing",
+        "ro": "Virați puternic dreapta la Shibuya Crossing",
+        "ru": "Поверните направо на Shibuya Crossing",
+        "sl": "Zavijte ostro desno na Shibuya Crossing",
+        "sv": "Sväng höger vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda keskin sağ tarafa dönün",
+        "uk": "Поверніть різко праворуч на Shibuya Crossing",
+        "vi": "Quẹo phải gắt ở Shibuya Crossing",
+        "yo": "Tan-an didasilẹ ọtun ni Shibuya Crossing",
+        "zh-Hans": "Turn 急向右 at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/end_of_road/sharp_right_name.json
+++ b/test/fixtures/v5/end_of_road/sharp_right_name.json
@@ -21,7 +21,7 @@
         "hu": "Forduljon be élesen jobbra a Way Name irányába",
         "id": "Belok tajam kanan ke Way Name",
         "it": "Gira a destra in Way Name",
-        "ja": "大きく右に曲がり、Way Nameを進む",
+        "ja": "右戻るに曲がり、Way Nameを進む",
         "ko": "바로우회전회전하고 Way Name로 가세요.",
         "my": "Way Name​ပေါ်သို့ ညာဘက် ထောင့်ချိုးကိုလှည့်ပါ",
         "nl": "Ga scherpe bocht naar rechts naar Way Name",

--- a/test/fixtures/v5/end_of_road/slight_left_junction_name.json
+++ b/test/fixtures/v5/end_of_road/slight_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يساراً قليلاًا على Shibuya Crossing",
+        "da": "Drej svagt til venstre ved Shibuya Crossing",
+        "de": "Leicht links abbiegen an Shibuya Crossing",
+        "en": "Turn slight left at Shibuya Crossing",
+        "eo": "Veturu maldekstreten ĉe Shibuya Crossing",
+        "es": "Gira a levemente a la izquierda en Shibuya Crossing",
+        "es-ES": "Al final de la calle gira ligeramente a la izquierda en Shibuya Crossing",
+        "fi": "Käänny loivasti vasempaan tielle Shibuya Crossing",
+        "fr": "Tourner légèrement à gauche en Shibuya Crossing",
+        "he": "פנה קלה שמאלה על Shibuya Crossing",
+        "hu": "Forduljon be enyhén balra az Shibuya Crossing",
+        "id": "Turn agak ke kiri at Shibuya Crossing",
+        "it": "Gira a sinistra leggermente al Shibuya Crossing",
+        "ja": "Shibuya Crossingを斜め左です",
+        "ko": "Shibuya Crossing에서 조금왼쪽 회전하세요.",
+        "my": "Shibuya Crossing​ပေါ်သို့ ဘယ်ဘက် အနည်းငယ်ကိုလှည့်ပါ",
+        "nl": "Ga iets naar links bij Shibuya Crossing",
+        "no": "Sving litt til venstre i Shibuya Crossing",
+        "pl": "Skręć łagodnie w lewo na Shibuya Crossing",
+        "pt-BR": "Vire suave à esquerda em Shibuya Crossing",
+        "pt-PT": "Vire ligeiramente à esquerda em Shibuya Crossing",
+        "ro": "Virați ușor stânga la Shibuya Crossing",
+        "ru": "Поверните левее на Shibuya Crossing",
+        "sl": "Zavijte rahlo levo na Shibuya Crossing",
+        "sv": "Sväng vänster vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda hafif sol tarafa dönün",
+        "uk": "Поверніть плавно ліворуч на Shibuya Crossing",
+        "vi": "Quẹo trái nghiêng ở Shibuya Crossing",
+        "yo": "Tan-an diẹ osi ni Shibuya Crossing",
+        "zh-Hans": "Turn 稍向左 at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/end_of_road/slight_right_junction_name.json
+++ b/test/fixtures/v5/end_of_road/slight_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يساراً قليلاًا على Shibuya Crossing",
+        "da": "Drej svagt til højre ved Shibuya Crossing",
+        "de": "Leicht rechts abbiegen an Shibuya Crossing",
+        "en": "Turn slight right at Shibuya Crossing",
+        "eo": "Veturu dekstreten ĉe Shibuya Crossing",
+        "es": "Gira a levemente a la derecha en Shibuya Crossing",
+        "es-ES": "Al final de la calle gira ligeramente a la derecha en Shibuya Crossing",
+        "fi": "Käänny loivasti oikeaan tielle Shibuya Crossing",
+        "fr": "Tourner légèrement à droite en Shibuya Crossing",
+        "he": "פנה קלה ימינה על Shibuya Crossing",
+        "hu": "Forduljon be enyhén jobbra az Shibuya Crossing",
+        "id": "Turn agak ke kanan at Shibuya Crossing",
+        "it": "Gira a destra leggermente al Shibuya Crossing",
+        "ja": "Shibuya Crossingを斜め右です",
+        "ko": "Shibuya Crossing에서 조금오른쪽 회전하세요.",
+        "my": "Shibuya Crossing​ပေါ်သို့ ညာဘက် အနည်းငယ်ကိုလှည့်ပါ",
+        "nl": "Ga iets naar rechts bij Shibuya Crossing",
+        "no": "Sving litt til høyre i Shibuya Crossing",
+        "pl": "Skręć łagodnie w prawo na Shibuya Crossing",
+        "pt-BR": "Vire suave à direita em Shibuya Crossing",
+        "pt-PT": "Vire ligeiramente à direita em Shibuya Crossing",
+        "ro": "Virați ușor dreapta la Shibuya Crossing",
+        "ru": "Поверните правее на Shibuya Crossing",
+        "sl": "Zavijte rahlo desno na Shibuya Crossing",
+        "sv": "Sväng höger vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda hafif sağ tarafa dönün",
+        "uk": "Поверніть плавно праворуч на Shibuya Crossing",
+        "vi": "Quẹo phải nghiêng ở Shibuya Crossing",
+        "yo": "Tan-an diẹ ọtun ni Shibuya Crossing",
+        "zh-Hans": "Turn 稍向右 at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/end_of_road/straight_junction_name.json
+++ b/test/fixtures/v5/end_of_road/straight_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "تابع إلى الأمام على Shibuya Crossing",
+        "da": "Fortsæt ligeud ved Shibuya Crossing",
+        "de": "Geradeaus weiterfahren an Shibuya Crossing",
+        "en": "Continue straight at Shibuya Crossing",
+        "eo": "Veturu rekten ĉe Shibuya Crossing",
+        "es": "Continúa recto en Shibuya Crossing",
+        "es-ES": "Al final de la calle continúa recto en Shibuya Crossing",
+        "fi": "Jatka suoraan eteenpäin tielle Shibuya Crossing",
+        "fr": "Continuer tout droit en Shibuya Crossing",
+        "he": "המשך ישר על Shibuya Crossing",
+        "hu": "Hajtson tovább egyenesen az Shibuya Crossing",
+        "id": "Continue straight at Shibuya Crossing",
+        "it": "Continua dritto al Shibuya Crossing",
+        "ja": "Shibuya Crossingを直進です",
+        "ko": "Shibuya Crossing에서 계속 직진해 주세요.",
+        "my": "Shibuya Crossing​ပေါ်သို့တည့်တည့်ဆက်သွားပါ",
+        "nl": "Ga rechtdoor bij Shibuya Crossing",
+        "no": "Fortsett rett frem i Shibuya Crossing",
+        "pl": "Kontynuuj prosto na Shibuya Crossing",
+        "pt-BR": "Continue em frente em Shibuya Crossing",
+        "pt-PT": "Continue em frente em Shibuya Crossing",
+        "ro": "Continuați înainte la Shibuya Crossing",
+        "ru": "Двигайтесь прямо по Shibuya Crossing",
+        "sl": "Nadaljujte naravnost na Shibuya Crossing",
+        "sv": "Fortsätt rakt fram vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda düz devam et",
+        "uk": "Продовжуйте рух прямо до Shibuya Crossing",
+        "vi": "Chạy thẳng ở Shibuya Crossing",
+        "yo": "Tẹsiwaju ni gígùn ni Shibuya Crossing",
+        "zh-Hans": "Continue straight at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/end_of_road/uturn_junction_name.json
+++ b/test/fixtures/v5/end_of_road/uturn_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "end of road",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف دوراناً عكسياً نحو Shibuya Crossing",
+        "da": "Foretag en U-vending ved Shibuya Crossing",
+        "de": "180°-Wendung an Shibuya Crossing",
+        "en": "Make a U-turn at Shibuya Crossing",
+        "eo": "Turniĝu malantaŭen ĉe Shibuya Crossing",
+        "es": "Haz un cambio de sentido en Shibuya Crossing",
+        "es-ES": "Haz un cambio de sentido en Shibuya Crossing",
+        "fi": "Tien päässä tee U-käännös tielle Shibuya Crossing",
+        "fr": "Faire demi-tour en Shibuya Crossing",
+        "he": "פנה פניית פרסה על Shibuya Crossing בסוף הדרך",
+        "hu": "Forduljon vissza az Shibuya Crossing",
+        "id": "Make a U-turn at Shibuya Crossing",
+        "it": "Fai un’inversione a U al Shibuya Crossing",
+        "ja": "Shibuya Crossingの突き当りでUターンする",
+        "ko": "Shibuya Crossing에서 유턴 하세요.",
+        "my": "လမ်းအဆုံးတွင် Shibuya Crossing​ပေါ်သို့ဂ-ကွေ့ကွေ့ပါ",
+        "nl": "Keer om bij Shibuya Crossing",
+        "no": "Ta en U-sving i Shibuya Crossing",
+        "pl": "Zawróć na Shibuya Crossing",
+        "pt-BR": "Faça o retorno em Shibuya Crossing",
+        "pt-PT": "Faça uma inversão de marcha em Shibuya Crossing",
+        "ro": "Întoarceți-vă la Shibuya Crossing",
+        "ru": "Развернитесь в конце Shibuya Crossing",
+        "sl": "Polkrožno obrnite na Shibuya Crossing",
+        "sv": "Gör en U-sväng vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda bir U-dönüşü yap",
+        "uk": "Здійсніть розворот на Shibuya Crossing",
+        "vi": "Quẹo ngược lại ở Shibuya Crossing",
+        "yo": "Ṣe ayipada U ni Shibuya Crossing",
+        "zh-Hans": "Make a U-turn at Shibuya Crossing at the end of the road"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/left_junction_name.json
+++ b/test/fixtures/v5/exit_rotary/left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اخرج من مسار الدوران على Way Name",
+        "da": "Forlad rundkørslen ad Way Name",
+        "de": "Links abbiegen auf Way Name",
+        "en": "Exit the roundabout onto Way Name",
+        "eo": "Elveturu trafikcirklegon al Way Name",
+        "es": "Sal la rotonda en Way Name",
+        "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
+        "fr": "Sortir du rond-point sur Way Name",
+        "he": "צא ממעגל התנועה לWay Name",
+        "hu": "Hajtson ki a körforgalomból a Way Name felé",
+        "id": "Belok kiri ke Way Name",
+        "it": "Svolta a sinistra in Way Name",
+        "ja": "ランアバウトを出てWay Nameを進む",
+        "ko": "로타리에서 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Verlaat de rotonde en ga verder op Way Name",
+        "no": "Kjør ut av rundkjøringen og inn på Way Name",
+        "pl": "Skręć w lewo na Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
+        "pt-PT": "Saia da rotunda para Way Name",
+        "ro": "Ieșiți din sensul giratoriu pe Way Name",
+        "ru": "Сверните с круговой развязки на Way Name",
+        "sl": "Zapustite krožišče in zapeljite na Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
+        "tr": "Way Name üzerinde sola dön",
+        "uk": "Залишить коло на Way Name зʼїзді",
+        "vi": "Ra bùng binh vào Way Name",
+        "yo": "Jade ni ọna iṣakoso pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "驶离环岛，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/right_junction_name.json
+++ b/test/fixtures/v5/exit_rotary/right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اخرج من مسار الدوران على Way Name",
+        "da": "Forlad rundkørslen ad Way Name",
+        "de": "Rechts abbiegen auf Way Name",
+        "en": "Exit the roundabout onto Way Name",
+        "eo": "Elveturu trafikcirklegon al Way Name",
+        "es": "Sal la rotonda en Way Name",
+        "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
+        "fr": "Sortir du rond-point sur Way Name",
+        "he": "צא ממעגל התנועה לWay Name",
+        "hu": "Hajtson ki a körforgalomból a Way Name felé",
+        "id": "Belok kanan ke Way Name",
+        "it": "Svolta a destra in Way Name",
+        "ja": "ランアバウトを出てWay Nameを進む",
+        "ko": "로타리에서 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Verlaat de rotonde en ga verder op Way Name",
+        "no": "Kjør ut av rundkjøringen og inn på Way Name",
+        "pl": "Skręć w prawo na Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
+        "pt-PT": "Saia da rotunda para Way Name",
+        "ro": "Ieșiți din sensul giratoriu pe Way Name",
+        "ru": "Сверните с круговой развязки на Way Name",
+        "sl": "Zapustite krožišče in zapeljite na Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
+        "tr": "Way Name üzerinde sağa dön",
+        "uk": "Залишить коло на Way Name зʼїзді",
+        "vi": "Ra bùng binh vào Way Name",
+        "yo": "Jade ni ọna iṣakoso pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "驶离环岛，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/sharp_left_junction_name.json
+++ b/test/fixtures/v5/exit_rotary/sharp_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اخرج من مسار الدوران على Way Name",
+        "da": "Forlad rundkørslen ad Way Name",
+        "de": "Scharf links abbiegen auf Way Name",
+        "en": "Exit the roundabout onto Way Name",
+        "eo": "Elveturu trafikcirklegon al Way Name",
+        "es": "Sal la rotonda en Way Name",
+        "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
+        "fr": "Sortir du rond-point sur Way Name",
+        "he": "צא ממעגל התנועה לWay Name",
+        "hu": "Hajtson ki a körforgalomból a Way Name felé",
+        "id": "Lakukan tajam kiri ke arah Way Name",
+        "it": "Fai una sinistra in Way Name",
+        "ja": "ランアバウトを出てWay Nameを進む",
+        "ko": "로타리에서 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Verlaat de rotonde en ga verder op Way Name",
+        "no": "Kjør ut av rundkjøringen og inn på Way Name",
+        "pl": "Ostro w lewo na Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
+        "pt-PT": "Saia da rotunda para Way Name",
+        "ro": "Ieșiți din sensul giratoriu pe Way Name",
+        "ru": "Сверните с круговой развязки на Way Name",
+        "sl": "Zapustite krožišče in zapeljite na Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
+        "tr": "Way Name üzerinde keskin sol yöne dön",
+        "uk": "Залишить коло на Way Name зʼїзді",
+        "vi": "Ra bùng binh vào Way Name",
+        "yo": "Jade ni ọna iṣakoso pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "驶离环岛，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/sharp_right_junction_name.json
+++ b/test/fixtures/v5/exit_rotary/sharp_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اخرج من مسار الدوران على Way Name",
+        "da": "Forlad rundkørslen ad Way Name",
+        "de": "Scharf rechts abbiegen auf Way Name",
+        "en": "Exit the roundabout onto Way Name",
+        "eo": "Elveturu trafikcirklegon al Way Name",
+        "es": "Sal la rotonda en Way Name",
+        "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
+        "fr": "Sortir du rond-point sur Way Name",
+        "he": "צא ממעגל התנועה לWay Name",
+        "hu": "Hajtson ki a körforgalomból a Way Name felé",
+        "id": "Lakukan tajam kanan ke arah Way Name",
+        "it": "Fai una destra in Way Name",
+        "ja": "ランアバウトを出てWay Nameを進む",
+        "ko": "로타리에서 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Verlaat de rotonde en ga verder op Way Name",
+        "no": "Kjør ut av rundkjøringen og inn på Way Name",
+        "pl": "Ostro w prawo na Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
+        "pt-PT": "Saia da rotunda para Way Name",
+        "ro": "Ieșiți din sensul giratoriu pe Way Name",
+        "ru": "Сверните с круговой развязки на Way Name",
+        "sl": "Zapustite krožišče in zapeljite na Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
+        "tr": "Way Name üzerinde keskin sağ yöne dön",
+        "uk": "Залишить коло на Way Name зʼїзді",
+        "vi": "Ra bùng binh vào Way Name",
+        "yo": "Jade ni ọna iṣakoso pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "驶离环岛，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/slight_left_junction_name.json
+++ b/test/fixtures/v5/exit_rotary/slight_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اخرج من مسار الدوران على Way Name",
+        "da": "Forlad rundkørslen ad Way Name",
+        "de": "Leicht links abbiegen auf Way Name",
+        "en": "Exit the roundabout onto Way Name",
+        "eo": "Elveturu trafikcirklegon al Way Name",
+        "es": "Sal la rotonda en Way Name",
+        "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
+        "fr": "Sortir du rond-point sur Way Name",
+        "he": "צא ממעגל התנועה לWay Name",
+        "hu": "Hajtson ki a körforgalomból a Way Name felé",
+        "id": "Lakukan agak ke kiri ke arah Way Name",
+        "it": "Fai una sinistra leggermente in Way Name",
+        "ja": "ランアバウトを出てWay Nameを進む",
+        "ko": "로타리에서 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Verlaat de rotonde en ga verder op Way Name",
+        "no": "Kjør ut av rundkjøringen og inn på Way Name",
+        "pl": "Łagodnie w lewo na Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
+        "pt-PT": "Saia da rotunda para Way Name",
+        "ro": "Ieșiți din sensul giratoriu pe Way Name",
+        "ru": "Сверните с круговой развязки на Way Name",
+        "sl": "Zapustite krožišče in zapeljite na Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
+        "tr": "Way Name üzerinde hafif sol yöne dön",
+        "uk": "Залишить коло на Way Name зʼїзді",
+        "vi": "Ra bùng binh vào Way Name",
+        "yo": "Jade ni ọna iṣakoso pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "驶离环岛，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/slight_right_junction_name.json
+++ b/test/fixtures/v5/exit_rotary/slight_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اخرج من مسار الدوران على Way Name",
+        "da": "Forlad rundkørslen ad Way Name",
+        "de": "Leicht rechts abbiegen auf Way Name",
+        "en": "Exit the roundabout onto Way Name",
+        "eo": "Elveturu trafikcirklegon al Way Name",
+        "es": "Sal la rotonda en Way Name",
+        "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
+        "fr": "Sortir du rond-point sur Way Name",
+        "he": "צא ממעגל התנועה לWay Name",
+        "hu": "Hajtson ki a körforgalomból a Way Name felé",
+        "id": "Lakukan agak ke kanan ke arah Way Name",
+        "it": "Fai una destra leggermente in Way Name",
+        "ja": "ランアバウトを出てWay Nameを進む",
+        "ko": "로타리에서 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Verlaat de rotonde en ga verder op Way Name",
+        "no": "Kjør ut av rundkjøringen og inn på Way Name",
+        "pl": "Łagodnie w prawo na Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
+        "pt-PT": "Saia da rotunda para Way Name",
+        "ro": "Ieșiți din sensul giratoriu pe Way Name",
+        "ru": "Сверните с круговой развязки на Way Name",
+        "sl": "Zapustite krožišče in zapeljite na Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
+        "tr": "Way Name üzerinde hafif sağ yöne dön",
+        "uk": "Залишить коло на Way Name зʼїзді",
+        "vi": "Ra bùng binh vào Way Name",
+        "yo": "Jade ni ọna iṣakoso pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "驶离环岛，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/straight_junction_name.json
+++ b/test/fixtures/v5/exit_rotary/straight_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اخرج من مسار الدوران على Way Name",
+        "da": "Forlad rundkørslen ad Way Name",
+        "de": "Geradeaus weiterfahren auf Way Name",
+        "en": "Exit the roundabout onto Way Name",
+        "eo": "Elveturu trafikcirklegon al Way Name",
+        "es": "Sal la rotonda en Way Name",
+        "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
+        "fr": "Sortir du rond-point sur Way Name",
+        "he": "צא ממעגל התנועה לWay Name",
+        "hu": "Hajtson ki a körforgalomból a Way Name felé",
+        "id": "Lurus arah Way Name",
+        "it": "Continua su Way Name",
+        "ja": "ランアバウトを出てWay Nameを進む",
+        "ko": "로타리에서 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Verlaat de rotonde en ga verder op Way Name",
+        "no": "Kjør ut av rundkjøringen og inn på Way Name",
+        "pl": "Jedź prosto na Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
+        "pt-PT": "Saia da rotunda para Way Name",
+        "ro": "Ieșiți din sensul giratoriu pe Way Name",
+        "ru": "Сверните с круговой развязки на Way Name",
+        "sl": "Zapustite krožišče in zapeljite na Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
+        "tr": "Way Name üzerinde düz devam et",
+        "uk": "Залишить коло на Way Name зʼїзді",
+        "vi": "Ra bùng binh vào Way Name",
+        "yo": "Jade ni ọna iṣakoso pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "驶离环岛，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_rotary/uturn_junction_name.json
+++ b/test/fixtures/v5/exit_rotary/uturn_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit rotary",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اخرج من مسار الدوران على Way Name",
+        "da": "Forlad rundkørslen ad Way Name",
+        "de": "180°-Wendung abbiegen auf Way Name",
+        "en": "Exit the roundabout onto Way Name",
+        "eo": "Elveturu trafikcirklegon al Way Name",
+        "es": "Sal la rotonda en Way Name",
+        "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
+        "fr": "Sortir du rond-point sur Way Name",
+        "he": "צא ממעגל התנועה לWay Name",
+        "hu": "Hajtson ki a körforgalomból a Way Name felé",
+        "id": "Lakukan putar balik ke arah Way Name",
+        "it": "Fai una inversione a U in Way Name",
+        "ja": "ランアバウトを出てWay Nameを進む",
+        "ko": "로타리에서 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Verlaat de rotonde en ga verder op Way Name",
+        "no": "Kjør ut av rundkjøringen og inn på Way Name",
+        "pl": "Zawróć na Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
+        "pt-PT": "Saia da rotunda para Way Name",
+        "ro": "Ieșiți din sensul giratoriu pe Way Name",
+        "ru": "Сверните с круговой развязки на Way Name",
+        "sl": "Zapustite krožišče in zapeljite na Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
+        "tr": "Way Name üzerinde U dönüşü yöne dön",
+        "uk": "Залишить коло на Way Name зʼїзді",
+        "vi": "Ra bùng binh vào Way Name",
+        "yo": "Jade ni ọna iṣakoso pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "驶离环岛，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/left_junction_name.json
+++ b/test/fixtures/v5/exit_roundabout/left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اخرج من مسار الدوران على Way Name",
+        "da": "Forlad rundkørslen ad Way Name",
+        "de": "Links abbiegen auf Way Name",
+        "en": "Exit the roundabout onto Way Name",
+        "eo": "Elveturu trafikcirklegon al Way Name",
+        "es": "Sal la rotonda en Way Name",
+        "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
+        "fr": "Sortir du rond-point sur Way Name",
+        "he": "צא ממעגל התנועה לWay Name",
+        "hu": "Hajtson ki a körforgalomból a Way Name felé",
+        "id": "Belok kiri ke Way Name",
+        "it": "Svolta a sinistra in Way Name",
+        "ja": "ランアバウトを出てWay Nameを進む",
+        "ko": "로타리에서 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Verlaat de rotonde en ga verder op Way Name",
+        "no": "Kjør ut av rundkjøringen og inn på Way Name",
+        "pl": "Skręć w lewo na Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
+        "pt-PT": "Saia da rotunda para Way Name",
+        "ro": "Ieșiți din sensul giratoriu pe Way Name",
+        "ru": "Сверните с круговой развязки на Way Name",
+        "sl": "Zapustite krožišče in zapeljite na Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
+        "tr": "Way Name üzerinde sola dön",
+        "uk": "Залишить коло на Way Name зʼїзді",
+        "vi": "Ra bùng binh vào Way Name",
+        "yo": "Jade ni ọna iṣakoso pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "驶离环岛，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/right_junction_name.json
+++ b/test/fixtures/v5/exit_roundabout/right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اخرج من مسار الدوران على Way Name",
+        "da": "Forlad rundkørslen ad Way Name",
+        "de": "Rechts abbiegen auf Way Name",
+        "en": "Exit the roundabout onto Way Name",
+        "eo": "Elveturu trafikcirklegon al Way Name",
+        "es": "Sal la rotonda en Way Name",
+        "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
+        "fr": "Sortir du rond-point sur Way Name",
+        "he": "צא ממעגל התנועה לWay Name",
+        "hu": "Hajtson ki a körforgalomból a Way Name felé",
+        "id": "Belok kanan ke Way Name",
+        "it": "Svolta a destra in Way Name",
+        "ja": "ランアバウトを出てWay Nameを進む",
+        "ko": "로타리에서 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Verlaat de rotonde en ga verder op Way Name",
+        "no": "Kjør ut av rundkjøringen og inn på Way Name",
+        "pl": "Skręć w prawo na Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
+        "pt-PT": "Saia da rotunda para Way Name",
+        "ro": "Ieșiți din sensul giratoriu pe Way Name",
+        "ru": "Сверните с круговой развязки на Way Name",
+        "sl": "Zapustite krožišče in zapeljite na Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
+        "tr": "Way Name üzerinde sağa dön",
+        "uk": "Залишить коло на Way Name зʼїзді",
+        "vi": "Ra bùng binh vào Way Name",
+        "yo": "Jade ni ọna iṣakoso pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "驶离环岛，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/sharp_left_junction_name.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اخرج من مسار الدوران على Way Name",
+        "da": "Forlad rundkørslen ad Way Name",
+        "de": "Scharf links abbiegen auf Way Name",
+        "en": "Exit the roundabout onto Way Name",
+        "eo": "Elveturu trafikcirklegon al Way Name",
+        "es": "Sal la rotonda en Way Name",
+        "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
+        "fr": "Sortir du rond-point sur Way Name",
+        "he": "צא ממעגל התנועה לWay Name",
+        "hu": "Hajtson ki a körforgalomból a Way Name felé",
+        "id": "Lakukan tajam kiri ke arah Way Name",
+        "it": "Fai una sinistra in Way Name",
+        "ja": "ランアバウトを出てWay Nameを進む",
+        "ko": "로타리에서 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Verlaat de rotonde en ga verder op Way Name",
+        "no": "Kjør ut av rundkjøringen og inn på Way Name",
+        "pl": "Ostro w lewo na Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
+        "pt-PT": "Saia da rotunda para Way Name",
+        "ro": "Ieșiți din sensul giratoriu pe Way Name",
+        "ru": "Сверните с круговой развязки на Way Name",
+        "sl": "Zapustite krožišče in zapeljite na Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
+        "tr": "Way Name üzerinde keskin sol yöne dön",
+        "uk": "Залишить коло на Way Name зʼїзді",
+        "vi": "Ra bùng binh vào Way Name",
+        "yo": "Jade ni ọna iṣakoso pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "驶离环岛，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/sharp_right_junction_name.json
+++ b/test/fixtures/v5/exit_roundabout/sharp_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اخرج من مسار الدوران على Way Name",
+        "da": "Forlad rundkørslen ad Way Name",
+        "de": "Scharf rechts abbiegen auf Way Name",
+        "en": "Exit the roundabout onto Way Name",
+        "eo": "Elveturu trafikcirklegon al Way Name",
+        "es": "Sal la rotonda en Way Name",
+        "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
+        "fr": "Sortir du rond-point sur Way Name",
+        "he": "צא ממעגל התנועה לWay Name",
+        "hu": "Hajtson ki a körforgalomból a Way Name felé",
+        "id": "Lakukan tajam kanan ke arah Way Name",
+        "it": "Fai una destra in Way Name",
+        "ja": "ランアバウトを出てWay Nameを進む",
+        "ko": "로타리에서 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Verlaat de rotonde en ga verder op Way Name",
+        "no": "Kjør ut av rundkjøringen og inn på Way Name",
+        "pl": "Ostro w prawo na Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
+        "pt-PT": "Saia da rotunda para Way Name",
+        "ro": "Ieșiți din sensul giratoriu pe Way Name",
+        "ru": "Сверните с круговой развязки на Way Name",
+        "sl": "Zapustite krožišče in zapeljite na Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
+        "tr": "Way Name üzerinde keskin sağ yöne dön",
+        "uk": "Залишить коло на Way Name зʼїзді",
+        "vi": "Ra bùng binh vào Way Name",
+        "yo": "Jade ni ọna iṣakoso pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "驶离环岛，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/slight_left_junction_name.json
+++ b/test/fixtures/v5/exit_roundabout/slight_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اخرج من مسار الدوران على Way Name",
+        "da": "Forlad rundkørslen ad Way Name",
+        "de": "Leicht links abbiegen auf Way Name",
+        "en": "Exit the roundabout onto Way Name",
+        "eo": "Elveturu trafikcirklegon al Way Name",
+        "es": "Sal la rotonda en Way Name",
+        "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
+        "fr": "Sortir du rond-point sur Way Name",
+        "he": "צא ממעגל התנועה לWay Name",
+        "hu": "Hajtson ki a körforgalomból a Way Name felé",
+        "id": "Lakukan agak ke kiri ke arah Way Name",
+        "it": "Fai una sinistra leggermente in Way Name",
+        "ja": "ランアバウトを出てWay Nameを進む",
+        "ko": "로타리에서 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Verlaat de rotonde en ga verder op Way Name",
+        "no": "Kjør ut av rundkjøringen og inn på Way Name",
+        "pl": "Łagodnie w lewo na Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
+        "pt-PT": "Saia da rotunda para Way Name",
+        "ro": "Ieșiți din sensul giratoriu pe Way Name",
+        "ru": "Сверните с круговой развязки на Way Name",
+        "sl": "Zapustite krožišče in zapeljite na Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
+        "tr": "Way Name üzerinde hafif sol yöne dön",
+        "uk": "Залишить коло на Way Name зʼїзді",
+        "vi": "Ra bùng binh vào Way Name",
+        "yo": "Jade ni ọna iṣakoso pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "驶离环岛，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/slight_right_junction_name.json
+++ b/test/fixtures/v5/exit_roundabout/slight_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اخرج من مسار الدوران على Way Name",
+        "da": "Forlad rundkørslen ad Way Name",
+        "de": "Leicht rechts abbiegen auf Way Name",
+        "en": "Exit the roundabout onto Way Name",
+        "eo": "Elveturu trafikcirklegon al Way Name",
+        "es": "Sal la rotonda en Way Name",
+        "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
+        "fr": "Sortir du rond-point sur Way Name",
+        "he": "צא ממעגל התנועה לWay Name",
+        "hu": "Hajtson ki a körforgalomból a Way Name felé",
+        "id": "Lakukan agak ke kanan ke arah Way Name",
+        "it": "Fai una destra leggermente in Way Name",
+        "ja": "ランアバウトを出てWay Nameを進む",
+        "ko": "로타리에서 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Verlaat de rotonde en ga verder op Way Name",
+        "no": "Kjør ut av rundkjøringen og inn på Way Name",
+        "pl": "Łagodnie w prawo na Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
+        "pt-PT": "Saia da rotunda para Way Name",
+        "ro": "Ieșiți din sensul giratoriu pe Way Name",
+        "ru": "Сверните с круговой развязки на Way Name",
+        "sl": "Zapustite krožišče in zapeljite na Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
+        "tr": "Way Name üzerinde hafif sağ yöne dön",
+        "uk": "Залишить коло на Way Name зʼїзді",
+        "vi": "Ra bùng binh vào Way Name",
+        "yo": "Jade ni ọna iṣakoso pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "驶离环岛，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/straight_junction_name.json
+++ b/test/fixtures/v5/exit_roundabout/straight_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اخرج من مسار الدوران على Way Name",
+        "da": "Forlad rundkørslen ad Way Name",
+        "de": "Geradeaus weiterfahren auf Way Name",
+        "en": "Exit the roundabout onto Way Name",
+        "eo": "Elveturu trafikcirklegon al Way Name",
+        "es": "Sal la rotonda en Way Name",
+        "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
+        "fr": "Sortir du rond-point sur Way Name",
+        "he": "צא ממעגל התנועה לWay Name",
+        "hu": "Hajtson ki a körforgalomból a Way Name felé",
+        "id": "Tetap lurus ke Way Name ",
+        "it": "Continua dritto in Way Name",
+        "ja": "ランアバウトを出てWay Nameを進む",
+        "ko": "로타리에서 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Verlaat de rotonde en ga verder op Way Name",
+        "no": "Kjør ut av rundkjøringen og inn på Way Name",
+        "pl": "Kontynuuj prosto na Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
+        "pt-PT": "Saia da rotunda para Way Name",
+        "ro": "Ieșiți din sensul giratoriu pe Way Name",
+        "ru": "Сверните с круговой развязки на Way Name",
+        "sl": "Zapustite krožišče in zapeljite na Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
+        "tr": "Way Name üzerinde düz devam et",
+        "uk": "Залишить коло на Way Name зʼїзді",
+        "vi": "Ra bùng binh vào Way Name",
+        "yo": "Jade ni ọna iṣakoso pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "驶离环岛，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/exit_roundabout/uturn_junction_name.json
+++ b/test/fixtures/v5/exit_roundabout/uturn_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "exit roundabout",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اخرج من مسار الدوران على Way Name",
+        "da": "Forlad rundkørslen ad Way Name",
+        "de": "180°-Wendung abbiegen auf Way Name",
+        "en": "Exit the roundabout onto Way Name",
+        "eo": "Elveturu trafikcirklegon al Way Name",
+        "es": "Sal la rotonda en Way Name",
+        "es-ES": "Toma la salida por Way Name",
+        "fi": "Poistu liikenneympyrästä tielle Way Name",
+        "fr": "Sortir du rond-point sur Way Name",
+        "he": "צא ממעגל התנועה לWay Name",
+        "hu": "Hajtson ki a körforgalomból a Way Name felé",
+        "id": "Lakukan putar balik ke arah Way Name",
+        "it": "Fai una inversione a U in Way Name",
+        "ja": "ランアバウトを出てWay Nameを進む",
+        "ko": "로타리에서 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Verlaat de rotonde en ga verder op Way Name",
+        "no": "Kjør ut av rundkjøringen og inn på Way Name",
+        "pl": "Zawróć na Way Name",
+        "pt-BR": "Exit the roundabout onto Way Name",
+        "pt-PT": "Saia da rotunda para Way Name",
+        "ro": "Ieșiți din sensul giratoriu pe Way Name",
+        "ru": "Сверните с круговой развязки на Way Name",
+        "sl": "Zapustite krožišče in zapeljite na Way Name",
+        "sv": "Kör ut ur rondellen in på Way Name",
+        "tr": "Way Name üzerinde U dönüşü yöne dön",
+        "uk": "Залишить коло на Way Name зʼїзді",
+        "vi": "Ra bùng binh vào Way Name",
+        "yo": "Jade ni ọna iṣakoso pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "驶离环岛，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/fork/left_junction_name.json
+++ b/test/fixtures/v5/fork/left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "الزم يسار على Way Name",
+        "da": "Hold til venstre på Way Name",
+        "de": "Links halten an der Gabelung auf Way Name",
+        "en": "Keep left onto Way Name",
+        "eo": "Pluu maldekstren al Way Name",
+        "es": "Mantente izquierda en Way Name",
+        "es-ES": "Mantente a la izquierda por Way Name",
+        "fi": "Jatka vasemmall(e/a) tielle Way Name",
+        "fr": "Tenir à gauche sur Way Name",
+        "he": "היצמד שמאלה על Way Name",
+        "hu": "Tartson balra a Way Name szakaszon",
+        "id": "Tetap kiri di pertigaan ke Way Name",
+        "it": "Mantieni la sinistra al bivio in Way Name",
+        "ja": "Way Nameの左車線を進む",
+        "ko": "좌회전하고 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ ဘယ်ဘက်ကိုဆက်သွားပါ",
+        "nl": "Houd links aan, tot Way Name",
+        "no": "Hold til venstre inn på Way Name",
+        "pl": "Na rozwidleniu trzymaj się lewo na Way Name",
+        "pt-BR": "Mantenha-se à esquerda na bifurcação em Way Name",
+        "pt-PT": "Mantenha-se à esquerda para Way Name",
+        "ro": "Țineți stânga la bifurcație pe Way Name",
+        "ru": "На развилке двигайтесь налево на Way Name",
+        "sl": "Držite se levona Way Name ",
+        "sv": "Håll till vänster in på Way Name",
+        "tr": "Way Name üzerindeki yol ayrımında sol yönde kal",
+        "uk": "Тримайтеся ліворуч і рухайтесь на Way Name",
+        "vi": "Giữ bên trái vào Way Name",
+        "yo": "Jeki apa osi pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "在岔道口保持向左，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/fork/right_junction_name.json
+++ b/test/fixtures/v5/fork/right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "الزم يمين على Way Name",
+        "da": "Hold til højre på Way Name",
+        "de": "Rechts halten an der Gabelung auf Way Name",
+        "en": "Keep right onto Way Name",
+        "eo": "Pluu dekstren al Way Name",
+        "es": "Mantente derecha en Way Name",
+        "es-ES": "Mantente a la derecha por Way Name",
+        "fi": "Jatka oikeall(e/a) tielle Way Name",
+        "fr": "Tenir à droite sur Way Name",
+        "he": "היצמד ימינה על Way Name",
+        "hu": "Tartson jobbra a Way Name szakaszon",
+        "id": "Tetap kanan di pertigaan ke Way Name",
+        "it": "Mantieni la destra al bivio in Way Name",
+        "ja": "Way Nameの右車線を進む",
+        "ko": "우회전하고 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ ညာဘက်ကိုဆက်သွားပါ",
+        "nl": "Houd rechts aan, tot Way Name",
+        "no": "Hold til høyre inn på Way Name",
+        "pl": "Na rozwidleniu trzymaj się prawo na Way Name",
+        "pt-BR": "Mantenha-se à direita na bifurcação em Way Name",
+        "pt-PT": "Mantenha-se à direita para Way Name",
+        "ro": "Țineți dreapta la bifurcație pe Way Name",
+        "ru": "На развилке двигайтесь направо на Way Name",
+        "sl": "Držite se desnona Way Name ",
+        "sv": "Håll till höger in på Way Name",
+        "tr": "Way Name üzerindeki yol ayrımında sağ yönde kal",
+        "uk": "Тримайтеся праворуч і рухайтесь на Way Name",
+        "vi": "Giữ bên phải vào Way Name",
+        "yo": "Jeki ọtun pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "在岔道口保持向右，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/fork/sharp_left_junction_name.json
+++ b/test/fixtures/v5/fork/sharp_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يساراً حاداً لتبقى على Way Name",
+        "da": "Drej skarpt til venstre ad Way Name",
+        "de": "Scharf links auf Way Name",
+        "en": "Take a sharp left onto Way Name",
+        "eo": "Turniĝu ege maldekstren al Way Name",
+        "es": "Gira a la izquierda en Way Name",
+        "es-ES": "Gira a la izquierda por Way Name",
+        "fi": "Käänny tienhaarassa jyrkästi vasempaan tielle Way Name",
+        "fr": "Tourner franchement à gauche sur Way Name",
+        "he": "פנה בחדות שמאלה על Way Name",
+        "hu": "Forduljon be élesen balra a Way Name felé",
+        "id": "Belok kiri tajam ke arah Way Name",
+        "it": "Svolta a sinistra in Way Name",
+        "ja": "大きく左方向に曲がり、Way Nameを進む",
+        "ko": "급좌회전 해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်တွင်နေရန် ဘယ်ဘက်ထောင့်ချိုးယူပါ",
+        "nl": "Neem een scherpe bocht naar links, tot aan Way Name",
+        "no": "Sving skarpt til venstre inn på Way Name",
+        "pl": "Skręć ostro w lewo w Way Name",
+        "pt-BR": "Faça uma curva fechada à esquerda em Way Name",
+        "pt-PT": "Vire acentuadamente à esquerda para Way Name",
+        "ro": "Virați puternic stânga la bifurcație pe Way Name",
+        "ru": "Резко поверните налево на Way Name",
+        "sl": "Zavijte ostro levo na Way Name ",
+        "sv": "Sväng vänster in på Way Name",
+        "tr": "Way Name yoluna doğru sola keskin dönüş yapın",
+        "uk": "Прийміть різко ліворуч на Way Name",
+        "vi": "Quẹo gắt bên trái vào Way Name",
+        "yo": "Mu pẹlẹpẹlẹ sisun ti osi Way Name",
+        "zh-Hans": "在岔道口左急转弯，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/fork/sharp_right_junction_name.json
+++ b/test/fixtures/v5/fork/sharp_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": " انعطف يميناً حاداً لتبقى على Way Name",
+        "da": "Drej skarpt til højre ad Way Name",
+        "de": "Scharf rechts auf Way Name",
+        "en": "Take a sharp right onto Way Name",
+        "eo": "Turniĝu ege dekstren al Way Name",
+        "es": "Gira a la derecha en Way Name",
+        "es-ES": "Gira a la derecha por Way Name",
+        "fi": "Käänny tienhaarassa jyrkästi oikeaan tielle Way Name",
+        "fr": "Tourner franchement à droite sur Way Name",
+        "he": "פנה בחדות ימינה על Way Name",
+        "hu": "Forduljon be élesen jobbra a Way Name felé",
+        "id": "Belok kanan tajam ke arah Way Name",
+        "it": "Svolta a destra in Way Name",
+        "ja": "大きく右方向に曲がり、Way Nameを進む",
+        "ko": "급우회전 해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ ညာဘက်ထောင့်ချိုးယူပါ",
+        "nl": "Neem een scherpe bocht naar rechts, tot aan Way Name",
+        "no": "Sving skarpt til høyre inn på Way Name",
+        "pl": "Skręć ostro w prawo na Way Name",
+        "pt-BR": "Faça uma curva fechada à direita em Way Name",
+        "pt-PT": "Vire acentuadamente à direita para Way Name",
+        "ro": "Virați puternic dreapta la bifurcație pe Way Name",
+        "ru": "Резко поверните направо на Way Name",
+        "sl": "Zavijte ostro desno na Way Name ",
+        "sv": "Sväng höger in på Way Name",
+        "tr": "Way Name yoluna doğru sağa keskin dönüş yapın",
+        "uk": "Прийміть різко праворуч на Way Name",
+        "vi": "Quẹo gắt bên phải vào Way Name",
+        "yo": "Mu pẹlẹsẹ to dara julọ Way Name",
+        "zh-Hans": "在岔道口右急转弯，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/fork/slight_left_junction_name.json
+++ b/test/fixtures/v5/fork/slight_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يساراً قليلاً لتبقى على Way Name",
+        "da": "Hold til venstre på Way Name",
+        "de": "Links halten an der Gabelung auf Way Name",
+        "en": "Keep left onto Way Name",
+        "eo": "Pluu maldekstren al Way Name",
+        "es": "Mantente a la izquierda en Way Name",
+        "es-ES": "Mantente a la izquierda por Way Name",
+        "fi": "Pysy vasemmalla tielle Way Name",
+        "fr": "Tenir la gauche sur Way Name",
+        "he": "היצמד לשמאל על Way Name",
+        "hu": "Tartson balra a Way Name felé",
+        "id": "Tetap di kiri pada pertigaan ke arah Way Name",
+        "it": "Mantieni la sinistra al bivio in Way Name",
+        "ja": "Way Nameの左車線を進む",
+        "ko": "좌회전 해서 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ",
+        "nl": "Houd links aan, tot Way Name",
+        "no": "Hold til venstre inn på Way Name",
+        "pl": "Na rozwidleniu trzymaj się lewej strony w Way Name",
+        "pt-BR": "Mantenha-se à esquerda na bifurcação em Way Name",
+        "pt-PT": "Mantenha-se à esquerda para Way Name",
+        "ro": "Țineți pe stânga la bifurcație pe Way Name",
+        "ru": "На развилке держитесь левее на Way Name",
+        "sl": "Držite se levo na Way Name",
+        "sv": "Håll till vänster in på Way Name",
+        "tr": "Çatalın solundan Way Name yoluna doğru ",
+        "uk": "Тримайтеся ліворуч і рухайтесь на Way Name",
+        "vi": "Giữ bên trái vào Way Name",
+        "yo": "Jeki pẹlẹpẹlẹ osi Way Name",
+        "zh-Hans": "在岔道口保持左侧行驶，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/fork/slight_right_junction_name.json
+++ b/test/fixtures/v5/fork/slight_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يميناً قليلاً لتبقى على Way Name",
+        "da": "Hold til højre på Way Name",
+        "de": "Rechts halten an der Gabelung auf Way Name",
+        "en": "Keep right onto Way Name",
+        "eo": "Pluu dekstren al Way Name",
+        "es": "Mantente a la derecha en Way Name",
+        "es-ES": "Mantente a la derecha por Way Name",
+        "fi": "Pysy oikealla tielle Way Name",
+        "fr": "Tenir la droite sur Way Name",
+        "he": "היצמד לימין על Way Name",
+        "hu": "Tartson jobbra a Way Name felé",
+        "id": "Tetap di kanan pada pertigaan ke arah Way Name",
+        "it": "Mantieni la destra al bivio in Way Name",
+        "ja": "Way Nameの右車線を進む",
+        "ko": "우회전 해서 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ညာဘက်ကိုဆက်သွားပါ",
+        "nl": "Houd rechts aan, tot Way Name",
+        "no": "Hold til høyre inn på Way Name",
+        "pl": "Na rozwidleniu trzymaj się prawej strony na Way Name",
+        "pt-BR": "Mantenha-se à direita na bifurcação em Way Name",
+        "pt-PT": "Mantenha-se à direita para Way Name",
+        "ro": "Țineți pe dreapta la bifurcație pe Way Name",
+        "ru": "На развилке держитесь правее на Way Name",
+        "sl": "Držite se desno na Way Name",
+        "sv": "Håll till höger in på Way Name",
+        "tr": "Way Name üzerindeki yol ayrımında sağda kal",
+        "uk": "Тримайтеся праворуч і рухайтесь на Way Name",
+        "vi": "Giữ bên phải vào Way Name",
+        "yo": "Jeki ọtun pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "在岔道口保持右侧行驶，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/fork/straight_junction_name.json
+++ b/test/fixtures/v5/fork/straight_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "الزم مباشرة على Way Name",
+        "da": "Fortsæt ligeud på Way Name",
+        "de": "Geradeaus halten an der Gabelung auf Way Name",
+        "en": "Keep straight onto Way Name",
+        "eo": "Pluu rekten al Way Name",
+        "es": "Mantente recto en Way Name",
+        "es-ES": "Mantente recto por Way Name",
+        "fi": "Jatka suoraan eteenpäin tielle Way Name",
+        "fr": "Tenir tout droit sur Way Name",
+        "he": "היצמד ישר על Way Name",
+        "hu": "Tartson egyenesen a Way Name szakaszon",
+        "id": "Tetap lurus di pertigaan ke Way Name",
+        "it": "Mantieni la dritto al bivio in Way Name",
+        "ja": "Way Nameの直進車線を進む",
+        "ko": "직진하고 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ ဖြောင့်ဖြောင့်တန်းတန်းကိုဆက်သွားပါ",
+        "nl": "Houd rechtdoor aan, tot Way Name",
+        "no": "Hold til rett frem inn på Way Name",
+        "pl": "Na rozwidleniu trzymaj się prosto na Way Name",
+        "pt-BR": "Mantenha-se em frente na bifurcação em Way Name",
+        "pt-PT": "Mantenha-se em frente para Way Name",
+        "ro": "Țineți înainte la bifurcație pe Way Name",
+        "ru": "На развилке двигайтесь прямо на Way Name",
+        "sl": "Držite se naravnostna Way Name ",
+        "sv": "Håll till rakt fram in på Way Name",
+        "tr": "Way Name üzerindeki yol ayrımında düz yönde kal",
+        "uk": "Тримайтеся прямо і рухайтесь на Way Name",
+        "vi": "Giữ bên thẳng vào Way Name",
+        "yo": "Jeki Taara pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "在岔道口保持直行，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/fork/uturn_junction_name.json
+++ b/test/fixtures/v5/fork/uturn_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف دوراناً عكسياً على Way Name",
+        "da": "Foretag en U-vending ad Way Name",
+        "de": "180°-Wendung auf Way Name",
+        "en": "Make a U-turn onto Way Name",
+        "eo": "Turniĝu malantaŭen al Way Name",
+        "es": "Haz un cambio de sentido en Way Name",
+        "es-ES": "Haz un cambio de sentido en Way Name",
+        "fi": "Tee U-käännös tielle Way Name",
+        "fr": "Faire demi-tour sur Way Name",
+        "he": "פנה פניית פרסה על Way Name",
+        "hu": "Forduljon vissza a Way Name felé",
+        "id": "Putar balik ke arah Way Name",
+        "it": "Fai un’inversione a U in Way Name",
+        "ja": "Uターンし、Way Nameを進む",
+        "ko": "유턴해서 Way Name로 가세요.",
+        "my": "Way Nameသို့ဂ-ကွေ့ကွေ့ပါ",
+        "nl": "Keer om naar Way Name",
+        "no": "Ta en U-sving til Way Name",
+        "pl": "Zawróć na Way Name",
+        "pt-BR": "Faça o retorno em Way Name",
+        "pt-PT": "Faça inversão de marcha para Way Name",
+        "ro": "Întoarceți-vă pe Way Name",
+        "ru": "На развилке развернитесь на Way Name",
+        "sl": "Polkrožno obrnite na Way Name",
+        "sv": "Gör en U-sväng in på Way Name",
+        "tr": "Way Name yoluna U dönüşü yapın",
+        "uk": "Здійсніть розворот на Way Name",
+        "vi": "Quẹo ngược lại Way Name",
+        "yo": "Ṣe U-tan pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "前方调头，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/merge/left_junction_name.json
+++ b/test/fixtures/v5/merge/left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يسار على Way Name",
+        "da": "Flet til venstre ad Way Name",
+        "de": "Links auffahren auf Way Name",
+        "en": "Merge left onto Way Name",
+        "eo": "Enveturu maldekstren al Way Name",
+        "es": "Incorpórate a izquierda en Way Name",
+        "es-ES": "Incorpórate a la izquierda por Way Name",
+        "fi": "Liity vasemmall(e/a), tielle Way Name",
+        "fr": "S’insérer à gauche sur Way Name",
+        "he": "השתלב שמאלה על Way Name",
+        "hu": "Soroljon be balra a Way Name felé",
+        "id": "Bergabung kiri ke arah Way Name",
+        "it": "Immettiti sinistra in Way Name",
+        "ja": "左に合流し、Way Nameを進む",
+        "ko": "좌회전 합류하여 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ ဘယ်ဘက်ကိုလာရောက်ပေါင်းဆုံပါ",
+        "nl": "Bij de splitsing links naar Way Name",
+        "no": "Hold venstre kjørefelt inn på Way Name",
+        "pl": "Włącz się lewo na Way Name",
+        "pt-BR": "Entre à esquerda na Way Name",
+        "pt-PT": "Una-se ao tráfego à esquerda para Way Name",
+        "ro": "Intrați în stânga pe Way Name",
+        "ru": "Перестройтесь налево на Way Name",
+        "sl": "Vključite se v promet levo na Way Name",
+        "sv": "Byt till vänster körfält, in på Way Name",
+        "tr": "Way Name üzerinde sol yöne gir",
+        "uk": "Приєднайтеся до потоку ліворуч на Way Name",
+        "vi": "Nhập sang trái vào Way Name",
+        "yo": "Dapọ apa osi pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "向左并道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/merge/right_junction_name.json
+++ b/test/fixtures/v5/merge/right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يمين على Way Name",
+        "da": "Flet til højre ad Way Name",
+        "de": "Rechts auffahren auf Way Name",
+        "en": "Merge right onto Way Name",
+        "eo": "Enveturu dekstren al Way Name",
+        "es": "Incorpórate a derecha en Way Name",
+        "es-ES": "Incorpórate a la derecha por Way Name",
+        "fi": "Liity oikeall(e/a), tielle Way Name",
+        "fr": "S’insérer à droite sur Way Name",
+        "he": "השתלב ימינה על Way Name",
+        "hu": "Soroljon be jobbra a Way Name felé",
+        "id": "Bergabung kanan ke arah Way Name",
+        "it": "Immettiti destra in Way Name",
+        "ja": "右に合流し、Way Nameを進む",
+        "ko": "우회전 합류하여 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ ညာဘက်ကိုလာရောက်ပေါင်းဆုံပါ",
+        "nl": "Bij de splitsing rechts naar Way Name",
+        "no": "Hold høyre kjørefelt inn på Way Name",
+        "pl": "Włącz się prawo na Way Name",
+        "pt-BR": "Entre à direita na Way Name",
+        "pt-PT": "Una-se ao tráfego à direita para Way Name",
+        "ro": "Intrați în dreapta pe Way Name",
+        "ru": "Перестройтесь направо на Way Name",
+        "sl": "Vključite se v promet desno na Way Name",
+        "sv": "Byt till höger körfält, in på Way Name",
+        "tr": "Way Name üzerinde sağ yöne gir",
+        "uk": "Приєднайтеся до потоку праворуч на Way Name",
+        "vi": "Nhập sang phải vào Way Name",
+        "yo": "Dapọ ọtun pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "向右并道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/merge/sharp_left_junction_name.json
+++ b/test/fixtures/v5/merge/sharp_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يسارا حادا لتبقى على Way Name",
+        "da": "Flet til venstre ad Way Name",
+        "de": "Scharf links auffahren auf Way Name",
+        "en": "Merge left onto Way Name",
+        "eo": "Enveture de maldekstre al Way Name",
+        "es": "Incorpórate a la izquierda en Way Name",
+        "es-ES": "Incorpórate a la izquierda por Way Name",
+        "fi": "Liity vasemmalle, tielle Way Name",
+        "fr": "S’insérer à gauche sur Way Name",
+        "he": "השתלב שמאלה על Way Name",
+        "hu": "Sorljon be balra a Way Name felé",
+        "id": "Bergabung di kiri ke arah Way Name",
+        "it": "Immèttitì a sinistra in Way Name",
+        "ja": "左に合流し、Way Nameを進む",
+        "ko": "좌측Way Name로 합류하세요.",
+        "my": "Way Name​ပေါ်သို့ဘယ်ဘက်ကိုလာရောက်ပေါင်းဆုံပါ",
+        "nl": "Bij de splitsing linksaf naar Way Name",
+        "no": "Hold venstre kjørefelt inn på Way Name",
+        "pl": "Włącz się z lewej strony na Way Name",
+        "pt-BR": "Entre à esquerda na Way Name",
+        "pt-PT": "Una-se ao tráfego à esquerda para Way Name",
+        "ro": "Intrați în stânga pe Way Name",
+        "ru": "Перестраивайтесь левее на Way Name",
+        "sl": "Vključite se v promet na levi na Way Name",
+        "sv": "Byt till vänstra körfältet, in på Way Name",
+        "tr": "Way Name üzerinde sola gir",
+        "uk": "Приєднайтеся до потоку ліворуч на Way Name",
+        "vi": "Nhập sang trái vào Way Name",
+        "yo": "Dapọ pẹlẹpẹlẹ osi Way Name",
+        "zh-Hans": "急向左并道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/merge/sharp_right_junction_name.json
+++ b/test/fixtures/v5/merge/sharp_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يمينا حادا لتبقى على Way Name",
+        "da": "Flet til højre ad Way Name",
+        "de": "Scharf rechts auffahren auf Way Name",
+        "en": "Merge right onto Way Name",
+        "eo": "Enveturu de dekstre al Way Name",
+        "es": "Incorpórate a la derecha en Way Name",
+        "es-ES": "Incorpórate a la derecha por Way Name",
+        "fi": "Liity oikealle, tielle Way Name",
+        "fr": "S’insérer à droite sur Way Name",
+        "he": "השתלב ימינה על Way Name",
+        "hu": "Soroljon be jobbra a Way Name felé",
+        "id": "Bergabung di kanan ke arah Way Name",
+        "it": "Immèttitì a destra in Way Name",
+        "ja": "右に合流し、Way Nameを進む",
+        "ko": "우측Way Name로 합류하세요.",
+        "my": "Way Name​ပေါ်သို့ညာဘက်ကိုလာရောက်ပေါင်းဆုံပါ",
+        "nl": "Bij de splitsing rechtsaf naar Way Name",
+        "no": "Hold høyre kjørefelt inn på Way Name",
+        "pl": "Włącz się z prawej strony na Way Name",
+        "pt-BR": "Entre à direita na Way Name",
+        "pt-PT": "Una-se ao tráfego à direita para Way Name",
+        "ro": "Intrați în dreapta pe Way Name",
+        "ru": "Перестраивайтесь правее на Way Name",
+        "sl": "Vključite se v promet na desni na Way Name",
+        "sv": "Byt till högra körfältet, in på Way Name",
+        "tr": "Way Name üzerinde sağa gir",
+        "uk": "Приєднайтеся до потоку праворуч на Way Name",
+        "vi": "Nhập sang phải vào Way Name",
+        "yo": "Darapọ mọ pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "急向右并道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/merge/slight_left_junction_name.json
+++ b/test/fixtures/v5/merge/slight_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يساراً قليلاً لتبقى على Way Name",
+        "da": "Flet til venstre ad Way Name",
+        "de": "Leicht links auffahren auf Way Name",
+        "en": "Merge left onto Way Name",
+        "eo": "Enveturu de maldekstre al Way Name",
+        "es": "Incorpórate a la izquierda en Way Name",
+        "es-ES": "Incorpórate a la izquierda por Way Name",
+        "fi": "Liity vasemmalle, tielle Way Name",
+        "fr": "S’insérer légèrement à gauche sur Way Name",
+        "he": "השתלב שמאלה על Way Name",
+        "hu": "Sorljon be balra a Way Name felé",
+        "id": "Bergabung di kiri ke arah Way Name",
+        "it": "Immèttitì a sinistra in Way Name",
+        "ja": "左に合流し、Way Nameを進む",
+        "ko": "좌측Way Name로 합류하세요.",
+        "my": "Way Name​ပေါ်သို့ဘယ်ဘက်ကိုလာရောက်ပေါင်းဆုံပါ",
+        "nl": "Bij de splitsing links aanhouden naar Way Name",
+        "no": "Hold venstre kjørefelt inn på Way Name",
+        "pl": "Włącz się z lewej strony na Way Name",
+        "pt-BR": "Entre à esquerda na Way Name",
+        "pt-PT": "Una-se ao tráfego à esquerda para Way Name",
+        "ro": "Intrați în stânga pe Way Name",
+        "ru": "Перестройтесь левее на Way Name",
+        "sl": "Vključite se v promet na levi na Way Name",
+        "sv": "Byt till vänstra körfältet, in på Way Name",
+        "tr": "Way Name üzerinde sola gir",
+        "uk": "Приєднайтеся до потоку ліворуч на Way Name",
+        "vi": "Nhập sang trái vào Way Name",
+        "yo": "Dapọ pẹlẹpẹlẹ osi Way Name",
+        "zh-Hans": "稍向左并道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/merge/slight_right_junction_name.json
+++ b/test/fixtures/v5/merge/slight_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يميناً قليلاً لتبقى على Way Name",
+        "da": "Flet til højre ad Way Name",
+        "de": "Leicht rechts auffahren auf Way Name",
+        "en": "Merge right onto Way Name",
+        "eo": "Enveturu de dekstre al Way Name",
+        "es": "Incorpórate a la derecha en Way Name",
+        "es-ES": "Incorpórate a la derecha por Way Name",
+        "fi": "Liity oikealle, tielle Way Name",
+        "fr": "S’insérer légèrement à droite sur Way Name",
+        "he": "השתלב ימינה על Way Name",
+        "hu": "Soroljon be jobbra a Way Name felé",
+        "id": "Bergabung di kanan ke arah Way Name",
+        "it": "Immèttitì a destra in Way Name",
+        "ja": "右に合流し、Way Nameを進む",
+        "ko": "우측Way Name로 합류하세요.",
+        "my": "Way Name​ပေါ်သို့ညာဘက်ကိုလာရောက်ပေါင်းဆုံပါ",
+        "nl": "Bij de splitsing rechts aanhouden naar Way Name",
+        "no": "Hold høyre kjørefelt inn på Way Name",
+        "pl": "Włącz się z prawej strony na Way Name",
+        "pt-BR": "Entre à direita na Way Name",
+        "pt-PT": "Una-se ao tráfego à direita para Way Name",
+        "ro": "Intrați în dreapta pe Way Name",
+        "ru": "Перестройтесь правее на Way Name",
+        "sl": "Vključite se v promet na desni na Way Name",
+        "sv": "Byt till högra körfältet, in på Way Name",
+        "tr": "Way Name üzerinde sağa gir",
+        "uk": "Приєднайтеся до потоку праворуч на Way Name",
+        "vi": "Nhập sang phải vào Way Name",
+        "yo": "Darapọ mọ pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "稍向右并道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/merge/straight_junction_name.json
+++ b/test/fixtures/v5/merge/straight_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "تابع قدماً على Way Name",
+        "da": "Flet ind på Way Name",
+        "de": "Geradeaus auffahren auf Way Name",
+        "en": "Merge onto Way Name",
+        "eo": "Enveturu al Way Name",
+        "es": "Incorpórate a Way Name",
+        "es-ES": "Incorpórate por Way Name",
+        "fi": "Liity tielle Way Name",
+        "fr": "S’insérer sur Way Name",
+        "he": "השתלב על Way Name",
+        "hu": "Soroljon be a Way Name felé",
+        "id": "Bergabung lurus ke arah Way Name",
+        "it": "Immettiti dritto in Way Name",
+        "ja": "合流し、Way Nameを進む",
+        "ko": "Way Name로 합류하세요.",
+        "my": "Way Name​ပေါ်သို့လာရောက်ပေါင်းဆုံပါ",
+        "nl": "Ga verder op Way Name",
+        "no": "Hold kjørefelt inn på Way Name",
+        "pl": "Włącz się prosto na Way Name",
+        "pt-BR": "Entre reto na Way Name",
+        "pt-PT": " Una-se ao tráfego para Way Name",
+        "ro": "Intrați pe Way Name",
+        "ru": "Продолжите движение по Way Name",
+        "sl": "Vključite se v promet na Way Name",
+        "sv": "Kör in på Way Name",
+        "tr": "Way Name üzerinde düz yöne gir",
+        "uk": "Приєднайтеся до потоку на Way Name",
+        "vi": "Nhập vào Way Name",
+        "yo": "Darapọ pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "直行并道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/merge/uturn_junction_name.json
+++ b/test/fixtures/v5/merge/uturn_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "merge",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف دورانا عكسيا على Way Name",
+        "da": "Foretag en U-vending ad Way Name",
+        "de": "180°-Wendung auf Way Name",
+        "en": "Make a U-turn onto Way Name",
+        "eo": "Turniĝu malantaŭen al Way Name",
+        "es": "Haz un cambio de sentido en Way Name",
+        "es-ES": "Haz un cambio de sentido en Way Name",
+        "fi": "Tee U-käännös tielle Way Name",
+        "fr": "Faire demi-tour sur Way Name",
+        "he": "פנה פניית פרסה על Way Name",
+        "hu": "Forduljon vissza a Way Name felé",
+        "id": "Putar balik ke arah Way Name",
+        "it": "Fai un’inversione a U in Way Name",
+        "ja": "Uターンし、Way Nameを進む",
+        "ko": "유턴해서 Way Name로 가세요.",
+        "my": "Way Nameလမ်းဘက်သို့ ဂ-ကွေ့ ကွေ့ပါ ",
+        "nl": "Keer om naar Way Name",
+        "no": "Ta en U-sving til Way Name",
+        "pl": "Zawróć na Way Name",
+        "pt-BR": "Faça o retorno em Way Name",
+        "pt-PT": "Faça inversão de marcha para Way Name",
+        "ro": "Întoarceți-vă pe Way Name",
+        "ru": "Развернитесь на Way Name",
+        "sl": "Polkrožno obrnite na Way Name",
+        "sv": "Gör en U-sväng in på Way Name",
+        "tr": "Way Name yoluna U dönüşü yapın",
+        "uk": "Здійсніть розворот на Way Name",
+        "vi": "Quẹo ngược lại Way Name",
+        "yo": "Ṣe U-tan pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "前方调头，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/modes/driving_turn_left.json
+++ b/test/fixtures/v5/modes/driving_turn_left.json
@@ -23,7 +23,7 @@
         "it": "Svolta a sinistra in Way Name",
         "ja": "左折してWay Nameを進む",
         "ko": "좌회전 하시고 Way Name로 가세요.",
-        "my": "Way Nameပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ ",
+        "my": "Way Nameပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ",
         "nl": "Ga linksaf naar Way Name",
         "no": "Sving til venstre inn på Way Name",
         "pl": "Skręć w lewo na Way Name",

--- a/test/fixtures/v5/modes/ferry_fork_left_junction_name.json
+++ b/test/fixtures/v5/modes/ferry_fork_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "fork",
+            "modifier": "left"
+        },
+        "mode": "ferry",
+        "name": "Way Name",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك العبّارة Way Name",
+        "da": "Tag færgen Way Name",
+        "de": "Fähre nehmen Way Name",
+        "en": "Take the ferry Way Name",
+        "eo": "Enpramiĝu Way Name",
+        "es": "Coge el ferry Way Name",
+        "es-ES": "Coge el ferry Way Name",
+        "fi": "Aja lautalle Way Name",
+        "fr": "Prendre le ferry Way Name",
+        "he": "עלה על המעבורת Way Name",
+        "hu": "Hajtson fel a kompra a Way Name felé",
+        "id": "Naik ferry di Way Name",
+        "it": "Prendi il traghetto Way Name",
+        "ja": "Way Nameのフェリーに乗る",
+        "ko": "페리를 타시오 Way Name",
+        "my": "Way Nameကို ဖယ်ရီစီးသွားပါ",
+        "nl": "Neem de veerpont Way Name",
+        "no": "Ta ferja Way Name",
+        "pl": "Weź prom Way Name",
+        "pt-BR": "Pegue a balsa Way Name",
+        "pt-PT": "Apanhe o ferry Way Name",
+        "ro": "Luați feribotul Way Name",
+        "ru": "Погрузитесь на паром Way Name",
+        "sl": "Pojdite na trajekt Way Name",
+        "sv": "Ta färjan på Way Name",
+        "tr": "Way Name vapurunu kullan",
+        "uk": "Скористайтесь поромом Way Name",
+        "vi": "Lên phà Way Name",
+        "yo": "Gba ọkọ oju-omi naa Way Name",
+        "zh-Hans": "乘坐Way Name轮渡"
+    }
+}

--- a/test/fixtures/v5/modes/ferry_turn_left_junction_name.json
+++ b/test/fixtures/v5/modes/ferry_turn_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "continue",
+            "modifier": "straight"
+        },
+        "mode": "ferry",
+        "name": "Way Name",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك العبّارة Way Name",
+        "da": "Tag færgen Way Name",
+        "de": "Fähre nehmen Way Name",
+        "en": "Take the ferry Way Name",
+        "eo": "Enpramiĝu Way Name",
+        "es": "Coge el ferry Way Name",
+        "es-ES": "Coge el ferry Way Name",
+        "fi": "Aja lautalle Way Name",
+        "fr": "Prendre le ferry Way Name",
+        "he": "עלה על המעבורת Way Name",
+        "hu": "Hajtson fel a kompra a Way Name felé",
+        "id": "Naik ferry di Way Name",
+        "it": "Prendi il traghetto Way Name",
+        "ja": "Way Nameのフェリーに乗る",
+        "ko": "페리를 타시오 Way Name",
+        "my": "Way Nameကို ဖယ်ရီစီးသွားပါ",
+        "nl": "Neem de veerpont Way Name",
+        "no": "Ta ferja Way Name",
+        "pl": "Weź prom Way Name",
+        "pt-BR": "Pegue a balsa Way Name",
+        "pt-PT": "Apanhe o ferry Way Name",
+        "ro": "Luați feribotul Way Name",
+        "ru": "Погрузитесь на паром Way Name",
+        "sl": "Pojdite na trajekt Way Name",
+        "sv": "Ta färjan på Way Name",
+        "tr": "Way Name vapurunu kullan",
+        "uk": "Скористайтесь поромом Way Name",
+        "vi": "Lên phà Way Name",
+        "yo": "Gba ọkọ oju-omi naa Way Name",
+        "zh-Hans": "乘坐Way Name轮渡"
+    }
+}

--- a/test/fixtures/v5/new_name/left_junction_name.json
+++ b/test/fixtures/v5/new_name/left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "تابع يسارا على Way Name",
+        "da": "Fortsæt til venstre ad Way Name",
+        "de": "Links weiterfahren auf Way Name",
+        "en": "Continue left onto Way Name",
+        "eo": "Pluu maldekstren al Way Name",
+        "es": "Continúa izquierda en Way Name",
+        "es-ES": "Continúa a la izquierda por Way Name",
+        "fi": "Jatka vasemmall(e/a) tielle Way Name",
+        "fr": "Continuer à gauche sur Way Name",
+        "he": "המשך שמאלה על Way Name",
+        "hu": "Hajtsontovább balra a Way Name felé",
+        "id": "Lanjutkan kiri menuju Way Name",
+        "it": "Continua a sinistra in Way Name",
+        "ja": "Way Nameを左に進む",
+        "ko": "좌회전 유지해서 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ ဘယ်ဘက်ကိုဆက်သွားပါ",
+        "nl": "Ga links naar Way Name",
+        "no": "Fortsett venstre til Way Name",
+        "pl": "Kontynuuj lewo na Way Name",
+        "pt-BR": "Continue à esquerda em Way Name",
+        "pt-PT": "Continue à esquerda para Way Name",
+        "ro": "Continuați stânga pe Way Name",
+        "ru": "Двигайтесь налево на Way Name",
+        "sl": "Nadaljujte levo na Way Name",
+        "sv": "Fortsätt vänster på Way Name",
+        "tr": "Way Name üzerinde sol yönde devam et",
+        "uk": "Рухайтесь ліворуч на Way Name",
+        "vi": "Chạy tiếp bên trái trên Way Name",
+        "yo": "Tesiwaju apa osi pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "继续向左，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/new_name/right_junction_name.json
+++ b/test/fixtures/v5/new_name/right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "تابع يمينا على Way Name",
+        "da": "Fortsæt til højre ad Way Name",
+        "de": "Rechts weiterfahren auf Way Name",
+        "en": "Continue right onto Way Name",
+        "eo": "Pluu dekstren al Way Name",
+        "es": "Continúa derecha en Way Name",
+        "es-ES": "Continúa a la derecha por Way Name",
+        "fi": "Jatka oikeall(e/a) tielle Way Name",
+        "fr": "Continuer à droite sur Way Name",
+        "he": "המשך ימינה על Way Name",
+        "hu": "Hajtsontovább jobbra a Way Name felé",
+        "id": "Lanjutkan kanan menuju Way Name",
+        "it": "Continua a destra in Way Name",
+        "ja": "Way Nameを右に進む",
+        "ko": "우회전 유지해서 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ ညာဘက်ကိုဆက်သွားပါ",
+        "nl": "Ga rechts naar Way Name",
+        "no": "Fortsett høyre til Way Name",
+        "pl": "Kontynuuj prawo na Way Name",
+        "pt-BR": "Continue à direita em Way Name",
+        "pt-PT": "Continue à direita para Way Name",
+        "ro": "Continuați dreapta pe Way Name",
+        "ru": "Двигайтесь направо на Way Name",
+        "sl": "Nadaljujte desno na Way Name",
+        "sv": "Fortsätt höger på Way Name",
+        "tr": "Way Name üzerinde sağ yönde devam et",
+        "uk": "Рухайтесь праворуч на Way Name",
+        "vi": "Chạy tiếp bên phải trên Way Name",
+        "yo": "Tesiwaju ọtun pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "继续向右，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/new_name/sharp_left_junction_name.json
+++ b/test/fixtures/v5/new_name/sharp_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يسارا حادا لتبقى على Way Name",
+        "da": "Drej skarpt til venstre ad Way Name",
+        "de": "Scharf links auf Way Name",
+        "en": "Take a sharp left onto Way Name",
+        "eo": "Turniĝu ege maldekstren al Way Name",
+        "es": "Gira a la izquierda en Way Name",
+        "es-ES": "Gira a la izquierda por Way Name",
+        "fi": "Käänny jyrkästi vasempaan tielle Way Name",
+        "fr": "Tourner franchement à gauche sur Way Name",
+        "he": "פנה בחדות שמאלה על Way Name",
+        "hu": "Forduljon be élesen balra a Way Name felé",
+        "id": "Belok kiri tajam ke arah Way Name",
+        "it": "Svolta a sinistra in Way Name",
+        "ja": "大きく左方向に曲がり、Way Nameを進む",
+        "ko": "급좌회전 해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်တွင်နေရန် ဘယ်ဘက်ထောင့်ချိုးယူပါ",
+        "nl": "Linksaf naar Way Name",
+        "no": "Sving skarpt til venstre inn på Way Name",
+        "pl": "Skręć ostro w lewo w Way Name",
+        "pt-BR": "Faça uma curva fechada à esquerda em Way Name",
+        "pt-PT": "Vire acentuadamente à esquerda para Way Name",
+        "ro": "Virați puternic la stânga pe Way Name",
+        "ru": "Резко поверните налево на Way Name",
+        "sl": "Zavijte ostro levo na Way Name",
+        "sv": "Gör en skarp vänstersväng in på Way Name",
+        "tr": "Way Name yoluna doğru sola keskin dönüş yapın",
+        "uk": "Прийміть різко ліворуч на Way Name",
+        "vi": "Quẹo gắt bên trái vào Way Name",
+        "yo": "Mu pẹlẹpẹlẹ sisun ti osi Way Name",
+        "zh-Hans": "前方左急转弯，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/new_name/sharp_right_junction_name.json
+++ b/test/fixtures/v5/new_name/sharp_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": " انعطف يمينا حادا لتبقى على Way Name",
+        "da": "Drej skarpt til højre ad Way Name",
+        "de": "Scharf rechts auf Way Name",
+        "en": "Take a sharp right onto Way Name",
+        "eo": "Turniĝu ege dekstren al Way Name",
+        "es": "Gira a la derecha en Way Name",
+        "es-ES": "Gira a la derecha por Way Name",
+        "fi": "Käänny jyrkästi oikeaan tielle Way Name",
+        "fr": "Tourner franchement à droite sur Way Name",
+        "he": "פנה בחדות ימינה על Way Name",
+        "hu": "Forduljon be élesen jobbra a Way Name felé",
+        "id": "Belok kanan tajam ke arah Way Name",
+        "it": "Svolta a destra in Way Name",
+        "ja": "大きく右方向に曲がり、Way Nameを進む",
+        "ko": "급우회전 해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ ညာဘက်ထောင့်ချိုးယူပါ",
+        "nl": "Rechtsaf naar Way Name",
+        "no": "Sving skarpt til høyre inn på Way Name",
+        "pl": "Skręć ostro w prawo na Way Name",
+        "pt-BR": "Faça uma curva fechada à direita em Way Name",
+        "pt-PT": "Vire acentuadamente à direita para Way Name",
+        "ro": "Virați puternic la dreapta pe Way Name",
+        "ru": "Резко поверните направо на Way Name",
+        "sl": "Zavijte ostro desno na Way Name",
+        "sv": "Gör en skarp högersväng in på Way Name",
+        "tr": "Way Name yoluna doğru sağa keskin dönüş yapın",
+        "uk": "Прийміть різко праворуч на Way Name",
+        "vi": "Quẹo gắt bên phải vào Way Name",
+        "yo": "Mu pẹlẹsẹ to dara julọ Way Name",
+        "zh-Hans": "前方右急转弯，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/new_name/slight_left_junction_name.json
+++ b/test/fixtures/v5/new_name/slight_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "تابع يساراً قليلاً على Way Name",
+        "da": "Fortsæt til venstre ad Way Name",
+        "de": "Leicht links weiter auf Way Name",
+        "en": "Continue slightly left onto Way Name",
+        "eo": "Pluu ete maldekstren al Way Name",
+        "es": "Continúa levemente a la izquierda en Way Name",
+        "es-ES": "Continúa ligeramente por la izquierda por Way Name",
+        "fi": "Jatka loivasti vasempaan tielle Way Name",
+        "fr": "Continuer légèrement à gauche sur Way Name",
+        "he": "המשך בנטייה קלה שמאלה על Way Name",
+        "hu": "Hajtson tovább enyhén balra a Way Name felé",
+        "id": "Lanjut dengan agak di kiri ke Way Name",
+        "it": "Continua leggermente a sinistra in Way Name",
+        "ja": "Way Nameを斜め左方向に進む",
+        "ko": "약간 좌회전해서 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ဘယ်ဘက် အနည်းငယ်ဆက်သွားပါ",
+        "nl": "Links aanhouden naar Way Name",
+        "no": "Fortsett litt mot venstre til Way Name",
+        "pl": "Kontynuuj łagodnie w lewo na Way Name",
+        "pt-BR": "Continue ligeiramente à esquerda em Way Name",
+        "pt-PT": "Continue ligeiramente à esquerda para Way Name",
+        "ro": "Continuați ușor la stânga pe Way Name",
+        "ru": "Плавно поверните налево на Way Name",
+        "sl": "Nadaljujte rahlo levo na Way Name",
+        "sv": "Fortsätt med lätt vänstersväng in på Way Name",
+        "tr": "Way Name üzerinde hafif solda devam et",
+        "uk": "Рухайтесь плавно ліворуч на Way Name",
+        "vi": "Nghiêng về bên trái vào Way Name",
+        "yo": "Tesiwaju die-die silẹ pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "继续稍向左，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/new_name/slight_right_junction_name.json
+++ b/test/fixtures/v5/new_name/slight_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "تابع يميناً قليلاً على Way Name",
+        "da": "Fortsæt til højre ad Way Name",
+        "de": "Leicht rechts weiter auf Way Name",
+        "en": "Continue slightly right onto Way Name",
+        "eo": "Pluu ete dekstren al Way Name",
+        "es": "Continúa levemente a la derecha en Way Name",
+        "es-ES": "Continúa ligeramente por la derecha por Way Name",
+        "fi": "Jatka loivasti oikeaan tielle Way Name",
+        "fr": "Continuer légèrement à droite sur Way Name",
+        "he": "המשך בנטייה קלה ימינה על Way Name",
+        "hu": "Hajtson tovább enyhén jobbra a Way Name felé",
+        "id": "Tetap agak di kanan ke Way Name",
+        "it": "Continua leggermente a destra in Way Name ",
+        "ja": "Way Nameを斜め右方向に進む",
+        "ko": "약간 우회전해서 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ညာဘက် အနည်းငယ်ဆက်သွားပါ",
+        "nl": "Rechts aanhouden naar Way Name",
+        "no": "Fortsett litt mot høyre til Way Name",
+        "pl": "Kontynuuj łagodnie w prawo na Way Name",
+        "pt-BR": "Continue ligeiramente à direita em Way Name",
+        "pt-PT": "Continue ligeiramente à direita para Way Name",
+        "ro": "Continuați ușor la dreapta pe Way Name",
+        "ru": "Плавно поверните направо на Way Name",
+        "sl": "Nadaljujte rahlo desno na Way Name",
+        "sv": "Fortsätt med lätt högersväng in på Way Name",
+        "tr": "Way Name üzerinde hafif sağda devam et",
+        "uk": "Рухайтесь плавно праворуч на Way Name",
+        "vi": "Nghiêng về bên phải vào Way Name",
+        "yo": "Tesiwaju die-die ọtun pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "继续稍向右，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/new_name/straight_junction_name.json
+++ b/test/fixtures/v5/new_name/straight_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "تابع على Way Name",
+        "da": "Fortsæt ad Way Name",
+        "de": "Weiterfahren auf Way Name",
+        "en": "Continue onto Way Name",
+        "eo": "Veturu rekten al Way Name",
+        "es": "Continúa en Way Name",
+        "es-ES": "Continúa por Way Name",
+        "fi": "Jatka tielle Way Name",
+        "fr": "Continuer tout droit sur Way Name",
+        "he": "המשך על Way Name",
+        "hu": "Hajtson tovább a Way Name felé",
+        "id": "Terus ke Way Name",
+        "it": "Continua in Way Name",
+        "ja": "Way Nameを直進する",
+        "ko": "Way Name로 계속 가세요.",
+        "my": "Way Nameပေါ်သို့ဆက်သွားပါ",
+        "nl": "Ga rechtdoor naar Way Name",
+        "no": "Fortsett inn på Way Name",
+        "pl": "Kontynuuj na Way Name",
+        "pt-BR": "Continue em Way Name",
+        "pt-PT": "Continue para Way Name",
+        "ro": "Continuați pe Way Name",
+        "ru": "Продолжите движение по Way Name",
+        "sl": "Nadaljujte na Way Name",
+        "sv": "Fortsätt in på Way Name",
+        "tr": "Way Name üzerinde devam et",
+        "uk": "Рухайтесь по Way Name",
+        "vi": "Chạy tiếp trên Way Name",
+        "yo": "Tẹsiwaju pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "继续在Way Name上直行"
+    }
+}

--- a/test/fixtures/v5/new_name/uturn_junction_name.json
+++ b/test/fixtures/v5/new_name/uturn_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "new name",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف دورانا عكسيا على Way Name",
+        "da": "Foretag en U-vending ad Way Name",
+        "de": "180°-Wendung auf Way Name",
+        "en": "Make a U-turn onto Way Name",
+        "eo": "Turniĝu malantaŭen al Way Name",
+        "es": "Haz un cambio de sentido en Way Name",
+        "es-ES": "Haz un cambio de sentido en Way Name",
+        "fi": "Tee U-käännös tielle Way Name",
+        "fr": "Faire demi-tour sur Way Name",
+        "he": "פנה פניית פרסה על Way Name",
+        "hu": "Forduljon vissza a Way Name felé",
+        "id": "Putar balik ke arah Way Name",
+        "it": "Fai un’inversione a U in Way Name",
+        "ja": "Uターンし、Way Nameを進む",
+        "ko": "유턴해서 Way Name로 가세요.",
+        "my": "Way Nameလမ်းဘက်သို့ ဂ-ကွေ့ ကွေ့ပါ",
+        "nl": "Keer om naar Way Name",
+        "no": "Ta en U-sving til Way Name",
+        "pl": "Zawróć na Way Name",
+        "pt-BR": "Faça o retorno em Way Name",
+        "pt-PT": "Faça inversão de marcha para Way Name",
+        "ro": "Întoarceți-vă pe Way Name",
+        "ru": "Развернитесь на Way Name",
+        "sl": "Polkrožno obrnite na Way Name",
+        "sv": "Gör en U-sväng in på Way Name",
+        "tr": "Way Name yoluna U dönüşü yapın",
+        "uk": "Здійсніть розворот на Way Name",
+        "vi": "Quẹo ngược lại Way Name",
+        "yo": "Ṣe U-tan pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "前方调头，上Way Name"
+    }
+}

--- a/test/fixtures/v5/notification/left_junction_name.json
+++ b/test/fixtures/v5/notification/left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "تابع يسارا على Way Name",
+        "da": "Fortsæt til venstre ad Way Name",
+        "de": "Links weiterfahren auf Way Name",
+        "en": "Continue left onto Way Name",
+        "eo": "Pluu maldekstren al Way Name",
+        "es": "Continúa izquierda en Way Name",
+        "es-ES": "Continúa a la izquierda por Way Name",
+        "fi": "Jatka vasemmall(e/a) tielle Way Name",
+        "fr": "Continuer à gauche sur Way Name",
+        "he": "המשך שמאלה על Way Name",
+        "hu": "Hajtson tovább balra a Way Name felé",
+        "id": "Lanjutkan kiri menuju Way Name",
+        "it": "Continua a sinistra in Way Name",
+        "ja": "Way Nameを左に進む",
+        "ko": "좌회전해서 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ ဘယ်ဘက်ကိုဆက်သွားပါ",
+        "nl": "Ga links naar Way Name",
+        "no": "Fortsett venstre til Way Name",
+        "pl": "Kontynuuj lewo na Way Name",
+        "pt-BR": "Continue à esquerda em Way Name",
+        "pt-PT": "Continue à esquerda para Way Name",
+        "ro": "Continuați stânga pe Way Name",
+        "ru": "Двигайтесь налево по Way Name",
+        "sl": "Nadaljujte levo na Way Name",
+        "sv": "Fortsätt vänster på Way Name",
+        "tr": "Way Name üzerinde sol yönde devam et",
+        "uk": "Рухайтесь ліворуч на Way Name",
+        "vi": "Chạy tiếp bên trái trên Way Name",
+        "yo": "Tesiwaju apa osi pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "继续向左，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/notification/right_junction_name.json
+++ b/test/fixtures/v5/notification/right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "تابع يمينا على Way Name",
+        "da": "Fortsæt til højre ad Way Name",
+        "de": "Rechts weiterfahren auf Way Name",
+        "en": "Continue right onto Way Name",
+        "eo": "Pluu dekstren al Way Name",
+        "es": "Continúa derecha en Way Name",
+        "es-ES": "Continúa a la derecha por Way Name",
+        "fi": "Jatka oikeall(e/a) tielle Way Name",
+        "fr": "Continuer à droite sur Way Name",
+        "he": "המשך ימינה על Way Name",
+        "hu": "Hajtson tovább jobbra a Way Name felé",
+        "id": "Lanjutkan kanan menuju Way Name",
+        "it": "Continua a destra in Way Name",
+        "ja": "Way Nameを右に進む",
+        "ko": "우회전해서 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ ညာဘက်ကိုဆက်သွားပါ",
+        "nl": "Ga rechts naar Way Name",
+        "no": "Fortsett høyre til Way Name",
+        "pl": "Kontynuuj prawo na Way Name",
+        "pt-BR": "Continue à direita em Way Name",
+        "pt-PT": "Continue à direita para Way Name",
+        "ro": "Continuați dreapta pe Way Name",
+        "ru": "Двигайтесь направо по Way Name",
+        "sl": "Nadaljujte desno na Way Name",
+        "sv": "Fortsätt höger på Way Name",
+        "tr": "Way Name üzerinde sağ yönde devam et",
+        "uk": "Рухайтесь праворуч на Way Name",
+        "vi": "Chạy tiếp bên phải trên Way Name",
+        "yo": "Tesiwaju ọtun pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "继续向右，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/notification/sharp_left_default.json
+++ b/test/fixtures/v5/notification/sharp_left_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson tovább élesen balra",
         "id": "Lanjutkan tajam kiri",
         "it": "Continua a sinistra",
-        "ja": "大きく左に進む",
+        "ja": "左戻るに進む",
         "ko": "바로좌회전 하세요.",
         "my": "ဘယ်ဘက် ထောင့်ချိုးကိုဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar links",

--- a/test/fixtures/v5/notification/sharp_left_destination.json
+++ b/test/fixtures/v5/notification/sharp_left_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson tovább élesen balra a Destination 1 irányába",
         "id": "Lanjutkan tajam kiri menuju Destination 1",
         "it": "Continua a sinistra verso Destination 1",
-        "ja": "Destination 1へ向けて大きく左に進む",
+        "ja": "Destination 1へ向けて左戻るに進む",
         "ko": "바로좌회전해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ဘယ်ဘက် ထောင့်ချိုးကို ဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar links richting Destination 1",

--- a/test/fixtures/v5/notification/sharp_left_exit.json
+++ b/test/fixtures/v5/notification/sharp_left_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson tovább élesen balra a Way Name felé",
         "id": "Lanjutkan tajam kiri menuju Way Name",
         "it": "Continua a sinistra in Way Name",
-        "ja": "Way Nameを大きく左に進む",
+        "ja": "Way Nameを左戻るに進む",
         "ko": "바로좌회전해서 Way Name로 가세요.",
         "my": "Way Name​ပေါ်သို့ ဘယ်ဘက် ထောင့်ချိုးကိုဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar links naar Way Name",

--- a/test/fixtures/v5/notification/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/notification/sharp_left_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson tovább élesen balra a Destination 1 irányába",
         "id": "Lanjutkan tajam kiri menuju Destination 1",
         "it": "Continua a sinistra verso Destination 1",
-        "ja": "Destination 1へ向けて大きく左に進む",
+        "ja": "Destination 1へ向けて左戻るに進む",
         "ko": "바로좌회전해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ဘယ်ဘက် ထောင့်ချိုးကို ဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar links richting Destination 1",

--- a/test/fixtures/v5/notification/sharp_left_junction_name.json
+++ b/test/fixtures/v5/notification/sharp_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "تابع يسار حادا على Way Name",
+        "da": "Fortsæt skarpt til venstre ad Way Name",
+        "de": "Scharf links weiterfahren auf Way Name",
+        "en": "Continue sharp left onto Way Name",
+        "eo": "Pluu maldekstregen al Way Name",
+        "es": "Continúa cerrada a la izquierda en Way Name",
+        "es-ES": "Continúa cerrada a la izquierda por Way Name",
+        "fi": "Jatka jyrkästi vasempaan tielle Way Name",
+        "fr": "Continuer franchement à gauche sur Way Name",
+        "he": "המשך חדה שמאלה על Way Name",
+        "hu": "Hajtson tovább élesen balra a Way Name felé",
+        "id": "Lanjutkan tajam kiri menuju Way Name",
+        "it": "Continua a sinistra in Way Name",
+        "ja": "Way Nameを左戻るに進む",
+        "ko": "바로좌회전해서 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ ဘယ်ဘက် ထောင့်ချိုးကိုဆက်သွားပါ",
+        "nl": "Ga scherpe bocht naar links naar Way Name",
+        "no": "Fortsett skarp venstre til Way Name",
+        "pl": "Kontynuuj ostro w lewo na Way Name",
+        "pt-BR": "Continue fechada à esquerda em Way Name",
+        "pt-PT": "Continue acentuadamente à esquerda para Way Name",
+        "ro": "Continuați puternic stânga pe Way Name",
+        "ru": "Двигайтесь налево по Way Name",
+        "sl": "Nadaljujte ostro levo na Way Name",
+        "sv": "Fortsätt vänster på Way Name",
+        "tr": "Way Name üzerinde keskin sol yönde devam et",
+        "uk": "Рухайтесь різко ліворуч на Way Name",
+        "vi": "Chạy tiếp bên trái gắt trên Way Name",
+        "yo": "Tesiwaju didasilẹ pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "继续急向左，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/notification/sharp_left_name.json
+++ b/test/fixtures/v5/notification/sharp_left_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson tovább élesen balra a Way Name felé",
         "id": "Lanjutkan tajam kiri menuju Way Name",
         "it": "Continua a sinistra in Way Name",
-        "ja": "Way Nameを大きく左に進む",
+        "ja": "Way Nameを左戻るに進む",
         "ko": "바로좌회전해서 Way Name로 가세요.",
         "my": "Way Name​ပေါ်သို့ ဘယ်ဘက် ထောင့်ချိုးကိုဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar links naar Way Name",

--- a/test/fixtures/v5/notification/sharp_right_default.json
+++ b/test/fixtures/v5/notification/sharp_right_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson tovább élesen jobbra",
         "id": "Lanjutkan tajam kanan",
         "it": "Continua a destra",
-        "ja": "大きく右に進む",
+        "ja": "右戻るに進む",
         "ko": "바로우회전 하세요.",
         "my": "ညာဘက် ထောင့်ချိုးကိုဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar rechts",

--- a/test/fixtures/v5/notification/sharp_right_destination.json
+++ b/test/fixtures/v5/notification/sharp_right_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson tovább élesen jobbra a Destination 1 irányába",
         "id": "Lanjutkan tajam kanan menuju Destination 1",
         "it": "Continua a destra verso Destination 1",
-        "ja": "Destination 1へ向けて大きく右に進む",
+        "ja": "Destination 1へ向けて右戻るに進む",
         "ko": "바로우회전해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ညာဘက် ထောင့်ချိုးကို ဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar rechts richting Destination 1",

--- a/test/fixtures/v5/notification/sharp_right_exit.json
+++ b/test/fixtures/v5/notification/sharp_right_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson tovább élesen jobbra a Way Name felé",
         "id": "Lanjutkan tajam kanan menuju Way Name",
         "it": "Continua a destra in Way Name",
-        "ja": "Way Nameを大きく右に進む",
+        "ja": "Way Nameを右戻るに進む",
         "ko": "바로우회전해서 Way Name로 가세요.",
         "my": "Way Name​ပေါ်သို့ ညာဘက် ထောင့်ချိုးကိုဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar rechts naar Way Name",

--- a/test/fixtures/v5/notification/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/notification/sharp_right_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson tovább élesen jobbra a Destination 1 irányába",
         "id": "Lanjutkan tajam kanan menuju Destination 1",
         "it": "Continua a destra verso Destination 1",
-        "ja": "Destination 1へ向けて大きく右に進む",
+        "ja": "Destination 1へ向けて右戻るに進む",
         "ko": "바로우회전해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ညာဘက် ထောင့်ချိုးကို ဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar rechts richting Destination 1",

--- a/test/fixtures/v5/notification/sharp_right_junction_name.json
+++ b/test/fixtures/v5/notification/sharp_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "تابع يمين حادا على Way Name",
+        "da": "Fortsæt skarpt til højre ad Way Name",
+        "de": "Scharf rechts weiterfahren auf Way Name",
+        "en": "Continue sharp right onto Way Name",
+        "eo": "Pluu dekstregen al Way Name",
+        "es": "Continúa cerrada a la derecha en Way Name",
+        "es-ES": "Continúa cerrada a la derecha por Way Name",
+        "fi": "Jatka jyrkästi oikeaan tielle Way Name",
+        "fr": "Continuer franchement à droite sur Way Name",
+        "he": "המשך חדה ימינה על Way Name",
+        "hu": "Hajtson tovább élesen jobbra a Way Name felé",
+        "id": "Lanjutkan tajam kanan menuju Way Name",
+        "it": "Continua a destra in Way Name",
+        "ja": "Way Nameを右戻るに進む",
+        "ko": "바로우회전해서 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ ညာဘက် ထောင့်ချိုးကိုဆက်သွားပါ",
+        "nl": "Ga scherpe bocht naar rechts naar Way Name",
+        "no": "Fortsett skarp høyre til Way Name",
+        "pl": "Kontynuuj ostro w prawo na Way Name",
+        "pt-BR": "Continue fechada à direita em Way Name",
+        "pt-PT": "Continue acentuadamente à direita para Way Name",
+        "ro": "Continuați puternic dreapta pe Way Name",
+        "ru": "Двигайтесь направо по Way Name",
+        "sl": "Nadaljujte ostro desno na Way Name",
+        "sv": "Fortsätt höger på Way Name",
+        "tr": "Way Name üzerinde keskin sağ yönde devam et",
+        "uk": "Рухайтесь різко праворуч на Way Name",
+        "vi": "Chạy tiếp bên phải gắt trên Way Name",
+        "yo": "Tesiwaju didasilẹ ọtun pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "继续急向右，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/notification/sharp_right_name.json
+++ b/test/fixtures/v5/notification/sharp_right_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson tovább élesen jobbra a Way Name felé",
         "id": "Lanjutkan tajam kanan menuju Way Name",
         "it": "Continua a destra in Way Name",
-        "ja": "Way Nameを大きく右に進む",
+        "ja": "Way Nameを右戻るに進む",
         "ko": "바로우회전해서 Way Name로 가세요.",
         "my": "Way Name​ပေါ်သို့ ညာဘက် ထောင့်ချိုးကိုဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar rechts naar Way Name",

--- a/test/fixtures/v5/notification/slight_left_junction_name.json
+++ b/test/fixtures/v5/notification/slight_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "تابع يساراً قليلاًا على Way Name",
+        "da": "Fortsæt svagt til venstre ad Way Name",
+        "de": "Leicht links weiterfahren auf Way Name",
+        "en": "Continue slight left onto Way Name",
+        "eo": "Pluu maldekstreten al Way Name",
+        "es": "Continúa levemente a la izquierda en Way Name",
+        "es-ES": "Continúa ligeramente a la izquierda por Way Name",
+        "fi": "Jatka loivasti vasempaan tielle Way Name",
+        "fr": "Continuer légèrement à gauche sur Way Name",
+        "he": "המשך קלה שמאלה על Way Name",
+        "hu": "Hajtson tovább enyhén balra a Way Name felé",
+        "id": "Lanjutkan agak ke kiri menuju Way Name",
+        "it": "Continua a sinistra leggermente in Way Name",
+        "ja": "Way Nameを斜め左に進む",
+        "ko": "조금왼쪽해서 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ ဘယ်ဘက် အနည်းငယ်ကိုဆက်သွားပါ",
+        "nl": "Ga iets naar links naar Way Name",
+        "no": "Fortsett litt til venstre til Way Name",
+        "pl": "Kontynuuj łagodnie w lewo na Way Name",
+        "pt-BR": "Continue suave à esquerda em Way Name",
+        "pt-PT": "Continue ligeiramente à esquerda para Way Name",
+        "ro": "Continuați ușor stânga pe Way Name",
+        "ru": "Двигайтесь левее по Way Name",
+        "sl": "Nadaljujte rahlo levo na Way Name",
+        "sv": "Fortsätt vänster på Way Name",
+        "tr": "Way Name üzerinde hafif sol yönde devam et",
+        "uk": "Рухайтесь плавно ліворуч на Way Name",
+        "vi": "Chạy tiếp bên trái nghiêng trên Way Name",
+        "yo": "Tesiwaju diẹ osi pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "继续稍向左，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/notification/slight_right_junction_name.json
+++ b/test/fixtures/v5/notification/slight_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "تابع يساراً قليلاًا على Way Name",
+        "da": "Fortsæt svagt til højre ad Way Name",
+        "de": "Leicht rechts weiterfahren auf Way Name",
+        "en": "Continue slight right onto Way Name",
+        "eo": "Pluu dekstreten al Way Name",
+        "es": "Continúa levemente a la derecha en Way Name",
+        "es-ES": "Continúa ligeramente a la derecha por Way Name",
+        "fi": "Jatka loivasti oikeaan tielle Way Name",
+        "fr": "Continuer légèrement à droite sur Way Name",
+        "he": "המשך קלה ימינה על Way Name",
+        "hu": "Hajtson tovább enyhén jobbra a Way Name felé",
+        "id": "Lanjutkan agak ke kanan menuju Way Name",
+        "it": "Continua a destra leggermente in Way Name",
+        "ja": "Way Nameを斜め右に進む",
+        "ko": "조금오른쪽해서 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ ညာဘက် အနည်းငယ်ကိုဆက်သွားပါ",
+        "nl": "Ga iets naar rechts naar Way Name",
+        "no": "Fortsett litt til høyre til Way Name",
+        "pl": "Kontynuuj łagodnie w prawo na Way Name",
+        "pt-BR": "Continue suave à direita em Way Name",
+        "pt-PT": "Continue ligeiramente à direita para Way Name",
+        "ro": "Continuați ușor dreapta pe Way Name",
+        "ru": "Двигайтесь правее по Way Name",
+        "sl": "Nadaljujte rahlo desno na Way Name",
+        "sv": "Fortsätt höger på Way Name",
+        "tr": "Way Name üzerinde hafif sağ yönde devam et",
+        "uk": "Рухайтесь плавно праворуч на Way Name",
+        "vi": "Chạy tiếp bên phải nghiêng trên Way Name",
+        "yo": "Tesiwaju diẹ ọtun pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "继续稍向右，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/notification/straight_junction_name.json
+++ b/test/fixtures/v5/notification/straight_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "تابع مباشرةا على Way Name",
+        "da": "Fortsæt ligeud ad Way Name",
+        "de": "Geradeaus weiterfahren auf Way Name",
+        "en": "Continue straight onto Way Name",
+        "eo": "Pluu rekten al Way Name",
+        "es": "Continúa recto en Way Name",
+        "es-ES": "Continúa recto por Way Name",
+        "fi": "Jatka suoraan eteenpäin tielle Way Name",
+        "fr": "Continuer tout droit sur Way Name",
+        "he": "המשך ישר על Way Name",
+        "hu": "Hajtson tovább egyenesen a Way Name felé",
+        "id": "Lanjutkan lurus menuju Way Name",
+        "it": "Continua a dritto in Way Name",
+        "ja": "Way Nameを直進に進む",
+        "ko": "직진해서 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့ ဖြောင့်ဖြောင့်တန်းတန်းကိုဆက်သွားပါ",
+        "nl": "Ga rechtdoor naar Way Name",
+        "no": "Fortsett rett frem til Way Name",
+        "pl": "Kontynuuj prosto na Way Name",
+        "pt-BR": "Continue em frente em Way Name",
+        "pt-PT": "Continue em frente para Way Name",
+        "ro": "Continuați înainte pe Way Name",
+        "ru": "Двигайтесь прямо по Way Name",
+        "sl": "Nadaljujte naravnost na Way Name",
+        "sv": "Fortsätt rakt fram på Way Name",
+        "tr": "Way Name üzerinde düz yönde devam et",
+        "uk": "Рухайтесь прямо на Way Name",
+        "vi": "Chạy tiếp bên thẳng trên Way Name",
+        "yo": "Tesiwaju Taara pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "继续直行，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/notification/uturn_junction_name.json
+++ b/test/fixtures/v5/notification/uturn_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "notification",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف دورانا عكسيا على Way Name",
+        "da": "Foretag en U-vending ad Way Name",
+        "de": "180°-Wendung auf Way Name",
+        "en": "Make a U-turn onto Way Name",
+        "eo": "Turniĝu malantaŭen al Way Name",
+        "es": "Haz un cambio de sentido en Way Name",
+        "es-ES": "Haz un cambio de sentido en Way Name",
+        "fi": "Tee U-käännös tielle Way Name",
+        "fr": "Faire demi-tour sur Way Name",
+        "he": "פנה פניית פרסה על Way Name",
+        "hu": "Forduljon vissza a Way Name felé",
+        "id": "Putar balik ke arah Way Name",
+        "it": "Fai un’inversione a U in Way Name",
+        "ja": "Uターンし、Way Nameを進む",
+        "ko": "유턴해서 Way Name로 가세요.",
+        "my": "Way Nameလမ်းဘက်သို့ ဂ-ကွေ့ ကွေ့ပါ",
+        "nl": "Keer om naar Way Name",
+        "no": "Ta en U-sving til Way Name",
+        "pl": "Zawróć na Way Name",
+        "pt-BR": "Faça o retorno em Way Name",
+        "pt-PT": "Faça inversão de marcha para Way Name",
+        "ro": "Întoarceți-vă pe Way Name",
+        "ru": "Развернитесь на Way Name",
+        "sl": "Polkrožno obrnite na Way Name",
+        "sv": "Gör en U-sväng in på Way Name",
+        "tr": "Way Name yoluna U dönüşü yapın",
+        "uk": "Здійсніть розворот на Way Name",
+        "vi": "Quẹo ngược lại Way Name",
+        "yo": "Ṣe U-tan pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "前方调头，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/off_ramp/left_default.json
+++ b/test/fixtures/v5/off_ramp/left_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról",
         "id": "Ambil jalan yang melandai di sebelah kiri",
         "it": "Prendi la rampa a sinistra",
-        "ja": "左方向のランプに向かう",
+        "ja": "左方向、出口です",
         "ko": "왼쪽의 램프로 진출해 주세요.",
         "my": "ဘယ်ဘက်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit links",

--- a/test/fixtures/v5/off_ramp/left_destination.json
+++ b/test/fixtures/v5/off_ramp/left_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Destination 1 irányába",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",
-        "ja": "左方向のランプに向かい、その後Destination 1へ向かう",
+        "ja": "左方向、Destination 1方面、出口です",
         "ko": "왼쪽의 램프로 진출해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ဘယ်ဘက်ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit links richting Destination 1",

--- a/test/fixtures/v5/off_ramp/left_exit.json
+++ b/test/fixtures/v5/off_ramp/left_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson ki a 4A kijáraton balról",
         "id": "Take exit 4A on the left",
         "it": "Prendi l’uscita 4A a sinistra",
-        "ja": "左方向の4A出口を出る",
+        "ja": "左方向、4A 出口です",
         "ko": "4A 왼쪽의 출구로 나가세요.",
         "my": "ဘယ်ဘက်တွင်4Aကို ယူပါ",
         "nl": "Neem afslag 4A aan de linkerkant",

--- a/test/fixtures/v5/off_ramp/left_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/left_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson ki a 4A kijáraton balról a Destination 1 irányába",
         "id": "Take exit 4A on the left towards Destination 1",
         "it": "Prendi la 4A uscita a sinistra verso Destination 1",
-        "ja": "左方向の4A出口を出てDestination 1へ向かう",
+        "ja": "左方向、Destination 1 方面、4A　出口です",
         "ko": "4A 왼쪽의 출구로 가나서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ဘယ်ဘက်မှ 4A ကိုယူပါ",
         "nl": "Neem afslag 4A aan de linkerkant richting Destination 1",

--- a/test/fixtures/v5/off_ramp/left_junction_name.json
+++ b/test/fixtures/v5/off_ramp/left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك المدخل يسارا حادا لتبقى على Way Name",
+        "da": "Tag afkørslen til venstre ad Way Name",
+        "de": "Ausfahrt links nehmen auf Way Name",
+        "en": "Take the ramp on the left onto Way Name",
+        "eo": "Direktiĝu al enveturejo ĉe maldekstre al Way Name",
+        "es": "Toma la salida en la izquierda en Way Name",
+        "es-ES": "Coge la cuesta abajo de la izquierda por Way Name",
+        "fi": "Aja vasemmalla olevaa erkanemiskaistaa tielle Way Name",
+        "fr": "Prendre la sortie à gauche sur Way Name",
+        "he": "צא ביציאה שמשמאלך על Way Name",
+        "hu": "Hajtson az átkötő útszakaszra balról a Way Name felé",
+        "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
+        "it": "Prendi la rampa a sinistra in Way Name",
+        "ja": "左方向、Way Name方面、出口です",
+        "ko": "왼쪽의 램프로 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ဘယ်ဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
+        "nl": "Neem de afrit links naar Way Name",
+        "no": "Ta avkjørselen på venstre side inn på Way Name",
+        "pl": "Weź zjazd po lewej na Way Name",
+        "pt-BR": "Pegue a rampa à esquerda em Way Name",
+        "pt-PT": "Saia na saída à esquerda para Way Name",
+        "ro": "Urmați breteaua din stânga pe Way Name",
+        "ru": "Сверните на левый съезд на Way Name",
+        "sl": "Zapeljite na izhod na levi na Way Name",
+        "sv": "Ta avfarten till vänster in på Way Name",
+        "tr": "Way Name üzerindeki sol bağlantı yoluna geç",
+        "uk": "Рухайтесь на зʼїзд ліворуч на Way Name",
+        "vi": "Đi đường nhánh Way Name bên trái",
+        "yo": "Gba awọn ibọn ni apa osi pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "下左侧匝道，上Way Name"
+    }
+}

--- a/test/fixtures/v5/off_ramp/left_name.json
+++ b/test/fixtures/v5/off_ramp/left_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Way Name felé",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",
-        "ja": "左方向のランプに向かい、Way Nameを進む",
+        "ja": "左方向、Way Name方面、出口です",
         "ko": "왼쪽의 램프로 진출해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ဘယ်ဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit links naar Way Name",

--- a/test/fixtures/v5/off_ramp/right_default.json
+++ b/test/fixtures/v5/off_ramp/right_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra",
         "id": "Ambil jalan melandai",
         "it": "Prendi la rampa",
-        "ja": "ランプに向かう",
+        "ja": "出口です",
         "ko": "램프로 진출해 주세요..",
         "my": "ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit",

--- a/test/fixtures/v5/off_ramp/right_destination.json
+++ b/test/fixtures/v5/off_ramp/right_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Destination 1 irányába",
         "id": "Ambil jalan melandai menuju Destination 1",
         "it": "Prendi la rampa verso Destination 1",
-        "ja": "Destination 1に向けてランプに向かう",
+        "ja": "Destination 1方面、出口です",
         "ko": "램프로 진출해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit richting Destination 1",

--- a/test/fixtures/v5/off_ramp/right_exit.json
+++ b/test/fixtures/v5/off_ramp/right_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson ki a 4A kijáraton",
         "id": "Take exit 4A",
         "it": "Prendi l’uscita 4A",
-        "ja": "4A出口に向かう",
+        "ja": "4A 出口です",
         "ko": "4A 출구로 나가세요.",
         "my": "4Aကို ယူပါ",
         "nl": "Neem afslag 4A",

--- a/test/fixtures/v5/off_ramp/right_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/right_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson ki a 4A kijáraton a Destination 1 irányába",
         "id": "Take exit 4A towards Destination 1",
         "it": "Prendi l’uscita 4A verso Destination 1",
-        "ja": "4A出口を出てDestination 1へ向かう",
+        "ja": "Destination 1 方面、4A　出口です",
         "ko": "4A 출구로 나가서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ 4A ကိုယူပါ",
         "nl": "Neem afslag 4A richting Destination 1",

--- a/test/fixtures/v5/off_ramp/right_junction_name.json
+++ b/test/fixtures/v5/off_ramp/right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اتبع المنحدر على Way Name",
+        "da": "Tag afkørslen ad Way Name",
+        "de": "Ausfahrt nehmen auf Way Name",
+        "en": "Take the ramp onto Way Name",
+        "eo": "Direktiĝu al enveturejo al Way Name",
+        "es": "Toma la salida en Way Name",
+        "es-ES": "Coge la cuesta abajo por Way Name",
+        "fi": "Aja erkanemiskaistaa tielle Way Name",
+        "fr": "Prendre la sortie sur Way Name",
+        "he": "צא ביציאה על Way Name",
+        "hu": "Hajtson az átkötő útszakaszra a Way Name felé",
+        "id": "Ambil jalan melandai ke Way Name",
+        "it": "Prendi la rampa in Way Name",
+        "ja": "Way Name方面、出口です",
+        "ko": "램프로 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
+        "nl": "Neem de afrit naar Way Name",
+        "no": "Ta avkjørselen inn på Way Name",
+        "pl": "Weź zjazd na Way Name",
+        "pt-BR": "Pegue a rampa em Way Name",
+        "pt-PT": "Saia na saída para Way Name",
+        "ro": "Urmați breteaua pe Way Name",
+        "ru": "Сверните на съезд на Way Name",
+        "sl": "Zapeljite na izhod na Way Name",
+        "sv": "Ta avfarten in på Way Name",
+        "tr": "Way Name üzerindeki bağlantı yoluna geç",
+        "uk": "Рухайтесь на зʼїзд на Way Name",
+        "vi": "Đi đường nhánh Way Name",
+        "yo": "Mu awọn rampan si pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "下匝道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/off_ramp/right_name.json
+++ b/test/fixtures/v5/off_ramp/right_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Way Name felé",
         "id": "Ambil jalan melandai ke Way Name",
         "it": "Prendi la rampa in Way Name",
-        "ja": "Way Nameに向けてランプに向かう",
+        "ja": "Way Name方面、出口です",
         "ko": "램프로 진출해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit naar Way Name",

--- a/test/fixtures/v5/off_ramp/sharp_left_default.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról",
         "id": "Ambil jalan yang melandai di sebelah kiri",
         "it": "Prendi la rampa a sinistra",
-        "ja": "左方向のランプに向かう",
+        "ja": "左方向、出口です",
         "ko": "왼쪽의 램프로 진출해 주세요.",
         "my": "ဘယ်ဘက်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit links",

--- a/test/fixtures/v5/off_ramp/sharp_left_destination.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Destination 1 irányába",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",
-        "ja": "左方向のランプに向かい、Destination 1へ向かう",
+        "ja": "左方向、Destination 1方面、出口です",
         "ko": "왼쪽의 램프로 진출해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ဘယ်ဘက်ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit links richting Destination 1",

--- a/test/fixtures/v5/off_ramp/sharp_left_exit.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson ki a 4A kijáraton balról",
         "id": "Take exit 4A on the left",
         "it": "Prendi l’uscita 4A a sinistra",
-        "ja": "左方向の4A出口を出る",
+        "ja": "左方向、4A 出口です",
         "ko": "4A 왼쪽의 출구로 나가세요.",
         "my": "ဘယ်ဘက်တွင်4Aကို ယူပါ",
         "nl": "Neem afslag 4A aan de linkerkant",

--- a/test/fixtures/v5/off_ramp/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson ki a 4A kijáraton balról a Destination 1 irányába",
         "id": "Take exit 4A on the left towards Destination 1",
         "it": "Prendi la 4A uscita a sinistra verso Destination 1",
-        "ja": "左方向の4A出口を出てDestination 1へ向かう",
+        "ja": "左方向、Destination 1 方面、4A　出口です",
         "ko": "4A 왼쪽의 출구로 가나서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ဘယ်ဘက်မှ 4A ကိုယူပါ",
         "nl": "Neem afslag 4A aan de linkerkant richting Destination 1",

--- a/test/fixtures/v5/off_ramp/sharp_left_junction_name.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك المدخل يسارا حادا لتبقى على Way Name",
+        "da": "Tag afkørslen til venstre ad Way Name",
+        "de": "Ausfahrt links Seite nehmen auf Way Name",
+        "en": "Take the ramp on the left onto Way Name",
+        "eo": "Direktiĝu al enveturejo ĉe maldekstre al Way Name",
+        "es": "Ve cuesta abajo en la izquierda en Way Name",
+        "es-ES": "Coge la cuesta abajo de la izquierda por Way Name",
+        "fi": "Aja vasemmalla olevaa erkanemiskaistaa tielle Way Name",
+        "fr": "Prendre la sortie à gauche sur Way Name",
+        "he": "צא ביציאה שמשמאלך על Way Name",
+        "hu": "Hajtson az átkötő útszakaszra balról a Way Name felé",
+        "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
+        "it": "Prendi la rampa a sinistra in Way Name",
+        "ja": "左方向、Way Name方面、出口です",
+        "ko": "왼쪽의 램프로 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ဘယ်ဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
+        "nl": "Neem de afrit links naar Way Name",
+        "no": "Ta avkjørselen på venstre side inn på Way Name",
+        "pl": "Weź zjazd po lewej na Way Name",
+        "pt-BR": "Pegue a rampa à esquerda em Way Name",
+        "pt-PT": "Saia na saída à esquerda para Way Name",
+        "ro": "Urmați breteaua din stânga pe Way Name",
+        "ru": "Поверните налево на съезд на Way Name",
+        "sl": "Zapeljite na izhod na levi na Way Name",
+        "sv": "Ta avfarten till vänster in på Way Name",
+        "tr": "Way Name üzerindeki sol bağlantı yoluna geç",
+        "uk": "Рухайтесь на зʼїзд ліворуч на Way Name",
+        "vi": "Đi đường nhánh Way Name bên trái",
+        "yo": "Gba awọn ibọn ni apa osi pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "急向左下匝道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/off_ramp/sharp_left_name.json
+++ b/test/fixtures/v5/off_ramp/sharp_left_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Way Name felé",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",
-        "ja": "左方向のランプに向かい、Way Nameを進む",
+        "ja": "左方向、Way Name方面、出口です",
         "ko": "왼쪽의 램프로 진출해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ဘယ်ဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit links naar Way Name",

--- a/test/fixtures/v5/off_ramp/sharp_right_default.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra",
         "id": "Ambil jalan melandai",
         "it": "Prendi la rampa",
-        "ja": "ランプに向かう",
+        "ja": "出口です",
         "ko": "램프로 진출해 주세요..",
         "my": "ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit",

--- a/test/fixtures/v5/off_ramp/sharp_right_destination.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Destination 1 irányába",
         "id": "Ambil jalan melandai menuju Destination 1",
         "it": "Prendi la rampa verso Destination 1",
-        "ja": "Destination 1に向けてランプに向かう",
+        "ja": "Destination 1方面、出口です",
         "ko": "램프로 진출해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit richting Destination 1",

--- a/test/fixtures/v5/off_ramp/sharp_right_exit.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson ki a 4A kijáraton",
         "id": "Take exit 4A",
         "it": "Prendi l’uscita 4A",
-        "ja": "4A出口に向かう",
+        "ja": "4A 出口です",
         "ko": "4A 출구로 나가세요.",
         "my": "4Aကို ယူပါ",
         "nl": "Neem afslag 4A",

--- a/test/fixtures/v5/off_ramp/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson ki a 4A kijáraton a Destination 1 irányába",
         "id": "Take exit 4A towards Destination 1",
         "it": "Prendi l’uscita 4A verso Destination 1",
-        "ja": "4A出口を出てDestination 1へ向かう",
+        "ja": "Destination 1 方面、4A　出口です",
         "ko": "4A 출구로 나가서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ 4A ကိုယူပါ",
         "nl": "Neem afslag 4A richting Destination 1",

--- a/test/fixtures/v5/off_ramp/sharp_right_junction_name.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اتبع المنحدر على Way Name",
+        "da": "Tag afkørslen ad Way Name",
+        "de": "Ausfahrt nehmen auf Way Name",
+        "en": "Take the ramp onto Way Name",
+        "eo": "Direktiĝu al enveturejo al Way Name",
+        "es": "Toma la salida en Way Name",
+        "es-ES": "Coge la cuesta abajo por Way Name",
+        "fi": "Aja erkanemiskaistaa tielle Way Name",
+        "fr": "Prendre la sortie sur Way Name",
+        "he": "צא ביציאה על Way Name",
+        "hu": "Hajtson az átkötő útszakaszra a Way Name felé",
+        "id": "Ambil jalan melandai ke Way Name",
+        "it": "Prendi la rampa in Way Name",
+        "ja": "Way Name方面、出口です",
+        "ko": "램프로 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
+        "nl": "Neem de afrit naar Way Name",
+        "no": "Ta avkjørselen inn på Way Name",
+        "pl": "Weź zjazd na Way Name",
+        "pt-BR": "Pegue a rampa em Way Name",
+        "pt-PT": "Saia na saída para Way Name",
+        "ro": "Urmați breteaua pe Way Name",
+        "ru": "Сверните на съезд на Way Name",
+        "sl": "Zapeljite na izhod na Way Name",
+        "sv": "Ta avfarten in på Way Name",
+        "tr": "Way Name üzerindeki bağlantı yoluna geç",
+        "uk": "Рухайтесь на зʼїзд на Way Name",
+        "vi": "Đi đường nhánh Way Name",
+        "yo": "Mu awọn rampan si pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "下匝道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/off_ramp/sharp_right_name.json
+++ b/test/fixtures/v5/off_ramp/sharp_right_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Way Name felé",
         "id": "Ambil jalan melandai ke Way Name",
         "it": "Prendi la rampa in Way Name",
-        "ja": "Way Nameに向けてランプに向かう",
+        "ja": "Way Name方面、出口です",
         "ko": "램프로 진출해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit naar Way Name",

--- a/test/fixtures/v5/off_ramp/slight_left_default.json
+++ b/test/fixtures/v5/off_ramp/slight_left_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson at átkötő útszakaszra balról",
         "id": "Ambil jalan yang melandai di sebelah kiri",
         "it": "Prendi la rampa a sinistra",
-        "ja": "左方向のランプへ向かう",
+        "ja": "左方向、出口です",
         "ko": "왼쪽의 램프로 진출해 주세요.",
         "my": "ဘယ်ဘက်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit links",

--- a/test/fixtures/v5/off_ramp/slight_left_destination.json
+++ b/test/fixtures/v5/off_ramp/slight_left_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Destination 1 irányába",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",
-        "ja": "左方向のランプに向かい、その後Destination 1へ向かう",
+        "ja": "左方向、Destination 1方面、出口です",
         "ko": "왼쪽의 램프로 진출해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ဘယ်ဘက်ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit links richting Destination 1",

--- a/test/fixtures/v5/off_ramp/slight_left_exit.json
+++ b/test/fixtures/v5/off_ramp/slight_left_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson ki a 4A kijáraton balról",
         "id": "Take exit 4A on the left",
         "it": "Prendi l’uscita 4A a sinistra",
-        "ja": "左方向の4A出口を出る",
+        "ja": "左方向、4A 出口です",
         "ko": "4A 왼쪽의 출구로 나가세요.",
         "my": "ဘယ်ဘက်တွင်4Aကို ယူပါ",
         "nl": "Neem afslag 4A aan de linkerkant",

--- a/test/fixtures/v5/off_ramp/slight_left_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/slight_left_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson ki a 4A kijáraton balról a Destination 1 irányába",
         "id": "Take exit 4A on the left towards Destination 1",
         "it": "Prendi la 4A uscita a sinistra verso Destination 1",
-        "ja": "左方向の4A出口を出てDestination 1へ向かう",
+        "ja": "左方向、Destination 1 方面、4A　出口です",
         "ko": "4A 왼쪽의 출구로 가나서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ဘယ်ဘက်မှ 4A ကိုယူပါ",
         "nl": "Neem afslag 4A aan de linkerkant richting Destination 1",

--- a/test/fixtures/v5/off_ramp/slight_left_junction_name.json
+++ b/test/fixtures/v5/off_ramp/slight_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك المدخل يسارا حادا لتبقى على Way Name",
+        "da": "Tag afkørslen til venstre ad Way Name",
+        "de": "Ausfahrt links nehmen auf Way Name",
+        "en": "Take the ramp on the left onto Way Name",
+        "eo": "Direktiĝu al enveturejo ĉe maldekstre al Way Name",
+        "es": "Ve cuesta abajo en la izquierda en Way Name",
+        "es-ES": "Coge la cuesta abajo de la izquierda por Way Name",
+        "fi": "Aja vasemmalla olevaa erkanemiskaistaa tielle Way Name",
+        "fr": "Prendre la sortie à gauche sur Way Name",
+        "he": "צא ביציאה שמשמאלך על Way Name",
+        "hu": "Hajtson az átkötő útszakaszra balról a Way Name felé",
+        "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
+        "it": "Prendi la rampa a sinistra in Way Name",
+        "ja": "左方向、Way Name方面、出口です",
+        "ko": "왼쪽의 램프로 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ဘယ်ဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
+        "nl": "Neem de afrit links naar Way Name",
+        "no": "Ta avkjørselen på venstre side inn på Way Name",
+        "pl": "Weź zjazd po lewej na Way Name",
+        "pt-BR": "Pegue a rampa à esquerda em Way Name",
+        "pt-PT": "Saia na saída à esquerda para Way Name",
+        "ro": "Urmați breteaua din stânga pe Way Name",
+        "ru": "Перестройтесь левее на съезд на Way Name",
+        "sl": "Zapeljite na izhod na levi na Way Name",
+        "sv": "Ta avfarten till vänster in på Way Name",
+        "tr": "Way Name üzerindeki sol bağlantı yoluna geç",
+        "uk": "Рухайтесь на зʼїзд ліворуч на Way Name",
+        "vi": "Đi đường nhánh Way Name bên trái",
+        "yo": "Gba awọn ibọn ni apa osi pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "稍向左下匝道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/off_ramp/slight_left_name.json
+++ b/test/fixtures/v5/off_ramp/slight_left_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Way Name felé",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",
-        "ja": "左方向のランプに向かい、Way Nameを進む",
+        "ja": "左方向、Way Name方面、出口です",
         "ko": "왼쪽의 램프로 진출해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ဘယ်ဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit links naar Way Name",

--- a/test/fixtures/v5/off_ramp/slight_right_default.json
+++ b/test/fixtures/v5/off_ramp/slight_right_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra",
         "id": "Ambil jalan melandai",
         "it": "Prendi la rampa",
-        "ja": "ランプに向かう",
+        "ja": "出口です",
         "ko": "램프로 진출해 주세요..",
         "my": "ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit",

--- a/test/fixtures/v5/off_ramp/slight_right_destination.json
+++ b/test/fixtures/v5/off_ramp/slight_right_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Destination 1 irányába",
         "id": "Ambil jalan melandai menuju Destination 1",
         "it": "Prendi la rampa verso Destination 1",
-        "ja": "Destination 1に向けてランプに向かう",
+        "ja": "Destination 1方面、出口です",
         "ko": "램프로 진출해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit richting Destination 1",

--- a/test/fixtures/v5/off_ramp/slight_right_exit.json
+++ b/test/fixtures/v5/off_ramp/slight_right_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson ki a 4A kijáraton",
         "id": "Take exit 4A",
         "it": "Prendi l’uscita 4A",
-        "ja": "4A出口に向かう",
+        "ja": "4A 出口です",
         "ko": "4A 출구로 나가세요.",
         "my": "4Aကို ယူပါ",
         "nl": "Neem afslag 4A",

--- a/test/fixtures/v5/off_ramp/slight_right_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/slight_right_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson ki a 4A kijáraton a Destination 1 irányába",
         "id": "Take exit 4A towards Destination 1",
         "it": "Prendi l’uscita 4A verso Destination 1",
-        "ja": "4A出口を出てDestination 1へ向かう",
+        "ja": "Destination 1 方面、4A　出口です",
         "ko": "4A 출구로 나가서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ 4A ကိုယူပါ",
         "nl": "Neem afslag 4A richting Destination 1",

--- a/test/fixtures/v5/off_ramp/slight_right_junction_name.json
+++ b/test/fixtures/v5/off_ramp/slight_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اتبع المنحدر على Way Name",
+        "da": "Tag afkørslen ad Way Name",
+        "de": "Ausfahrt nehmen auf Way Name",
+        "en": "Take the ramp onto Way Name",
+        "eo": "Direktiĝu al enveturejo al Way Name",
+        "es": "Toma la salida en Way Name",
+        "es-ES": "Coge la cuesta abajo por Way Name",
+        "fi": "Aja erkanemiskaistaa tielle Way Name",
+        "fr": "Prendre la sortie sur Way Name",
+        "he": "צא ביציאה על Way Name",
+        "hu": "Hajtson az átkötő útszakaszra a Way Name felé",
+        "id": "Ambil jalan melandai ke Way Name",
+        "it": "Prendi la rampa in Way Name",
+        "ja": "Way Name方面、出口です",
+        "ko": "램프로 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
+        "nl": "Neem de afrit naar Way Name",
+        "no": "Ta avkjørselen inn på Way Name",
+        "pl": "Weź zjazd na Way Name",
+        "pt-BR": "Pegue a rampa em Way Name",
+        "pt-PT": "Saia na saída para Way Name",
+        "ro": "Urmați breteaua pe Way Name",
+        "ru": "Сверните на съезд на Way Name",
+        "sl": "Zapeljite na izhod na Way Name",
+        "sv": "Ta avfarten in på Way Name",
+        "tr": "Way Name üzerindeki bağlantı yoluna geç",
+        "uk": "Рухайтесь на зʼїзд на Way Name",
+        "vi": "Đi đường nhánh Way Name",
+        "yo": "Mu awọn rampan si pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "下匝道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/off_ramp/slight_right_name.json
+++ b/test/fixtures/v5/off_ramp/slight_right_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Way Name felé",
         "id": "Ambil jalan melandai ke Way Name",
         "it": "Prendi la rampa in Way Name",
-        "ja": "Way Nameに向けてランプに向かう",
+        "ja": "Way Name方面、出口です",
         "ko": "램프로 진출해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit naar Way Name",

--- a/test/fixtures/v5/off_ramp/straight_default.json
+++ b/test/fixtures/v5/off_ramp/straight_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra",
         "id": "Ambil jalan melandai",
         "it": "Prendi la rampa",
-        "ja": "ランプに向かう",
+        "ja": "出口です",
         "ko": "램프로 진출해 주세요..",
         "my": "ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit",

--- a/test/fixtures/v5/off_ramp/straight_destination.json
+++ b/test/fixtures/v5/off_ramp/straight_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Destination 1 irányába",
         "id": "Ambil jalan melandai menuju Destination 1",
         "it": "Prendi la rampa verso Destination 1",
-        "ja": "Destination 1に向けてランプに向かう",
+        "ja": "Destination 1方面、出口です",
         "ko": "램프로 진출해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit richting Destination 1",

--- a/test/fixtures/v5/off_ramp/straight_exit.json
+++ b/test/fixtures/v5/off_ramp/straight_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson ki a 4A kijáraton",
         "id": "Take exit 4A",
         "it": "Prendi l’uscita 4A",
-        "ja": "4A出口に向かう",
+        "ja": "4A 出口です",
         "ko": "4A 출구로 나가세요.",
         "my": "4Aကို ယူပါ",
         "nl": "Neem afslag 4A",

--- a/test/fixtures/v5/off_ramp/straight_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/straight_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson ki a 4A kijáraton a Destination 1 irányába",
         "id": "Take exit 4A towards Destination 1",
         "it": "Prendi l’uscita 4A verso Destination 1",
-        "ja": "4A出口を出てDestination 1へ向かう",
+        "ja": "Destination 1 方面、4A　出口です",
         "ko": "4A 출구로 나가서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ 4A ကိုယူပါ",
         "nl": "Neem afslag 4A richting Destination 1",

--- a/test/fixtures/v5/off_ramp/straight_junction_name.json
+++ b/test/fixtures/v5/off_ramp/straight_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اتبع المنحدر على Way Name",
+        "da": "Tag afkørslen ad Way Name",
+        "de": "Ausfahrt nehmen auf Way Name",
+        "en": "Take the ramp onto Way Name",
+        "eo": "Direktiĝu al enveturejo al Way Name",
+        "es": "Toma la salida en Way Name",
+        "es-ES": "Coge la cuesta abajo por Way Name",
+        "fi": "Aja erkanemiskaistaa tielle Way Name",
+        "fr": "Prendre la sortie sur Way Name",
+        "he": "צא ביציאה על Way Name",
+        "hu": "Hajtson az átkötő útszakaszra a Way Name felé",
+        "id": "Ambil jalan melandai ke Way Name",
+        "it": "Prendi la rampa in Way Name",
+        "ja": "Way Name方面、出口です",
+        "ko": "램프로 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
+        "nl": "Neem de afrit naar Way Name",
+        "no": "Ta avkjørselen inn på Way Name",
+        "pl": "Weź zjazd na Way Name",
+        "pt-BR": "Pegue a rampa em Way Name",
+        "pt-PT": "Saia na saída para Way Name",
+        "ro": "Urmați breteaua pe Way Name",
+        "ru": "Сверните на съезд на Way Name",
+        "sl": "Zapeljite na izhod na Way Name",
+        "sv": "Ta avfarten in på Way Name",
+        "tr": "Way Name üzerindeki bağlantı yoluna geç",
+        "uk": "Рухайтесь на зʼїзд на Way Name",
+        "vi": "Đi đường nhánh Way Name",
+        "yo": "Mu awọn rampan si pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "下匝道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/off_ramp/straight_name.json
+++ b/test/fixtures/v5/off_ramp/straight_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Way Name felé",
         "id": "Ambil jalan melandai ke Way Name",
         "it": "Prendi la rampa in Way Name",
-        "ja": "Way Nameに向けてランプに向かう",
+        "ja": "Way Name方面、出口です",
         "ko": "램프로 진출해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit naar Way Name",

--- a/test/fixtures/v5/off_ramp/uturn_default.json
+++ b/test/fixtures/v5/off_ramp/uturn_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra",
         "id": "Ambil jalan melandai",
         "it": "Prendi la rampa",
-        "ja": "ランプに向かう",
+        "ja": "出口です",
         "ko": "램프로 진출해 주세요..",
         "my": "ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit",

--- a/test/fixtures/v5/off_ramp/uturn_destination.json
+++ b/test/fixtures/v5/off_ramp/uturn_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Destination 1 irányába",
         "id": "Ambil jalan melandai menuju Destination 1",
         "it": "Prendi la rampa verso Destination 1",
-        "ja": "Destination 1に向けてランプに向かう",
+        "ja": "Destination 1方面、出口です",
         "ko": "램프로 진출해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit richting Destination 1",

--- a/test/fixtures/v5/off_ramp/uturn_exit.json
+++ b/test/fixtures/v5/off_ramp/uturn_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson ki a 4A kijáraton",
         "id": "Take exit 4A",
         "it": "Prendi l’uscita 4A",
-        "ja": "4A出口に向かう",
+        "ja": "4A 出口です",
         "ko": "4A 출구로 나가세요.",
         "my": "4Aကို ယူပါ",
         "nl": "Neem afslag 4A",

--- a/test/fixtures/v5/off_ramp/uturn_exit_destination.json
+++ b/test/fixtures/v5/off_ramp/uturn_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson ki a 4A kijáraton a Destination 1 irányába",
         "id": "Take exit 4A towards Destination 1",
         "it": "Prendi l’uscita 4A verso Destination 1",
-        "ja": "4A出口を出てDestination 1へ向かう",
+        "ja": "Destination 1 方面、4A　出口です",
         "ko": "4A 출구로 나가서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ 4A ကိုယူပါ",
         "nl": "Neem afslag 4A richting Destination 1",

--- a/test/fixtures/v5/off_ramp/uturn_junction_name.json
+++ b/test/fixtures/v5/off_ramp/uturn_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "off ramp",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اتبع المنحدر على Way Name",
+        "da": "Tag afkørslen ad Way Name",
+        "de": "Ausfahrt nehmen auf Way Name",
+        "en": "Take the ramp onto Way Name",
+        "eo": "Direktiĝu al enveturejo al Way Name",
+        "es": "Toma la salida en Way Name",
+        "es-ES": "Coge la cuesta abajo por Way Name",
+        "fi": "Aja erkanemiskaistaa tielle Way Name",
+        "fr": "Prendre la sortie sur Way Name",
+        "he": "צא ביציאה על Way Name",
+        "hu": "Hajtson az átkötő útszakaszra a Way Name felé",
+        "id": "Ambil jalan melandai ke Way Name",
+        "it": "Prendi la rampa in Way Name",
+        "ja": "Way Name方面、出口です",
+        "ko": "램프로 진출해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
+        "nl": "Neem de afrit naar Way Name",
+        "no": "Ta avkjørselen inn på Way Name",
+        "pl": "Weź zjazd na Way Name",
+        "pt-BR": "Pegue a rampa em Way Name",
+        "pt-PT": "Saia na saída para Way Name",
+        "ro": "Urmați breteaua pe Way Name",
+        "ru": "Сверните на съезд на Way Name",
+        "sl": "Zapeljite na izhod na Way Name",
+        "sv": "Ta avfarten in på Way Name",
+        "tr": "Way Name üzerindeki bağlantı yoluna geç",
+        "uk": "Рухайтесь на зʼїзд на Way Name",
+        "vi": "Đi đường nhánh Way Name",
+        "yo": "Mu awọn rampan si pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "下匝道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/off_ramp/uturn_name.json
+++ b/test/fixtures/v5/off_ramp/uturn_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Way Name felé",
         "id": "Ambil jalan melandai ke Way Name",
         "it": "Prendi la rampa in Way Name",
-        "ja": "Way Nameに向けてランプに向かう",
+        "ja": "Way Name方面、出口です",
         "ko": "램프로 진출해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit naar Way Name",

--- a/test/fixtures/v5/on_ramp/left_default.json
+++ b/test/fixtures/v5/on_ramp/left_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról",
         "id": "Ambil jalan yang melandai di sebelah kiri",
         "it": "Prendi la rampa a sinistra",
-        "ja": "左方向のランプへ向かう",
+        "ja": "左方向、入口です",
         "ko": "왼쪽의 램프로 진입해 주세요.",
         "my": "ဘယ်ဘက်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit links",

--- a/test/fixtures/v5/on_ramp/left_destination.json
+++ b/test/fixtures/v5/on_ramp/left_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Destination 1 irányába",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",
-        "ja": "左方向のランプに向かい、その後Destination 1へ向かう",
+        "ja": "左方向、Destination 1方面、入口です",
         "ko": "왼쪽의 램프로 진입해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ဘယ်ဘက်ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit links richting Destination 1",

--- a/test/fixtures/v5/on_ramp/left_exit.json
+++ b/test/fixtures/v5/on_ramp/left_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Way Name felé",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",
-        "ja": "左方向のランプに向かい、Way Nameを進む",
+        "ja": "左方向、Way Name方面、入口です",
         "ko": "왼쪽의 램프로 진입해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ဘယ်ဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit links naar Way Name",

--- a/test/fixtures/v5/on_ramp/left_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/left_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Destination 1 irányába",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",
-        "ja": "左方向のランプに向かい、その後Destination 1へ向かう",
+        "ja": "左方向、Destination 1方面、入口です",
         "ko": "왼쪽의 램프로 진입해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ဘယ်ဘက်ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit links richting Destination 1",

--- a/test/fixtures/v5/on_ramp/left_junction_name.json
+++ b/test/fixtures/v5/on_ramp/left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك المدخل يسارا لتبقى على Way Name",
+        "da": "Tag afkørslen til venstre ad Way Name",
+        "de": "Auffahrt links nehmen auf Way Name",
+        "en": "Take the ramp on the left onto Way Name",
+        "eo": "Direktiĝu al enveturejo ĉe maldekstre al Way Name",
+        "es": "Toma la rampa en la izquierda en Way Name",
+        "es-ES": "Coge la cuesta de la izquierda por Way Name",
+        "fi": "Aja vasemmalla olevaa erkanemiskaistaa tielle Way Name",
+        "fr": "Prendre la sortie à gauche sur Way Name",
+        "he": "צא ביציאה שמשמאלך על Way Name",
+        "hu": "Hajtson az átkötő útszakaszra balról a Way Name felé",
+        "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
+        "it": "Prendi la rampa a sinistra in Way Name",
+        "ja": "左方向、Way Name方面、入口です",
+        "ko": "왼쪽의 램프로 진입해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ဘယ်ဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
+        "nl": "Neem de oprit links naar Way Name",
+        "no": "Ta avkjørselen på venstre side inn på Way Name",
+        "pl": "Weź zjazd po lewej na Way Name",
+        "pt-BR": "Pegue a rampa à esquerda em Way Name",
+        "pt-PT": "Saia na saída à esquerda para Way Name",
+        "ro": "Urmați breteaua din stânga pe Way Name",
+        "ru": "Сверните на левый въезд на Way Name",
+        "sl": "Zapeljite na izhod na levi na Way Name",
+        "sv": "Ta påfarten till vänster in på Way Name",
+        "tr": "Way Name üzerindeki sol bağlantı yoluna geç",
+        "uk": "Рухайтесь на вʼїзд ліворуч на Way Name",
+        "vi": "Đi đường nhánh Way Name bên trái",
+        "yo": "Gba awọn ibọn ni apa osi pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "上左侧匝道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/on_ramp/left_name.json
+++ b/test/fixtures/v5/on_ramp/left_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Way Name felé",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",
-        "ja": "左方向のランプに向かい、Way Nameを進む",
+        "ja": "左方向、Way Name方面、入口です",
         "ko": "왼쪽의 램프로 진입해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ဘယ်ဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit links naar Way Name",

--- a/test/fixtures/v5/on_ramp/right_default.json
+++ b/test/fixtures/v5/on_ramp/right_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra jobbról",
         "id": "Ambil jalan melandai di sebelah kanan",
         "it": "Prendi la rampa a destra",
-        "ja": "右方向のランプへ向かう",
+        "ja": "右方向、入口です",
         "ko": "오른쪽의 램프로 진입해 주세요.",
         "my": "ညာဘက်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit rechts",

--- a/test/fixtures/v5/on_ramp/right_destination.json
+++ b/test/fixtures/v5/on_ramp/right_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra jobbról a Destination 1 irányába",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
         "it": "Prendi la rampa a destra verso Destination 1",
-        "ja": "右方向のランプに向かい、その後Destination 1へ向かう",
+        "ja": "右方向、Destination 1方面、入口です",
         "ko": "오른쪽의 램프로 진입해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ညာဘက်ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit rechts richting Destination 1",

--- a/test/fixtures/v5/on_ramp/right_exit.json
+++ b/test/fixtures/v5/on_ramp/right_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra jobbról a Way Name felé",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
         "it": "Prendi la rampa a destra in Way Name",
-        "ja": "右方向のランプに向かい、Way Nameを進む",
+        "ja": "右方向、Way Name方面、入口です",
         "ko": "오른쪽의 램프로 진입해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ညာဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit rechts naar Way Name",

--- a/test/fixtures/v5/on_ramp/right_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/right_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson az átkötő útszakaszra jobbról a Destination 1 irányába",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
         "it": "Prendi la rampa a destra verso Destination 1",
-        "ja": "右方向のランプに向かい、その後Destination 1へ向かう",
+        "ja": "右方向、Destination 1方面、入口です",
         "ko": "오른쪽의 램프로 진입해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ညာဘက်ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit rechts richting Destination 1",

--- a/test/fixtures/v5/on_ramp/right_junction_name.json
+++ b/test/fixtures/v5/on_ramp/right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك المدخل يمينا لتبقى على Way Name",
+        "da": "Tag afkørslen til højre ad Way Name",
+        "de": "Auffahrt rechts nehmen auf Way Name",
+        "en": "Take the ramp on the right onto Way Name",
+        "eo": "Direktiĝu al enveturejo ĉe dekstre al Way Name",
+        "es": "Toma la rampa en la derecha en Way Name",
+        "es-ES": "Coge la cuesta de la derecha por Way Name",
+        "fi": "Aja oikealla olevaa erkanemiskaistaa tielle Way Name",
+        "fr": "Prendre la sortie à droite sur Way Name",
+        "he": "צא ביציאה שמימינך על Way Name",
+        "hu": "Hajtson az átkötő útszakaszra jobbról a Way Name felé",
+        "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
+        "it": "Prendi la rampa a destra in Way Name",
+        "ja": "右方向、Way Name方面、入口です",
+        "ko": "오른쪽의 램프로 진입해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ညာဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
+        "nl": "Neem de oprit rechts naar Way Name",
+        "no": "Ta avkjørselen på høyre side inn på Way Name",
+        "pl": "Weź zjazd po prawej na Way Name",
+        "pt-BR": "Pegue a rampa à direita em Way Name",
+        "pt-PT": "Saia na saída à direita para Way Name",
+        "ro": "Urmați breteaua din dreapta pe Way Name",
+        "ru": "Сверните на правый въезд на Way Name",
+        "sl": "Zapeljite na izhod na desni na Way Name",
+        "sv": "Ta påfarten till höger in på Way Name",
+        "tr": "Way Name üzerindeki sağ bağlantı yoluna geç",
+        "uk": "Рухайтесь на вʼїзд праворуч на Way Name",
+        "vi": "Đi đường nhánh Way Name bên phải",
+        "yo": "Mu awọn rampu lori ọtun pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "上右侧匝道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/on_ramp/right_name.json
+++ b/test/fixtures/v5/on_ramp/right_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra jobbról a Way Name felé",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
         "it": "Prendi la rampa a destra in Way Name",
-        "ja": "右方向のランプに向かい、Way Nameを進む",
+        "ja": "右方向、Way Name方面、入口です",
         "ko": "오른쪽의 램프로 진입해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ညာဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit rechts naar Way Name",

--- a/test/fixtures/v5/on_ramp/sharp_left_default.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról",
         "id": "Ambil jalan yang melandai di sebelah kiri",
         "it": "Prendi la rampa a sinistra",
-        "ja": "左方向のランプへ向かう",
+        "ja": "左方向、入口です",
         "ko": "왼쪽의 램프로 진입해 주세요.",
         "my": "ဘယ်ဘက်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit links",

--- a/test/fixtures/v5/on_ramp/sharp_left_destination.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Destination 1 irányába",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",
-        "ja": "左方向のランプに向かい、その後Destination 1へ向かう",
+        "ja": "左方向、Destination 1方面、入口です",
         "ko": "왼쪽의 램프로 진입해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ဘယ်ဘက်ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit links richting Destination 1",

--- a/test/fixtures/v5/on_ramp/sharp_left_exit.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Way Name felé",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",
-        "ja": "左方向のランプに向かい、Way Nameを進む",
+        "ja": "左方向、Way Name方面、入口です",
         "ko": "왼쪽의 램프로 진입해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ဘယ်ဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit links naar Way Name",

--- a/test/fixtures/v5/on_ramp/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Destination 1 irányába",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",
-        "ja": "左方向のランプに向かい、その後Destination 1へ向かう",
+        "ja": "左方向、Destination 1方面、入口です",
         "ko": "왼쪽의 램프로 진입해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ဘယ်ဘက်ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit links richting Destination 1",

--- a/test/fixtures/v5/on_ramp/sharp_left_junction_name.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك المدخل يسارا حادا لتبقى على Way Name",
+        "da": "Tag afkørslen til venstre ad Way Name",
+        "de": "Auffahrt links nehmen auf Way Name",
+        "en": "Take the ramp on the left onto Way Name",
+        "eo": "Direktiĝu al enveturejo ĉe maldekstre al Way Name",
+        "es": "Toma la rampa en la izquierda en Way Name",
+        "es-ES": "Coge la cuesta de la izquierda por Way Name",
+        "fi": "Aja vasemmalla olevaa erkanemiskaistaa tielle Way Name",
+        "fr": "Prendre la sortie à gauche sur Way Name",
+        "he": "צא ביציאה שמשמאלך על Way Name",
+        "hu": "Hajtson az átkötő útszakaszra balról a Way Name felé",
+        "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
+        "it": "Prendi la rampa a sinistra in Way Name",
+        "ja": "左方向、Way Name方面、入口です",
+        "ko": "왼쪽의 램프로 진입해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ဘယ်ဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
+        "nl": "Neem de oprit links naar Way Name",
+        "no": "Ta avkjørselen på venstre side inn på Way Name",
+        "pl": "Weź zjazd po lewej na Way Name",
+        "pt-BR": "Pegue a rampa à esquerda em Way Name",
+        "pt-PT": "Saia na saída à esquerda para Way Name",
+        "ro": "Urmați breteaua din stânga pe Way Name",
+        "ru": "Поверните на левый въезд на Way Name",
+        "sl": "Zapeljite na izhod na levi na Way Name",
+        "sv": "Ta påfarten till vänster in på Way Name",
+        "tr": "Way Name üzerindeki sol bağlantı yoluna geç",
+        "uk": "Рухайтесь на вʼїзд ліворуч на Way Name",
+        "vi": "Đi đường nhánh Way Name bên trái",
+        "yo": "Gba awọn ibọn ni apa osi pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "急向左上匝道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/on_ramp/sharp_left_name.json
+++ b/test/fixtures/v5/on_ramp/sharp_left_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Way Name felé",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",
-        "ja": "左方向のランプに向かい、Way Nameを進む",
+        "ja": "左方向、Way Name方面、入口です",
         "ko": "왼쪽의 램프로 진입해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ဘယ်ဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit links naar Way Name",

--- a/test/fixtures/v5/on_ramp/sharp_right_default.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra jobbról",
         "id": "Ambil jalan melandai di sebelah kanan",
         "it": "Prendi la rampa a destra",
-        "ja": "右方向のランプへ向かう",
+        "ja": "右方向、入口です",
         "ko": "오른쪽의 램프로 진입해 주세요.",
         "my": "ညာဘက်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit rechts",

--- a/test/fixtures/v5/on_ramp/sharp_right_destination.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra jobbról a Destination 1 irányába",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
         "it": "Prendi la rampa a destra verso Destination 1",
-        "ja": "右方向のランプに向かい、その後Destination 1へ向かう",
+        "ja": "右方向、Destination 1方面、入口です",
         "ko": "오른쪽의 램프로 진입해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ညာဘက်ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit rechts richting Destination 1",

--- a/test/fixtures/v5/on_ramp/sharp_right_exit.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra jobbról a Way Name felé",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
         "it": "Prendi la rampa a destra in Way Name",
-        "ja": "右方向のランプに向かい、Way Nameを進む",
+        "ja": "右方向、Way Name方面、入口です",
         "ko": "오른쪽의 램프로 진입해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ညာဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit rechts naar Way Name",

--- a/test/fixtures/v5/on_ramp/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson az átkötő útszakaszra jobbról a Destination 1 irányába",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
         "it": "Prendi la rampa a destra verso Destination 1",
-        "ja": "右方向のランプに向かい、その後Destination 1へ向かう",
+        "ja": "右方向、Destination 1方面、入口です",
         "ko": "오른쪽의 램프로 진입해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ညာဘက်ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit rechts richting Destination 1",

--- a/test/fixtures/v5/on_ramp/sharp_right_junction_name.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك المدخل يمينا حادا لتبقى على Way Name",
+        "da": "Tag afkørslen til højre ad Way Name",
+        "de": "Auffahrt rechts nehmen auf Way Name",
+        "en": "Take the ramp on the right onto Way Name",
+        "eo": "Direktiĝu al enveturejo ĉe dekstre al Way Name",
+        "es": "Toma la rampa en la derecha en Way Name",
+        "es-ES": "Coge la cuesta de la derecha por Way Name",
+        "fi": "Aja oikealla olevaa erkanemiskaistaa tielle Way Name",
+        "fr": "Prendre la sortie à droite sur Way Name",
+        "he": "צא ביציאה שמימינך על Way Name",
+        "hu": "Hajtson az átkötő útszakaszra jobbról a Way Name felé",
+        "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
+        "it": "Prendi la rampa a destra in Way Name",
+        "ja": "右方向、Way Name方面、入口です",
+        "ko": "오른쪽의 램프로 진입해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ညာဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
+        "nl": "Neem de oprit rechts naar Way Name",
+        "no": "Ta avkjørselen på høyre side inn på Way Name",
+        "pl": "Weź zjazd po prawej na Way Name",
+        "pt-BR": "Pegue a rampa à direita em Way Name",
+        "pt-PT": "Saia na saída à direita para Way Name",
+        "ro": "Urmați breteaua din dreapta pe Way Name",
+        "ru": "Поверните на правый въезд на Way Name",
+        "sl": "Zapeljite na izhod na desni na Way Name",
+        "sv": "Ta påfarten till höger in på Way Name",
+        "tr": "Way Name üzerindeki sağ bağlantı yoluna geç",
+        "uk": "Рухайтесь на вʼїзд праворуч на Way Name",
+        "vi": "Đi đường nhánh Way Name bên phải",
+        "yo": "Mu awọn rampu lori ọtun pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "急向右上匝道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/on_ramp/sharp_right_name.json
+++ b/test/fixtures/v5/on_ramp/sharp_right_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra jobbról a Way Name felé",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
         "it": "Prendi la rampa a destra in Way Name",
-        "ja": "右方向のランプに向かい、Way Nameを進む",
+        "ja": "右方向、Way Name方面、入口です",
         "ko": "오른쪽의 램프로 진입해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ညာဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit rechts naar Way Name",

--- a/test/fixtures/v5/on_ramp/slight_left_default.json
+++ b/test/fixtures/v5/on_ramp/slight_left_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról",
         "id": "Ambil jalan yang melandai di sebelah kiri",
         "it": "Prendi la rampa a sinistra",
-        "ja": "左方向のランプへ向かう",
+        "ja": "左方向、入口です",
         "ko": "왼쪽의 램프로 진입해 주세요.",
         "my": "ဘယ်ဘက်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit links",

--- a/test/fixtures/v5/on_ramp/slight_left_destination.json
+++ b/test/fixtures/v5/on_ramp/slight_left_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Destination 1 irányába",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",
-        "ja": "左方向のランプに向かい、その後Destination 1へ向かう",
+        "ja": "左方向、Destination 1方面、入口です",
         "ko": "왼쪽의 램프로 진입해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ဘယ်ဘက်ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit links richting Destination 1",

--- a/test/fixtures/v5/on_ramp/slight_left_exit.json
+++ b/test/fixtures/v5/on_ramp/slight_left_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Way Name felé",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",
-        "ja": "左方向のランプに向かい、Way Nameを進む",
+        "ja": "左方向、Way Name方面、入口です",
         "ko": "왼쪽의 램프로 진입해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ဘယ်ဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit links naar Way Name",

--- a/test/fixtures/v5/on_ramp/slight_left_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/slight_left_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Destination 1 irányába",
         "id": "Ambil jalan melandai di sebelah kiri menuju Destination 1",
         "it": "Prendi la rampa a sinistra verso Destination 1",
-        "ja": "左方向のランプに向かい、その後Destination 1へ向かう",
+        "ja": "左方向、Destination 1方面、入口です",
         "ko": "왼쪽의 램프로 진입해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ဘယ်ဘက်ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit links richting Destination 1",

--- a/test/fixtures/v5/on_ramp/slight_left_junction_name.json
+++ b/test/fixtures/v5/on_ramp/slight_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك المدخل يسارا قليلا لتبقى على Way Name",
+        "da": "Tag afkørslen til venstre ad Way Name",
+        "de": "Auffahrt links nehmen auf Way Name",
+        "en": "Take the ramp on the left onto Way Name",
+        "eo": "Direktiĝu al enveturejo ĉe maldekstre al Way Name",
+        "es": "Toma la rampa en la izquierda en Way Name",
+        "es-ES": "Coge la cuesta de la izquierda por Way Name",
+        "fi": "Aja vasemmalla olevaa erkanemiskaistaa tielle Way Name",
+        "fr": "Prendre la sortie à gauche sur Way Name",
+        "he": "צא ביציאה שמשמאלך על Way Name",
+        "hu": "Hajtson az átkötő útszakaszra balról a Way Name felé",
+        "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
+        "it": "Prendi la rampa a sinistra in Way Name",
+        "ja": "左方向、Way Name方面、入口です",
+        "ko": "왼쪽의 램프로 진입해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ဘယ်ဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
+        "nl": "Neem de oprit links naar Way Name",
+        "no": "Ta avkjørselen på venstre side inn på Way Name",
+        "pl": "Weź zjazd po lewej na Way Name",
+        "pt-BR": "Pegue a rampa à esquerda em Way Name",
+        "pt-PT": "Saia na saída à esquerda para Way Name",
+        "ro": "Urmați breteaua din stânga pe Way Name",
+        "ru": "Перестройтесь левее на Way Name",
+        "sl": "Zapeljite na izhod na levi na Way Name",
+        "sv": "Ta påfarten till vänster in på Way Name",
+        "tr": "Way Name üzerindeki sol bağlantı yoluna geç",
+        "uk": "Рухайтесь на вʼїзд ліворуч на Way Name",
+        "vi": "Đi đường nhánh Way Name bên trái",
+        "yo": "Gba awọn ibọn ni apa osi pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "稍向左上匝道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/on_ramp/slight_left_name.json
+++ b/test/fixtures/v5/on_ramp/slight_left_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra balról a Way Name felé",
         "id": "Ambil jalan melandai di sebelah kiri ke arah Way Name",
         "it": "Prendi la rampa a sinistra in Way Name",
-        "ja": "左方向のランプに向かい、Way Nameを進む",
+        "ja": "左方向、Way Name方面、入口です",
         "ko": "왼쪽의 램프로 진입해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ဘယ်ဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit links naar Way Name",

--- a/test/fixtures/v5/on_ramp/slight_right_default.json
+++ b/test/fixtures/v5/on_ramp/slight_right_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra jobbról",
         "id": "Ambil jalan melandai di sebelah kanan",
         "it": "Prendi la rampa a destra",
-        "ja": "右方向のランプへ向かう",
+        "ja": "右方向、入口です",
         "ko": "오른쪽의 램프로 진입해 주세요.",
         "my": "ညာဘက်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit rechts",

--- a/test/fixtures/v5/on_ramp/slight_right_destination.json
+++ b/test/fixtures/v5/on_ramp/slight_right_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra jobbról a Destination 1 irányába",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
         "it": "Prendi la rampa a destra verso Destination 1",
-        "ja": "右方向のランプに向かい、その後Destination 1へ向かう",
+        "ja": "右方向、Destination 1方面、入口です",
         "ko": "오른쪽의 램프로 진입해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ညာဘက်ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit rechts richting Destination 1",

--- a/test/fixtures/v5/on_ramp/slight_right_exit.json
+++ b/test/fixtures/v5/on_ramp/slight_right_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra jobbról a Way Name felé",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
         "it": "Prendi la rampa a destra in Way Name",
-        "ja": "右方向のランプに向かい、Way Nameを進む",
+        "ja": "右方向、Way Name方面、入口です",
         "ko": "오른쪽의 램프로 진입해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ညာဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit rechts naar Way Name",

--- a/test/fixtures/v5/on_ramp/slight_right_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/slight_right_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson az átkötő útszakaszra jobbról a Destination 1 irányába",
         "id": "Ambil jalan melandai di sebelah kanan menuju Destination 1",
         "it": "Prendi la rampa a destra verso Destination 1",
-        "ja": "右方向のランプに向かい、その後Destination 1へ向かう",
+        "ja": "右方向、Destination 1方面、入口です",
         "ko": "오른쪽의 램프로 진입해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ညာဘက်ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit rechts richting Destination 1",

--- a/test/fixtures/v5/on_ramp/slight_right_junction_name.json
+++ b/test/fixtures/v5/on_ramp/slight_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك المدخل يمينا قليلا لتبقى على Way Name",
+        "da": "Tag afkørslen til højre ad Way Name",
+        "de": "Auffahrt rechts nehmen auf Way Name",
+        "en": "Take the ramp on the right onto Way Name",
+        "eo": "Direktiĝu al enveturejo ĉe dekstre al Way Name",
+        "es": "Toma la rampa en la derecha en Way Name",
+        "es-ES": "Coge la cuesta de la derecha por Way Name",
+        "fi": "Aja oikealla olevaa erkanemiskaistaa tielle Way Name",
+        "fr": "Prendre la sortie à droite sur Way Name",
+        "he": "צא ביציאה שמימינך על Way Name",
+        "hu": "Hajtson az átkötő útszakaszra jobbról a Way Name felé",
+        "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
+        "it": "Prendi la rampa a destra in Way Name",
+        "ja": "右方向、Way Name方面、入口です",
+        "ko": "오른쪽의 램프로 진입해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ညာဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
+        "nl": "Neem de oprit rechts naar Way Name",
+        "no": "Ta avkjørselen på høyre side inn på Way Name",
+        "pl": "Weź zjazd po prawej na Way Name",
+        "pt-BR": "Pegue a rampa à direita em Way Name",
+        "pt-PT": "Saia na saída à direita para Way Name",
+        "ro": "Urmați breteaua din dreapta pe Way Name",
+        "ru": "Перестройтесь правее на Way Name",
+        "sl": "Zapeljite na izhod na desni na Way Name",
+        "sv": "Ta påfarten till höger in på Way Name",
+        "tr": "Way Name üzerindeki sağ bağlantı yoluna geç",
+        "uk": "Рухайтесь на вʼїзд праворуч на Way Name",
+        "vi": "Đi đường nhánh Way Name bên phải",
+        "yo": "Mu awọn rampu lori ọtun pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "稍向右上匝道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/on_ramp/slight_right_name.json
+++ b/test/fixtures/v5/on_ramp/slight_right_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra jobbról a Way Name felé",
         "id": "Ambil jalan melandai di sebelah kanan ke Way Name",
         "it": "Prendi la rampa a destra in Way Name",
-        "ja": "右方向のランプに向かい、Way Nameを進む",
+        "ja": "右方向、Way Name方面、入口です",
         "ko": "오른쪽의 램프로 진입해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ညာဘက် ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit rechts naar Way Name",

--- a/test/fixtures/v5/on_ramp/straight_default.json
+++ b/test/fixtures/v5/on_ramp/straight_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra",
         "id": "Ambil jalan melandai",
         "it": "Prendi la rampa",
-        "ja": "ランプへ向かう",
+        "ja": "入口です",
         "ko": "램프로 진입해 주세요..",
         "my": "ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit",

--- a/test/fixtures/v5/on_ramp/straight_destination.json
+++ b/test/fixtures/v5/on_ramp/straight_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Destination 1 irányába",
         "id": "Ambil jalan melandai menuju Destination 1",
         "it": "Prendi la rampa verso Destination 1",
-        "ja": "ランプに向かい、その後Destination 1へ向かう",
+        "ja": "Destination 1方面、入口です",
         "ko": "램프로 진입해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit richting Destination 1",

--- a/test/fixtures/v5/on_ramp/straight_exit.json
+++ b/test/fixtures/v5/on_ramp/straight_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Way Name felé",
         "id": "Ambil jalan melandai ke Way Name",
         "it": "Prendi la rampa in Way Name",
-        "ja": "ランプへ向かい、Way Nameを進む",
+        "ja": "Way Name方面、入口です",
         "ko": "램프로 진입해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit naar Way Name",

--- a/test/fixtures/v5/on_ramp/straight_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/straight_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Destination 1 irányába",
         "id": "Ambil jalan melandai menuju Destination 1",
         "it": "Prendi la rampa verso Destination 1",
-        "ja": "ランプに向かい、その後Destination 1へ向かう",
+        "ja": "Destination 1方面、入口です",
         "ko": "램프로 진입해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit richting Destination 1",

--- a/test/fixtures/v5/on_ramp/straight_junction_name.json
+++ b/test/fixtures/v5/on_ramp/straight_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اتبع المنحدر على Way Name",
+        "da": "Tag afkørslen ad Way Name",
+        "de": "Auffahrt nehmen auf Way Name",
+        "en": "Take the ramp onto Way Name",
+        "eo": "Direktiĝu al enveturejo al Way Name",
+        "es": "Toma la rampa en Way Name",
+        "es-ES": "Coge la cuesta por Way Name",
+        "fi": "Aja erkanemiskaistaa tielle Way Name",
+        "fr": "Prendre la sortie sur Way Name",
+        "he": "צא ביציאה על Way Name",
+        "hu": "Hajtson az átkötő útszakaszra a Way Name felé",
+        "id": "Ambil jalan melandai ke Way Name",
+        "it": "Prendi la rampa in Way Name",
+        "ja": "Way Name方面、入口です",
+        "ko": "램프로 진입해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
+        "nl": "Neem de oprit naar Way Name",
+        "no": "Ta avkjørselen inn på Way Name",
+        "pl": "Weź zjazd na Way Name",
+        "pt-BR": "Pegue a rampa em Way Name",
+        "pt-PT": "Saia na saída para Way Name",
+        "ro": "Urmați breteaua pe Way Name",
+        "ru": "Сверните на въезд на Way Name",
+        "sl": "Zapeljite na izhod na Way Name",
+        "sv": "Ta påfarten in på Way Name",
+        "tr": "Way Name üzerindeki bağlantı yoluna geç",
+        "uk": "Рухайтесь на вʼїзд на Way Name",
+        "vi": "Đi đường nhánh Way Name",
+        "yo": "Mu awọn rampan si pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "上匝道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/on_ramp/straight_name.json
+++ b/test/fixtures/v5/on_ramp/straight_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Way Name felé",
         "id": "Ambil jalan melandai ke Way Name",
         "it": "Prendi la rampa in Way Name",
-        "ja": "ランプへ向かい、Way Nameを進む",
+        "ja": "Way Name方面、入口です",
         "ko": "램프로 진입해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit naar Way Name",

--- a/test/fixtures/v5/on_ramp/uturn_default.json
+++ b/test/fixtures/v5/on_ramp/uturn_default.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra",
         "id": "Ambil jalan melandai",
         "it": "Prendi la rampa",
-        "ja": "ランプへ向かう",
+        "ja": "入口です",
         "ko": "램프로 진입해 주세요..",
         "my": "ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit",

--- a/test/fixtures/v5/on_ramp/uturn_destination.json
+++ b/test/fixtures/v5/on_ramp/uturn_destination.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Destination 1 irányába",
         "id": "Ambil jalan melandai menuju Destination 1",
         "it": "Prendi la rampa verso Destination 1",
-        "ja": "ランプに向かい、その後Destination 1へ向かう",
+        "ja": "Destination 1方面、入口です",
         "ko": "램프로 진입해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit richting Destination 1",

--- a/test/fixtures/v5/on_ramp/uturn_exit.json
+++ b/test/fixtures/v5/on_ramp/uturn_exit.json
@@ -22,7 +22,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Way Name felé",
         "id": "Ambil jalan melandai ke Way Name",
         "it": "Prendi la rampa in Way Name",
-        "ja": "ランプへ向かい、Way Nameを進む",
+        "ja": "Way Name方面、入口です",
         "ko": "램프로 진입해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit naar Way Name",

--- a/test/fixtures/v5/on_ramp/uturn_exit_destination.json
+++ b/test/fixtures/v5/on_ramp/uturn_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Destination 1 irányába",
         "id": "Ambil jalan melandai menuju Destination 1",
         "it": "Prendi la rampa verso Destination 1",
-        "ja": "ランプに向かい、その後Destination 1へ向かう",
+        "ja": "Destination 1方面、入口です",
         "ko": "램프로 진입해서 Destination 1까지 가세요.",
         "my": "Destination 1ဆီသို့ ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit richting Destination 1",

--- a/test/fixtures/v5/on_ramp/uturn_junction_name.json
+++ b/test/fixtures/v5/on_ramp/uturn_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "on ramp",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اتبع المنحدر على Way Name",
+        "da": "Tag afkørslen ad Way Name",
+        "de": "Auffahrt nehmen auf Way Name",
+        "en": "Take the ramp onto Way Name",
+        "eo": "Direktiĝu al enveturejo al Way Name",
+        "es": "Toma la rampa en Way Name",
+        "es-ES": "Coge la cuesta por Way Name",
+        "fi": "Aja erkanemiskaistaa tielle Way Name",
+        "fr": "Prendre la sortie sur Way Name",
+        "he": "צא ביציאה על Way Name",
+        "hu": "Hajtson az átkötő útszakaszra a Way Name felé",
+        "id": "Ambil jalan melandai ke Way Name",
+        "it": "Prendi la rampa in Way Name",
+        "ja": "Way Name方面、入口です",
+        "ko": "램프로 진입해서 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
+        "nl": "Neem de oprit naar Way Name",
+        "no": "Ta avkjørselen inn på Way Name",
+        "pl": "Weź zjazd na Way Name",
+        "pt-BR": "Pegue a rampa em Way Name",
+        "pt-PT": "Saia na saída para Way Name",
+        "ro": "Urmați breteaua pe Way Name",
+        "ru": "Сверните на въезд на Way Name",
+        "sl": "Zapeljite na izhod na Way Name",
+        "sv": "Ta påfarten in på Way Name",
+        "tr": "Way Name üzerindeki bağlantı yoluna geç",
+        "uk": "Рухайтесь на вʼїзд на Way Name",
+        "vi": "Đi đường nhánh Way Name",
+        "yo": "Mu awọn rampan si pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "上匝道，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/on_ramp/uturn_name.json
+++ b/test/fixtures/v5/on_ramp/uturn_name.json
@@ -21,7 +21,7 @@
         "hu": "Hajtson az átkötő útszakaszra a Way Name felé",
         "id": "Ambil jalan melandai ke Way Name",
         "it": "Prendi la rampa in Way Name",
-        "ja": "ランプへ向かい、Way Nameを進む",
+        "ja": "Way Name方面、入口です",
         "ko": "램프로 진입해서 Way Name로 가세요.",
         "my": "Way Nameပေါ်သို့ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de oprit naar Way Name",

--- a/test/fixtures/v5/other/invalid_type.json
+++ b/test/fixtures/v5/other/invalid_type.json
@@ -22,7 +22,7 @@
         "it": "Svolta a sinistra in Way Name",
         "ja": "左折してWay Nameを進む",
         "ko": "좌회전 하시고 Way Name로 가세요.",
-        "my": "Way Nameပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ ",
+        "my": "Way Nameပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ",
         "nl": "Ga linksaf naar Way Name",
         "no": "Sving til venstre inn på Way Name",
         "pl": "Skręć w lewo na Way Name",

--- a/test/fixtures/v5/other/motorway_ref_has_no_number_slight left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_no_number_slight left.json
@@ -8,7 +8,7 @@
         "ref": "Ref no number"
     },
     "instructions": {
-        "ar": " انعطف يساراً قليلاً لتبقى على Cool highway ",
+        "ar": "انعطف يساراً قليلاً لتبقى على Cool highway",
         "da": "Drej let til venstre videre ad Cool highway",
         "de": "Leicht links weiter auf Cool highway",
         "en": "Make a slight left to stay on Cool highway",

--- a/test/fixtures/v5/other/motorway_ref_has_number_slight left.json
+++ b/test/fixtures/v5/other/motorway_ref_has_number_slight left.json
@@ -8,7 +8,7 @@
         "ref": "Ref1;Ref2"
     },
     "instructions": {
-        "ar": " انعطف يساراً قليلاً لتبقى على Ref1 ",
+        "ar": "انعطف يساراً قليلاً لتبقى على Ref1",
         "da": "Drej let til venstre videre ad Ref1",
         "de": "Leicht links weiter auf Ref1",
         "en": "Make a slight left to stay on Ref1",

--- a/test/fixtures/v5/other/way_name_class_ferry_slight left.json
+++ b/test/fixtures/v5/other/way_name_class_ferry_slight left.json
@@ -8,7 +8,7 @@
         "ref": "Ref1;Ref2"
     },
     "instructions": {
-        "ar": " انعطف يساراً قليلاً لتبقى على Cool highway (Ref1) ",
+        "ar": "انعطف يساراً قليلاً لتبقى على Cool highway (Ref1)",
         "da": "Drej let til venstre videre ad Cool highway (Ref1)",
         "de": "Leicht links weiter auf Cool highway (Ref1)",
         "en": "Make a slight left to stay on Cool highway (Ref1)",

--- a/test/fixtures/v5/other/way_name_destination_refs.json
+++ b/test/fixtures/v5/other/way_name_destination_refs.json
@@ -20,7 +20,7 @@
         "hu": "Hajtson az átkötő útszakaszra jobbról a Ref1: Destination 1 irányába",
         "id": "Ambil jalan melandai di sebelah kanan menuju Ref1: Destination 1",
         "it": "Prendi la rampa a destra verso Ref1: Destination 1",
-        "ja": "右方向のランプに向かい、その後Ref1: Destination 1へ向かう",
+        "ja": "右方向、Ref1: Destination 1方面、出口です",
         "ko": "오른쪽의 램프로 진출해서 Ref1: Destination 1까지 가세요.",
         "my": "Ref1: Destination 1ဆီသို့ ညာဘက်ပေါ်တွင်ချဉ်းကပ်လမ်းကိုယူပါ",
         "nl": "Neem de afrit rechts richting Ref1: Destination 1",

--- a/test/fixtures/v5/other/way_name_ref.json
+++ b/test/fixtures/v5/other/way_name_ref.json
@@ -23,7 +23,7 @@
         "it": "Svolta a sinistra in Ref1",
         "ja": "左折してRef1を進む",
         "ko": "좌회전 하시고 Ref1로 가세요.",
-        "my": "Ref1ပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ ",
+        "my": "Ref1ပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ",
         "nl": "Ga linksaf naar Ref1",
         "no": "Sving til venstre inn på Ref1",
         "pl": "Skręć w lewo na Ref1",

--- a/test/fixtures/v5/other/way_name_ref_mapbox_hack_1.json
+++ b/test/fixtures/v5/other/way_name_ref_mapbox_hack_1.json
@@ -23,7 +23,7 @@
         "it": "Svolta a sinistra in Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
         "ja": "左折してWay Name(Ref1 (Another+Way \\ (Ref1.1)))を進む",
         "ko": "좌회전 하시고 Way Name (Ref1 (Another+Way \\ (Ref1.1)))로 가세요.",
-        "my": "Way Name( Ref1 (Another+Way \\ (Ref1.1)))ပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ ",
+        "my": "Way Name( Ref1 (Another+Way \\ (Ref1.1)))ပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ",
         "nl": "Ga linksaf naar Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
         "no": "Sving til venstre inn på Way Name (Ref1 (Another+Way \\ (Ref1.1)))",
         "pl": "Skręć w lewo na Way Name (Ref1 (Another+Way \\ (Ref1.1)))",

--- a/test/fixtures/v5/other/way_name_ref_mapbox_hack_2.json
+++ b/test/fixtures/v5/other/way_name_ref_mapbox_hack_2.json
@@ -23,7 +23,7 @@
         "it": "Svolta a sinistra in Way Name (Ref0)",
         "ja": "左折してWay Name(Ref0)を進む",
         "ko": "좌회전 하시고 Way Name (Ref0)로 가세요.",
-        "my": "Way Name( Ref0)ပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ ",
+        "my": "Way Name( Ref0)ပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ",
         "nl": "Ga linksaf naar Way Name (Ref0)",
         "no": "Sving til venstre inn på Way Name (Ref0)",
         "pl": "Skręć w lewo na Way Name (Ref0)",

--- a/test/fixtures/v5/other/way_name_ref_mapbox_hack_3.json
+++ b/test/fixtures/v5/other/way_name_ref_mapbox_hack_3.json
@@ -23,7 +23,7 @@
         "it": "Svolta a sinistra in Ref0",
         "ja": "左折してRef0を進む",
         "ko": "좌회전 하시고 Ref0로 가세요.",
-        "my": "Ref0ပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ ",
+        "my": "Ref0ပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ",
         "nl": "Ga linksaf naar Ref0",
         "no": "Sving til venstre inn på Ref0",
         "pl": "Skręć w lewo na Ref0",

--- a/test/fixtures/v5/other/way_name_ref_name.json
+++ b/test/fixtures/v5/other/way_name_ref_name.json
@@ -23,7 +23,7 @@
         "it": "Svolta a sinistra in Way Name (Ref1)",
         "ja": "左折してWay Name(Ref1)を進む",
         "ko": "좌회전 하시고 Way Name (Ref1)로 가세요.",
-        "my": "Way Name( Ref1)ပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ ",
+        "my": "Way Name( Ref1)ပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ",
         "nl": "Ga linksaf naar Way Name (Ref1)",
         "no": "Sving til venstre inn på Way Name (Ref1)",
         "pl": "Skręć w lewo na Way Name (Ref1)",

--- a/test/fixtures/v5/rotary/default_junction_name.json
+++ b/test/fixtures/v5/rotary/default_junction_name.json
@@ -1,0 +1,42 @@
+{
+    "step": {
+        "maneuver": {
+            "modifier": "left",
+            "type": "rotary"
+        },
+        "name": "Way Name",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك مسار الدوران واخرج على Way Name",
+        "da": "I rundkørslen, kør fra ad Way Name",
+        "de": "Im Kreisverkehr die Ausfahrt auf Way Name nehmen",
+        "en": "Enter the roundabout and exit onto Way Name",
+        "eo": "Enveturu trafikcirklegon kaj elveturu al Way Name",
+        "es": "Entra en la rotonda y sal en Way Name",
+        "es-ES": "En la rotonda sal por Way Name",
+        "fi": "Aja liikenneympyrään ja valitse erkanemiskaista tielle Way Name",
+        "fr": "Prendre le rond-point, puis sortir sur Way Name",
+        "he": "השתלב במעגל התנועה וצא על Way Name",
+        "hu": "Hajtson be a körforgalomba, majd hajtson ki a Way Name felé",
+        "id": "Masuk bundaran dan keluar arah Way Name",
+        "it": "Immettiti nella ritonda ed esci in Way Name",
+        "ja": "ランアバウトからWay Nameへ進む",
+        "ko": "로터리로 진입해서 Way Name 나가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Betreedt rotonde en sla af op Way Name",
+        "no": "Kjør inn i rundkjøringen og deretter ut på Way Name",
+        "pl": "Wjedź na rondo i skręć na Way Name",
+        "pt-BR": "Entre na rotatória e saia na Way Name",
+        "pt-PT": "Entre na rotunda e saia para Way Name",
+        "ro": "Intrați în sensul giratoriu și ieșiți pe Way Name",
+        "ru": "На круговой развязке сверните на Way Name",
+        "sl": "Zapeljite v krožišče in izberite izvoz za Way Name",
+        "sv": "I rondellen, ta avfarten in på Way Name",
+        "tr": "Dönel kavşağa gir ve Way Name üzerinde çık",
+        "uk": "Рухайтесь по колу до Way Name",
+        "vi": "Đi vào bùng binh và ra tại Way Name",
+        "yo": "Tẹ atẹgun iṣowo ati jade ni pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "通过环岛后驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/rotary/exit_1_junction_name.json
+++ b/test/fixtures/v5/rotary/exit_1_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "modifier": "left",
+            "type": "rotary",
+            "exit": 1
+        },
+        "name": "Way Name",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك مسار الدوران واتبع المخرج الأولى على Way Name",
+        "da": "I rundkørslen, tag første afkørsel ad Way Name",
+        "de": "Im Kreisverkehr die erste Ausfahrt nehmen auf Way Name",
+        "en": "Enter the roundabout and take the 1st exit onto Way Name",
+        "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo al Way Name",
+        "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
+        "es-ES": "En la rotonda toma la 1ª salida por Way Name",
+        "fi": "Aja liikenneympyrään ja valitse 1. erkanemiskaista tielle Way Name",
+        "fr": "Prendre le rond-point, puis la première sortie sur Way Name",
+        "he": "השתלב במעגל התנועה וצא ביציאה ראשונה לWay Name",
+        "hu": "Hajtson be a körforgalomba, majd hajtson ki az 1. kijáraton a Way Name felé",
+        "id": "Masuk bundaran dan ambil jalan keluar 1 arah Way Name",
+        "it": "Immettiti nella rotonda e prendi la 1ª uscita in Way Name",
+        "ja": "ランアバウト1 つ目の番出口を出てWay Nameを進む",
+        "ko": "로터리로 진입해서 첫번쩨 출구로 나가 Way Name로 가세요.",
+        "my": "အဝိုင်းပတ်သို့ဝင်ပြီးပထမကိုယူကာWay Nameပေါ်သို့ထွက်ပါ",
+        "nl": "Betreedt rotonde en neem afslag 1e naar Way Name",
+        "no": "Kjør inn i rundkjøringen og ta 1. avkjørsel ut på Way Name",
+        "pl": "Wjedź na rondo i wyjedź 1. zjazdem na Way Name",
+        "pt-BR": "Entre na rotatória e pegue a 1º saída na Way Name",
+        "pt-PT": "Entre na rotunda e saia na saída 1º para Way Name",
+        "ro": "Intrați în sensul giratoriu și urmați prima ieșire pe Way Name",
+        "ru": "На круговой развязке сверните на первый съезд на Way Name",
+        "sl": "Zapeljite v krožišče in izberite 1.. izvoz za Way Name",
+        "sv": "I rondellen, ta 1:a avfarten in på Way Name",
+        "tr": "Dönel kavşağa gir ve Way Name üzerindeki birinci numaralı çıkışa gir",
+        "uk": "Рухайтесь по колу та поверніть у 1й з'їзд на Way Name",
+        "vi": "Đi vào bùng binh và ra tại đường đầu tiên tức Way Name",
+        "yo": "Tẹ ẹkun ijabọ ati ki o ya 1st jade pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "进入环岛后从第一出口驶出，上Way Name"
+    }
+}

--- a/test/fixtures/v5/rotary/name_exit_junction_name.json
+++ b/test/fixtures/v5/rotary/name_exit_junction_name.json
@@ -1,0 +1,44 @@
+{
+    "step": {
+        "maneuver": {
+            "modifier": "left",
+            "type": "rotary",
+            "exit": 2
+        },
+        "name": "Way Name",
+        "rotary_name": "Rotary Name",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "ادخل Rotary Name واسلك المخرج الثانية على Way Name",
+        "da": "Kør ind i Rotary Name og tag anden afkørsel ad Way Name",
+        "de": "In den Kreisverkehr fahren und zweite Ausfahrt nehmen auf Way Name",
+        "en": "Enter Rotary Name and take the 2nd exit onto Way Name",
+        "eo": "Enveturu Rotary Name kaj sekve al 2. elveturejo al Way Name",
+        "es": "Entra en Rotary Name y coge la 2ª salida en Way Name",
+        "es-ES": "En Rotary Name toma la 2ª salida por Way Name",
+        "fi": "Aja liikenneympyrään Rotary Name ja valitse 2. erkanemiskaista tielle Way Name",
+        "fr": "Prendre le rond-point de Rotary Name, puis la seconde sortie sur Way Name",
+        "he": "היכנס לRotary Name וצא ביציאה השניה לWay Name",
+        "hu": "Hajtson be a Rotary Name körforgalomba, majd hajtson ki a 2. kijáraton a Way Name felé",
+        "id": "Masuk Rotary Name dan ambil jalan keluar 2 arah Way Name",
+        "it": "Immèttitì in Rotary Name e prendi la 2ª uscita in Way Name",
+        "ja": "Rotary Nameの2 つ目の番出口からWay Nameを進む",
+        "ko": "Rotary Name로 진입해서 두번째번 출구로 나가 Way Name로 가세요.",
+        "my": "Rotary Nameကိုဝင်ပြီးဒုတိယကိုယူကာWay Nameပေါ်သို့ထွက်ပါ",
+        "nl": "Ga het knooppunt Rotary Name op en neem afslag 2e naar Way Name",
+        "no": "Kjør inn i Rotary Name og ta 2. avkjørsel inn på Way Name",
+        "pl": "Wjedź na Rotary Name i wyjedź 2. zjazdem na Way Name",
+        "pt-BR": "Entre em Rotary Name e saia na 2º saída em Way Name",
+        "pt-PT": "Entre em Rotary Name e saia na saída 2º para Way Name",
+        "ro": "Intrați în Rotary Name și urmați a doua ieșire pe Way Name",
+        "ru": "На Rotary Name сверните на второй съезд на Way Name",
+        "sl": "Zapeljite v Rotary Name in izberite 2.. izvoz za Way Name",
+        "sv": "I Rotary Name, ta 2:a avfarten in på Way Name",
+        "tr": "Rotary Name dönel kavşağa gir ve Way Name üzerindeki ikinci numaralı çıkışa gir",
+        "uk": "Рухайтесь по Rotary Name та поверніть у 2й з'їзд на Way Name",
+        "vi": "Đi vào Rotary Name và ra tại đường thứ 2 tức Way Name",
+        "yo": "Tẹ Rotary Name ki o si ya 2nd jade pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "进入Rotary Name环岛后从第二出口驶出，上Way Name"
+    }
+}

--- a/test/fixtures/v5/rotary/name_junction_name.json
+++ b/test/fixtures/v5/rotary/name_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "modifier": "left",
+            "type": "rotary"
+        },
+        "name": "Way Name",
+        "rotary_name": "Rotary Name",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك Rotary Name واخرج على Way Name",
+        "da": "Kør ind i Rotary Name og kør fra ad Way Name",
+        "de": "In Rotary Name die Ausfahrt auf Way Name nehmen",
+        "en": "Enter Rotary Name and exit onto Way Name",
+        "eo": "Enveturu Rotary Name kaj elveturu al Way Name",
+        "es": "Entra en Rotary Name y sal en Way Name",
+        "es-ES": "En Rotary Name sal por Way Name",
+        "fi": "Aja liikenneympyrään Rotary Name ja valitse erkanemiskaista tielle Way Name",
+        "fr": "Prendre le rond-point de Rotary Name, puis sortir par Way Name",
+        "he": "היכנס לRotary Name וצא על Way Name",
+        "hu": "Hajtson be a Rotary Name körforgalomba, majd hajtson ki a Way Name felé",
+        "id": "Masuk Rotary Name dan keluar arah Way Name",
+        "it": "Immèttitì in Rotary Name ed esci su Way Name",
+        "ja": "Rotary NameからWay Nameを進む",
+        "ko": "Rotary Name로 진입해서 Way Name로 나가세요.",
+        "my": "Rotary Nameအဝိုင်းပတ်ဝင်ပြီးWay Nameပေါ်သို့ထွက်ပါ",
+        "nl": "Verlaat het knooppunt Rotary Name naar Way Name",
+        "no": "Kjør inn i Rotary Name og deretter ut på Way Name",
+        "pl": "Wjedź na Rotary Name i skręć na Way Name",
+        "pt-BR": "Entre em Rotary Name e saia em Way Name",
+        "pt-PT": "Entre em Rotary Name e saia para Way Name",
+        "ro": "Intrați în Rotary Name și ieșiți pe Way Name",
+        "ru": "На Rotary Name сверните на Way Name",
+        "sl": "Zapeljite v Rotary Name in izberite izvoz za Way Name",
+        "sv": "I Rotary Name, ta av in på Way Name",
+        "tr": "Rotary Name dönel kavşağa gir ve Way Name üzerinde çık",
+        "uk": "Рухайтесь по Rotary Name та поверніть на Way Name",
+        "vi": "Đi vào Rotary Name và ra tại Way Name",
+        "yo": "Tẹ Rotary Name ati jade ni pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "通过Rotary Name环岛后驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout/default_junction_name.json
+++ b/test/fixtures/v5/roundabout/default_junction_name.json
@@ -1,0 +1,42 @@
+{
+    "step": {
+        "maneuver": {
+            "modifier": "left",
+            "type": "roundabout"
+        },
+        "name": "Way Name",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك مسار الدوران واخرج على Way Name",
+        "da": "I rundkørslen, kør fra ad Way Name",
+        "de": "Im Kreisverkehr die Ausfahrt auf Way Name nehmen",
+        "en": "Enter the roundabout and exit onto Way Name",
+        "eo": "Enveturu trafikcirklegon kaj elveturu al Way Name",
+        "es": "Entra en la rotonda y sal en Way Name",
+        "es-ES": "Incorpórate en la rotonda y sal en Way Name",
+        "fi": "Aja liikenneympyrään ja valitse erkanemiskaista tielle Way Name",
+        "fr": "Prendre le rond-point, puis sortir sur Way Name",
+        "he": "השתלב במעגל התנועה וצא על Way Name",
+        "hu": "Hajtson a körforgalomba, majd hagyja el a körforgalmat a Way Name felé",
+        "id": "Masuk bundaran dan keluar arah Way Name",
+        "it": "Entra nella rotonda e prendi l’uscita in Way Name",
+        "ja": "ランアバウトを出てWay Nameを進む",
+        "ko": "로터리로 진입해서 Way Name 나가세요.",
+        "my": "Way Nameပေါ်သို့အဝိုင်းပတ်လမ်းမှထွက်ပါ",
+        "nl": "Betreedt rotonde en sla af op Way Name",
+        "no": "Kjør inn i rundkjøringen og deretter ut på Way Name",
+        "pl": "Wjedź na rondo i wyjedź na Way Name",
+        "pt-BR": "Entre na rotatória e saia na Way Name",
+        "pt-PT": "Entre na rotunda e saia para Way Name",
+        "ro": "Intrați în sensul giratoriu și ieșiți pe Way Name",
+        "ru": "На круговой развязке сверните на Way Name",
+        "sl": "Zapeljite v krožišče in izberite izvoz za Way Name",
+        "sv": "I rondellen, ta avfarten in på Way Name",
+        "tr": "Göbekli kavşağa gir ve Way Name üzerinde çık",
+        "uk": "Рухайтесь по колу до Way Name",
+        "vi": "Đi vào bùng binh và ra tại Way Name",
+        "yo": "Tẹ atẹgun iṣowo ati jade ni pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "通过环岛后驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout/exit_junction_name.json
+++ b/test/fixtures/v5/roundabout/exit_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "modifier": "left",
+            "type": "roundabout",
+            "exit": 1
+        },
+        "name": "Way Name",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك مسار الدوران واتبع المخرج الأولى على Way Name",
+        "da": "I rundkørslen, tag første afkørsel ad Way Name",
+        "de": "Im Kreisverkehr die erste Ausfahrt nehmen auf Way Name",
+        "en": "Enter the roundabout and take the 1st exit onto Way Name",
+        "eo": "Enveturu trafikcirklegon kaj sekve al 1. elveturejo al Way Name",
+        "es": "Entra en la rotonda y toma la 1ª salida a Way Name",
+        "es-ES": "En la rotonda toma la 1ª salida por Way Name",
+        "fi": "Aja liikenneympyrään ja valitse 1. erkanemiskaista tielle Way Name",
+        "fr": "Prendre le rond-point, puis la première sortie sur Way Name",
+        "he": "השתלב במעגל התנועה וצא ביציאה ראשונה לWay Name",
+        "hu": "Hajtson be a körforgalomba, majd hajtson ki az 1. kijáraton a Way Name felé",
+        "id": "Masuk bundaran dan ambil jalan keluar 1 arah Way Name",
+        "it": "Immettiti nella rotonda e prendi la 1ª uscita in Way Name",
+        "ja": "ランアバウト1 つ目の番出口を出てWay Nameを進む",
+        "ko": "로터리로 진입해서 첫번쩨로 나가서 Way Name로 가세요.",
+        "my": "အဝိုင်းပတ်ဝင်ပြီးပထမကိုယူကာWay Nameပေါ်သို့ထွက်ပါ",
+        "nl": "Betreedt rotonde en neem afslag 1e naar Way Name",
+        "no": "Kjør inn i rundkjøringen og ta 1. avkjørsel inn på Way Name",
+        "pl": "Wjedź na rondo i wyjedź 1. zjazdem na Way Name",
+        "pt-BR": "Entre na rotatória e pegue a 1º saída na Way Name",
+        "pt-PT": "Entre na rotunda e saia na saída 1º para Way Name",
+        "ro": "Intrați în sensul giratoriu și urmați prima ieșire pe Way Name",
+        "ru": "На круговой развязке сверните на первый съезд на Way Name",
+        "sl": "Zapeljite v krožišče in izberite 1.. izvoz za Way Name",
+        "sv": "I rondellen, ta 1:a avfarten in på Way Name",
+        "tr": "Göbekli kavşağa gir ve Way Name üzerindeki birinci numaralı çıkışa gir",
+        "uk": "Рухайтесь по колу та поверніть у 1й з'їзд на Way Name",
+        "vi": "Đi vào bùng binh và ra tại đường đầu tiên tức Way Name",
+        "yo": "Tẹ ẹkun ijabọ ati ki o ya 1st jade pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "进入环岛后从第一出口驶出，上Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/left_junction_name.json
+++ b/test/fixtures/v5/roundabout_turn/left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك مسار الدوران يسارا على Way Name",
+        "da": "Drej til venstre ad Way Name",
+        "de": "Links abbiegen auf Way Name",
+        "en": "Turn left onto Way Name",
+        "eo": "Turniĝu maldekstren al Way Name",
+        "es": "Gira a la izquierda en Way Name",
+        "es-ES": "Gire a la izquierda en Way Name",
+        "fi": "Käänny vasempaan tielle Way Name",
+        "fr": "Tourner à gauche sur Way Name",
+        "he": "פנה שמאלה לWay Name",
+        "hu": "Forduljon be balra a Way Name irányába",
+        "id": "Belok kiri ke Way Name",
+        "it": "Svolta a sinistra in Way Name",
+        "ja": "左折してWay Nameを進む",
+        "ko": "좌회전 하시고 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ",
+        "nl": "Ga linksaf naar Way Name",
+        "no": "Sving til venstre inn på Way Name",
+        "pl": "Skręć w lewo na Way Name",
+        "pt-BR": "Vire à esquerda em Way Name",
+        "pt-PT": "Vire à esquerda para Way Name",
+        "ro": "La sensul giratoriu virați la stânga pe Way Name",
+        "ru": "Сверните налево на Way Name",
+        "sl": "Zavijte levo na Way Name",
+        "sv": "Sväng vänster in på Way Name",
+        "tr": "Way Name üzerinde sola dön",
+        "uk": "Поверніть ліворуч на Way Name",
+        "vi": "Quẹo trái vào Way Name",
+        "yo": "Tan apa osi pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "左转，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/right_junction_name.json
+++ b/test/fixtures/v5/roundabout_turn/right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك مسار الدوران يمينا على Way Name",
+        "da": "Drej til højre ad Way Name",
+        "de": "Rechts abbiegen auf Way Name",
+        "en": "Turn right onto Way Name",
+        "eo": "Turniĝu dekstren al Way Name",
+        "es": "Gira a la derecha en Way Name",
+        "es-ES": "Gire a la derecha en Way Name",
+        "fi": "Käänny oikeaan tielle Way Name",
+        "fr": "Tourner à droite sur Way Name",
+        "he": "פנה ימינה לWay Name",
+        "hu": "Forduljon be jobbra a Way Name felé",
+        "id": "Belok kanan ke Way Name",
+        "it": "Svolta a destra in Way Name",
+        "ja": "右折してWay Nameを進む",
+        "ko": "우회전 하시고 Way Name로 가세요.",
+        "my": "Way Nameပေါ်သို့ညာဘက်ကိုလာရောက်ပေါင်းဆုံပါ",
+        "nl": "Ga rechtsaf naar Way Name",
+        "no": "Sving til høyre inn på Way Name",
+        "pl": "Skręć w prawo na Way Name",
+        "pt-BR": "Vire à direita em Way Name",
+        "pt-PT": "Vire à direita para Way Name",
+        "ro": "La sensul giratoriu virați la dreapta pe Way Name",
+        "ru": "Сверните направо на Way Name",
+        "sl": "Zavijte desno na Way Name",
+        "sv": "Sväng höger in på Way Name",
+        "tr": "Way Name üzerinde sağa dön",
+        "uk": "Поверніть праворуч на Way Name",
+        "vi": "Quẹo phải vào Way Name",
+        "yo": "Tan ọtun si Way Name",
+        "zh-Hans": "右转，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/sharp_left_default.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_default.json
@@ -21,7 +21,7 @@
         "hu": "Forduljon élesen balra",
         "id": "Lakukan tajam kiri",
         "it": "Gira a sinistra",
-        "ja": "大きく左に向かう",
+        "ja": "左戻るに向かう",
         "ko": "바로좌회전 하세요.",
         "my": "ဘယ်ဘက် ထောင့်ချိုးကိုလှည့်ပါ",
         "nl": "Ga scherpe bocht naar links",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_destination.json
@@ -22,7 +22,7 @@
         "hu": "Forduljon élesen balra a Destination 1 irányába",
         "id": "Lakukan tajam kiri menuju Destination 1",
         "it": "Gira a sinistra verso Destination 1",
-        "ja": "大きく左に向かい、その後Destination 1へ向かう",
+        "ja": "左戻るに向かい、その後Destination 1へ向かう",
         "ko": "바로좌회전 하시고 Destination 1까지 가세요.",
         "my": "ဘယ်ဘက် ထောင့်ချိုးဆီသို့Destination 1ကို ဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar links richting Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_exit.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_exit.json
@@ -22,7 +22,7 @@
         "hu": "Forduljon be élesen balra a Way Name felé",
         "id": "Lakukan tajam kiri ke arah Way Name",
         "it": "Gira a sinistra in Way Name",
-        "ja": "大きく左に向かい、Way Nameを進む",
+        "ja": "左戻るに向かい、Way Nameを進む",
         "ko": "바로좌회전 하시고 Way Name로 가세요.",
         "my": "ဘယ်ဘက် ထောင့်ချိုး​ပေါ်သို့Way Nameကိုဆက်သွားပါ ",
         "nl": "Ga scherpe bocht naar links naar Way Name",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Forduljon élesen balra a Destination 1 irányába",
         "id": "Lakukan tajam kiri menuju Destination 1",
         "it": "Gira a sinistra verso Destination 1",
-        "ja": "大きく左に向かい、その後Destination 1へ向かう",
+        "ja": "左戻るに向かい、その後Destination 1へ向かう",
         "ko": "바로좌회전 하시고 Destination 1까지 가세요.",
         "my": "ဘယ်ဘက် ထောင့်ချိုးဆီသို့Destination 1ကို ဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar links richting Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_left_junction_name.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يسار حاد على Way Name",
+        "da": "Drej skarpt til venstre ad Way Name",
+        "de": "Scharf links abbiegen auf Way Name",
+        "en": "Make a sharp left onto Way Name",
+        "eo": "Veturu maldekstregen al Way Name",
+        "es": "Sigue cerrada a la izquierda en Way Name",
+        "es-ES": "Siga cerrada a la izquierda en Way Name",
+        "fi": "Käänny jyrkästi vasempaan tielle Way Name",
+        "fr": "Tourner franchement à gauche sur Way Name",
+        "he": "פנה חדה שמאלה על Way Name",
+        "hu": "Forduljon be élesen balra a Way Name felé",
+        "id": "Lakukan tajam kiri ke arah Way Name",
+        "it": "Gira a sinistra in Way Name",
+        "ja": "左戻るに向かい、Way Nameを進む",
+        "ko": "바로좌회전 하시고 Way Name로 가세요.",
+        "my": "ဘယ်ဘက် ထောင့်ချိုး​ပေါ်သို့Way Nameကိုဆက်သွားပါ ",
+        "nl": "Ga scherpe bocht naar links naar Way Name",
+        "no": "Ta en skarp venstre inn på Way Name",
+        "pl": "Ostro w lewo na Way Name",
+        "pt-BR": "Siga fechada à esquerda em Way Name",
+        "pt-PT": "Siga acentuadamente à esquerda para Way Name",
+        "ro": "La sensul giratoriu virați puternic stânga pe Way Name",
+        "ru": "Двигайтесь налево на Way Name",
+        "sl": "Zavijte ostro levo na Way Name",
+        "sv": "Sväng vänster in på Way Name",
+        "tr": "Way Name üzerinde keskin sol yöne dön",
+        "uk": "Рухайтесь різко ліворуч на Way Name",
+        "vi": "Quẹo trái gắt vào Way Name",
+        "yo": "Ṣe a didasilẹ pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "急向左转弯，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/sharp_left_name.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_left_name.json
@@ -21,7 +21,7 @@
         "hu": "Forduljon be élesen balra a Way Name felé",
         "id": "Lakukan tajam kiri ke arah Way Name",
         "it": "Gira a sinistra in Way Name",
-        "ja": "大きく左に向かい、Way Nameを進む",
+        "ja": "左戻るに向かい、Way Nameを進む",
         "ko": "바로좌회전 하시고 Way Name로 가세요.",
         "my": "ဘယ်ဘက် ထောင့်ချိုး​ပေါ်သို့Way Nameကိုဆက်သွားပါ ",
         "nl": "Ga scherpe bocht naar links naar Way Name",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_default.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_default.json
@@ -21,7 +21,7 @@
         "hu": "Forduljon élesen jobbra",
         "id": "Lakukan tajam kanan",
         "it": "Gira a destra",
-        "ja": "大きく右に向かう",
+        "ja": "右戻るに向かう",
         "ko": "바로우회전 하세요.",
         "my": "ညာဘက် ထောင့်ချိုးကိုလှည့်ပါ",
         "nl": "Ga scherpe bocht naar rechts",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_destination.json
@@ -22,7 +22,7 @@
         "hu": "Forduljon élesen jobbra a Destination 1 irányába",
         "id": "Lakukan tajam kanan menuju Destination 1",
         "it": "Gira a destra verso Destination 1",
-        "ja": "大きく右に向かい、その後Destination 1へ向かう",
+        "ja": "右戻るに向かい、その後Destination 1へ向かう",
         "ko": "바로우회전 하시고 Destination 1까지 가세요.",
         "my": "ညာဘက် ထောင့်ချိုးဆီသို့Destination 1ကို ဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar rechts richting Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_exit.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_exit.json
@@ -22,7 +22,7 @@
         "hu": "Forduljon be élesen jobbra a Way Name felé",
         "id": "Lakukan tajam kanan ke arah Way Name",
         "it": "Gira a destra in Way Name",
-        "ja": "大きく右に向かい、Way Nameを進む",
+        "ja": "右戻るに向かい、Way Nameを進む",
         "ko": "바로우회전 하시고 Way Name로 가세요.",
         "my": "ညာဘက် ထောင့်ချိုး​ပေါ်သို့Way Nameကိုဆက်သွားပါ ",
         "nl": "Ga scherpe bocht naar rechts naar Way Name",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Forduljon élesen jobbra a Destination 1 irányába",
         "id": "Lakukan tajam kanan menuju Destination 1",
         "it": "Gira a destra verso Destination 1",
-        "ja": "大きく右に向かい、その後Destination 1へ向かう",
+        "ja": "右戻るに向かい、その後Destination 1へ向かう",
         "ko": "바로우회전 하시고 Destination 1까지 가세요.",
         "my": "ညာဘက် ထောင့်ချိုးဆီသို့Destination 1ကို ဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar rechts richting Destination 1",

--- a/test/fixtures/v5/roundabout_turn/sharp_right_junction_name.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يمين حاد على Way Name",
+        "da": "Drej skarpt til højre ad Way Name",
+        "de": "Scharf rechts abbiegen auf Way Name",
+        "en": "Make a sharp right onto Way Name",
+        "eo": "Veturu dekstregen al Way Name",
+        "es": "Sigue cerrada a la derecha en Way Name",
+        "es-ES": "Siga cerrada a la derecha en Way Name",
+        "fi": "Käänny jyrkästi oikeaan tielle Way Name",
+        "fr": "Tourner franchement à droite sur Way Name",
+        "he": "פנה חדה ימינה על Way Name",
+        "hu": "Forduljon be élesen jobbra a Way Name felé",
+        "id": "Lakukan tajam kanan ke arah Way Name",
+        "it": "Gira a destra in Way Name",
+        "ja": "右戻るに向かい、Way Nameを進む",
+        "ko": "바로우회전 하시고 Way Name로 가세요.",
+        "my": "ညာဘက် ထောင့်ချိုး​ပေါ်သို့Way Nameကိုဆက်သွားပါ ",
+        "nl": "Ga scherpe bocht naar rechts naar Way Name",
+        "no": "Ta en skarp høyre inn på Way Name",
+        "pl": "Ostro w prawo na Way Name",
+        "pt-BR": "Siga fechada à direita em Way Name",
+        "pt-PT": "Siga acentuadamente à direita para Way Name",
+        "ro": "La sensul giratoriu virați puternic dreapta pe Way Name",
+        "ru": "Двигайтесь направо на Way Name",
+        "sl": "Zavijte ostro desno na Way Name",
+        "sv": "Sväng höger in på Way Name",
+        "tr": "Way Name üzerinde keskin sağ yöne dön",
+        "uk": "Рухайтесь різко праворуч на Way Name",
+        "vi": "Quẹo phải gắt vào Way Name",
+        "yo": "Ṣe a didasilẹ ọtun pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "急向右转弯，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/sharp_right_name.json
+++ b/test/fixtures/v5/roundabout_turn/sharp_right_name.json
@@ -21,7 +21,7 @@
         "hu": "Forduljon be élesen jobbra a Way Name felé",
         "id": "Lakukan tajam kanan ke arah Way Name",
         "it": "Gira a destra in Way Name",
-        "ja": "大きく右に向かい、Way Nameを進む",
+        "ja": "右戻るに向かい、Way Nameを進む",
         "ko": "바로우회전 하시고 Way Name로 가세요.",
         "my": "ညာဘက် ထောင့်ချိုး​ပေါ်သို့Way Nameကိုဆက်သွားပါ ",
         "nl": "Ga scherpe bocht naar rechts naar Way Name",

--- a/test/fixtures/v5/roundabout_turn/slight_left_junction_name.json
+++ b/test/fixtures/v5/roundabout_turn/slight_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يساراً قليلاً على Way Name",
+        "da": "Drej svagt til venstre ad Way Name",
+        "de": "Leicht links abbiegen auf Way Name",
+        "en": "Make a slight left onto Way Name",
+        "eo": "Veturu maldekstreten al Way Name",
+        "es": "Sigue levemente a la izquierda en Way Name",
+        "es-ES": "Siga ligeramente a la izquierda en Way Name",
+        "fi": "Käänny loivasti vasempaan tielle Way Name",
+        "fr": "Tourner légèrement à gauche sur Way Name",
+        "he": "פנה קלה שמאלה על Way Name",
+        "hu": "Forduljon be enyhén balra a Way Name felé",
+        "id": "Lakukan agak ke kiri ke arah Way Name",
+        "it": "Gira a sinistra leggermente in Way Name",
+        "ja": "斜め左に向かい、Way Nameを進む",
+        "ko": "조금왼쪽 하시고 Way Name로 가세요.",
+        "my": "ဘယ်ဘက် အနည်းငယ်​ပေါ်သို့Way Nameကိုဆက်သွားပါ ",
+        "nl": "Ga iets naar links naar Way Name",
+        "no": "Ta en litt til venstre inn på Way Name",
+        "pl": "Łagodnie w lewo na Way Name",
+        "pt-BR": "Siga suave à esquerda em Way Name",
+        "pt-PT": "Siga ligeiramente à esquerda para Way Name",
+        "ro": "La sensul giratoriu virați ușor stânga pe Way Name",
+        "ru": "Двигайтесь левее на Way Name",
+        "sl": "Zavijte rahlo levo na Way Name",
+        "sv": "Sväng vänster in på Way Name",
+        "tr": "Way Name üzerinde hafif sol yöne dön",
+        "uk": "Рухайтесь плавно ліворуч на Way Name",
+        "vi": "Quẹo trái nghiêng vào Way Name",
+        "yo": "Ṣe a diẹ osi pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "稍向左转弯，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/slight_right_junction_name.json
+++ b/test/fixtures/v5/roundabout_turn/slight_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يساراً قليلاً على Way Name",
+        "da": "Drej svagt til højre ad Way Name",
+        "de": "Leicht rechts abbiegen auf Way Name",
+        "en": "Make a slight right onto Way Name",
+        "eo": "Veturu dekstreten al Way Name",
+        "es": "Sigue levemente a la derecha en Way Name",
+        "es-ES": "Siga ligeramente a la derecha en Way Name",
+        "fi": "Käänny loivasti oikeaan tielle Way Name",
+        "fr": "Tourner légèrement à droite sur Way Name",
+        "he": "פנה קלה ימינה על Way Name",
+        "hu": "Forduljon be enyhén jobbra a Way Name felé",
+        "id": "Lakukan agak ke kanan ke arah Way Name",
+        "it": "Gira a destra leggermente in Way Name",
+        "ja": "斜め右に向かい、Way Nameを進む",
+        "ko": "조금오른쪽 하시고 Way Name로 가세요.",
+        "my": "ညာဘက် အနည်းငယ်​ပေါ်သို့Way Nameကိုဆက်သွားပါ ",
+        "nl": "Ga iets naar rechts naar Way Name",
+        "no": "Ta en litt til høyre inn på Way Name",
+        "pl": "Łagodnie w prawo na Way Name",
+        "pt-BR": "Siga suave à direita em Way Name",
+        "pt-PT": "Siga ligeiramente à direita para Way Name",
+        "ro": "La sensul giratoriu virați ușor dreapta pe Way Name",
+        "ru": "Двигайтесь правее на Way Name",
+        "sl": "Zavijte rahlo desno na Way Name",
+        "sv": "Sväng höger in på Way Name",
+        "tr": "Way Name üzerinde hafif sağ yöne dön",
+        "uk": "Рухайтесь плавно праворуч на Way Name",
+        "vi": "Quẹo phải nghiêng vào Way Name",
+        "yo": "Ṣe a diẹ ọtun pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "稍向右转弯，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/straight_junction_name.json
+++ b/test/fixtures/v5/roundabout_turn/straight_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "تابع إلى الأمام على Way Name",
+        "da": "Fortsæt ligeud ad Way Name",
+        "de": "Geradeaus weiterfahren auf Way Name",
+        "en": "Continue straight onto Way Name",
+        "eo": "Veturu rekten al Way Name",
+        "es": "Continúa recto en Way Name",
+        "es-ES": "Continúa recto por Way Name",
+        "fi": "Jatka suoraan eteenpäin tielle Way Name",
+        "fr": "Continuer tout droit sur Way Name",
+        "he": "המשך ישר על Way Name",
+        "hu": "Hajtson egyenesen a Way Name felé",
+        "id": "Tetap lurus ke Way Name ",
+        "it": "Continua dritto in Way Name",
+        "ja": "Way Nameを直進する",
+        "ko": "직진하시고 Way Name로 가세요.",
+        "my": "Way Name​ပေါ်သို့တည့်တည့်ဆက်သွားပါ",
+        "nl": "Ga naar Way Name",
+        "no": "Fortsett rett frem til Way Name",
+        "pl": "Kontynuuj prosto na Way Name",
+        "pt-BR": "Continue em frente em Way Name",
+        "pt-PT": "Continue em frente para Way Name",
+        "ro": "La sensul giratoriu continuați înainte pe Way Name",
+        "ru": "Двигайтесь прямо по Way Name",
+        "sl": "Nadaljujte naravnost na Way Name",
+        "sv": "Fortsätt rakt fram in på Way Name",
+        "tr": "Way Name üzerinde düz devam et",
+        "uk": "Продовжуйте рух прямо до Way Name",
+        "vi": "Chạy tiếp trên Way Name",
+        "yo": "Tesiwaju tẹsiwaju lẹsẹkẹsẹ Way Name",
+        "zh-Hans": "继续直行，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/roundabout_turn/uturn_junction_name.json
+++ b/test/fixtures/v5/roundabout_turn/uturn_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "roundabout turn",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف الدوران للخلف على Way Name",
+        "da": "Foretag en U-vending ad Way Name",
+        "de": "180°-Wendung abbiegen auf Way Name",
+        "en": "Make a U-turn onto Way Name",
+        "eo": "Veturu turniĝu malantaŭen al Way Name",
+        "es": "Sigue cambio de sentido en Way Name",
+        "es-ES": "Siga cambio de sentido en Way Name",
+        "fi": "Käänny U-käännös tielle Way Name",
+        "fr": "Tourner demi-tour sur Way Name",
+        "he": "פנה פניית פרסה על Way Name",
+        "hu": "Forduljon be vissza a Way Name felé",
+        "id": "Lakukan putar balik ke arah Way Name",
+        "it": "Gira a inversione a U in Way Name",
+        "ja": "Uターンに向かい、Way Nameを進む",
+        "ko": "유턴 하시고 Way Name로 가세요.",
+        "my": "ဂ-ကွေ့​ပေါ်သို့Way Nameကိုဆက်သွားပါ ",
+        "nl": "Ga omkeren naar Way Name",
+        "no": "Ta en U-sving inn på Way Name",
+        "pl": "Zawróć na Way Name",
+        "pt-BR": "Siga retorno em Way Name",
+        "pt-PT": "Siga inversão de marcha para Way Name",
+        "ro": "La sensul giratoriu virați întoarcere pe Way Name",
+        "ru": "Двигайтесь на разворот на Way Name",
+        "sl": "Zavijte polkrožni obrat na Way Name",
+        "sv": "Sväng U-sväng in på Way Name",
+        "tr": "Way Name üzerinde U dönüşü yöne dön",
+        "uk": "Рухайтесь розворот на Way Name",
+        "vi": "Quẹo ngược vào Way Name",
+        "yo": "Ṣe a U-tan pẹlẹpẹlẹ Way Name",
+        "zh-Hans": "调头转弯，驶入Way Name"
+    }
+}

--- a/test/fixtures/v5/turn/left_exit.json
+++ b/test/fixtures/v5/turn/left_exit.json
@@ -24,7 +24,7 @@
         "it": "Svolta a sinistra in Way Name",
         "ja": "左折してWay Nameを進む",
         "ko": "좌회전 하시고 Way Name로 가세요.",
-        "my": "Way Nameပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ ",
+        "my": "Way Nameပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ",
         "nl": "Ga linksaf naar Way Name",
         "no": "Sving til venstre inn på Way Name",
         "pl": "Skręć w lewo na Way Name",

--- a/test/fixtures/v5/turn/left_junction_name.json
+++ b/test/fixtures/v5/turn/left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك مسار الدوران يسارا على Shibuya Crossing",
+        "da": "Drej til venstre ved Shibuya Crossing",
+        "de": "Links abbiegen an Shibuya Crossing",
+        "en": "Turn left at Shibuya Crossing",
+        "eo": "Turniĝu maldekstren ĉe Shibuya Crossing",
+        "es": "Gira a la izquierda en Shibuya Crossing",
+        "es-ES": "Gira a la izquierda en Shibuya Crossing",
+        "fi": "Käänny vasemmalle Shibuya Crossing",
+        "fr": "Tourner à gauche en Shibuya Crossing",
+        "he": "פנה שמאלה לShibuya Crossing",
+        "hu": "Forduljon be balra az Shibuya Crossing",
+        "id": "Turn left at Shibuya Crossing",
+        "it": "Svolta a sinistra al Shibuya Crossing",
+        "ja": "Shibuya Crossingを左折です",
+        "ko": "Shibuya Crossing에서 좌회전.",
+        "my": "Shibuya Crossingပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ",
+        "nl": "Ga linksaf bij Shibuya Crossing",
+        "no": "Sving til venstre i Shibuya Crossing",
+        "pl": "Skręć w lewo na Shibuya Crossing",
+        "pt-BR": "Vire à esquerda em Shibuya Crossing",
+        "pt-PT": "Vire à esquerda em Shibuya Crossing",
+        "ro": "Virați la stânga la Shibuya Crossing",
+        "ru": "Поверните налево на Shibuya Crossing",
+        "sl": "Zavijte levo na Shibuya Crossing",
+        "sv": "Sväng vänster vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda sola dön",
+        "uk": "Turn left at Shibuya Crossing",
+        "vi": "Quẹo trái ở Shibuya Crossing",
+        "yo": "Ya si apa osi ni Shibuya Crossing",
+        "zh-Hans": "Turn left at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/turn/left_name.json
+++ b/test/fixtures/v5/turn/left_name.json
@@ -23,7 +23,7 @@
         "it": "Svolta a sinistra in Way Name",
         "ja": "左折してWay Nameを進む",
         "ko": "좌회전 하시고 Way Name로 가세요.",
-        "my": "Way Nameပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ ",
+        "my": "Way Nameပေါ်သို့ဘယ်ဘက်ကိုဆက်သွားပါ",
         "nl": "Ga linksaf naar Way Name",
         "no": "Sving til venstre inn på Way Name",
         "pl": "Skręć w lewo na Way Name",

--- a/test/fixtures/v5/turn/right_exit.json
+++ b/test/fixtures/v5/turn/right_exit.json
@@ -24,7 +24,7 @@
         "it": "Svolta a destra in Way Name",
         "ja": "右折してWay Nameを進む",
         "ko": "우회전 하시고 Way Name로 가세요.",
-        "my": "Way Nameပေါ်သို့ညာဘက်ကိုလာရောက်ပေါင်းဆုံပါ ",
+        "my": "Way Nameပေါ်သို့ညာဘက်ကိုလာရောက်ပေါင်းဆုံပါ",
         "nl": "Ga rechtsaf naar Way Name",
         "no": "Sving til høyre inn på Way Name",
         "pl": "Skręć w prawo na Way Name",

--- a/test/fixtures/v5/turn/right_junction_name.json
+++ b/test/fixtures/v5/turn/right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "اسلك مسار الدوران يمينا على Shibuya Crossing",
+        "da": "Drej til højre ved Shibuya Crossing",
+        "de": "Rechts abbiegen an Shibuya Crossing",
+        "en": "Turn right at Shibuya Crossing",
+        "eo": "Turniĝu dekstren ĉe Shibuya Crossing",
+        "es": "Gira a la derecha en Shibuya Crossing",
+        "es-ES": "Gira a la derecha en junction_name}",
+        "fi": "Käänny oikealle Shibuya Crossing",
+        "fr": "Tourner à droite en Shibuya Crossing",
+        "he": "פנה ימינה לShibuya Crossing",
+        "hu": "Forduljon be jobbra az Shibuya Crossing",
+        "id": "Turn right at Shibuya Crossing",
+        "it": "Svolta a destra al Shibuya Crossing",
+        "ja": "Shibuya Crossingを右折です",
+        "ko": "Shibuya Crossing에서 우회전.",
+        "my": "Shibuya Crossingပေါ်သို့ညာဘက်ကိုလာရောက်ပေါင်းဆုံပါ",
+        "nl": "Ga rechtsaf bij Shibuya Crossing",
+        "no": "Sving til høyre i Shibuya Crossing",
+        "pl": "Skręć w prawo na Shibuya Crossing",
+        "pt-BR": "Vire à direita em Shibuya Crossing",
+        "pt-PT": "Vire à direita em Shibuya Crossing",
+        "ro": "Virați la dreapta la Shibuya Crossing",
+        "ru": "Поверните направо на Shibuya Crossing",
+        "sl": "Zavijte desno na Shibuya Crossing",
+        "sv": "Sväng höger vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda sağa dön",
+        "uk": "Turn right at Shibuya Crossing",
+        "vi": "Quẹo phải ở Shibuya Crossing",
+        "yo": "Ya sowo otun ni Shibuya Crossing",
+        "zh-Hans": "Turn right at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/turn/right_name.json
+++ b/test/fixtures/v5/turn/right_name.json
@@ -23,7 +23,7 @@
         "it": "Svolta a destra in Way Name",
         "ja": "右折してWay Nameを進む",
         "ko": "우회전 하시고 Way Name로 가세요.",
-        "my": "Way Nameပေါ်သို့ညာဘက်ကိုလာရောက်ပေါင်းဆုံပါ ",
+        "my": "Way Nameပေါ်သို့ညာဘက်ကိုလာရောက်ပေါင်းဆုံပါ",
         "nl": "Ga rechtsaf naar Way Name",
         "no": "Sving til høyre inn på Way Name",
         "pl": "Skręć w prawo na Way Name",

--- a/test/fixtures/v5/turn/sharp_left_default.json
+++ b/test/fixtures/v5/turn/sharp_left_default.json
@@ -21,7 +21,7 @@
         "hu": "Forduljon élesen balra",
         "id": "Lakukan tajam kiri",
         "it": "Gira a sinistra",
-        "ja": "大きく左に向かう",
+        "ja": "左戻るに向かう",
         "ko": "바로좌회전 하세요.",
         "my": "ဘယ်ဘက် ထောင့်ချိုးကိုလှည့်ပါ",
         "nl": "Ga scherpe bocht naar links",

--- a/test/fixtures/v5/turn/sharp_left_destination.json
+++ b/test/fixtures/v5/turn/sharp_left_destination.json
@@ -22,7 +22,7 @@
         "hu": "Forduljon élesen balra a Destination 1 irányába",
         "id": "Lakukan tajam kiri menuju Destination 1",
         "it": "Gira a sinistra verso Destination 1",
-        "ja": "大きく左に向かい、その後Destination 1へ向かう",
+        "ja": "左戻るに向かい、その後Destination 1へ向かう",
         "ko": "바로좌회전 하시고 Destination 1까지 가세요.",
         "my": "ဘယ်ဘက် ထောင့်ချိုးဆီသို့Destination 1ကို ဆက်သွားပါ ",
         "nl": "Ga scherpe bocht naar links richting Destination 1",

--- a/test/fixtures/v5/turn/sharp_left_exit.json
+++ b/test/fixtures/v5/turn/sharp_left_exit.json
@@ -24,7 +24,7 @@
         "it": "Gira a sinistra in Way Name",
         "ja": "左戻るに向かい、Way Nameを進む",
         "ko": "바로좌회전 하시고 Way Name로 가세요.",
-        "my": "ဘယ်ဘက် ထောင့်ချိုးပေါ်သို့Way Nameကိုဆက်သွားပါ ",
+        "my": "ဘယ်ဘက် ထောင့်ချိုးပေါ်သို့Way Nameကိုဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar links naar Way Name",
         "no": "Ta en skarp venstre inn på Way Name",
         "pl": "Ostro w lewo na Way Name",

--- a/test/fixtures/v5/turn/sharp_left_exit.json
+++ b/test/fixtures/v5/turn/sharp_left_exit.json
@@ -22,7 +22,7 @@
         "hu": "Forduljon be élesen balra a Way Name felé",
         "id": "Lakukan tajam kiri ke arah Way Name",
         "it": "Gira a sinistra in Way Name",
-        "ja": "大きく左に向かい、Way Nameを進む",
+        "ja": "左戻るに向かい、Way Nameを進む",
         "ko": "바로좌회전 하시고 Way Name로 가세요.",
         "my": "ဘယ်ဘက် ထောင့်ချိုးပေါ်သို့Way Nameကိုဆက်သွားပါ ",
         "nl": "Ga scherpe bocht naar links naar Way Name",

--- a/test/fixtures/v5/turn/sharp_left_exit_destination.json
+++ b/test/fixtures/v5/turn/sharp_left_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Forduljon élesen balra a Destination 1 irányába",
         "id": "Lakukan tajam kiri menuju Destination 1",
         "it": "Gira a sinistra verso Destination 1",
-        "ja": "大きく左に向かい、その後Destination 1へ向かう",
+        "ja": "左戻るに向かい、その後Destination 1へ向かう",
         "ko": "바로좌회전 하시고 Destination 1까지 가세요.",
         "my": "ဘယ်ဘက် ထောင့်ချိုးဆီသို့Destination 1ကို ဆက်သွားပါ ",
         "nl": "Ga scherpe bocht naar links richting Destination 1",

--- a/test/fixtures/v5/turn/sharp_left_junction_name.json
+++ b/test/fixtures/v5/turn/sharp_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "sharp left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يسار حاد على Shibuya Crossing",
+        "da": "Drej skarpt til venstre ved Shibuya Crossing",
+        "de": "Make a scharf links at Shibuya Crossing",
+        "en": "Make a sharp left at Shibuya Crossing",
+        "eo": "Veturu maldekstregen ĉe Shibuya Crossing",
+        "es": "Sigue cerrada a la izquierda en Shibuya Crossing",
+        "es-ES": "Gira cerrada a la izquierda en Shibuya Crossing",
+        "fi": "Käänny jyrkästi vasempaan Shibuya Crossing",
+        "fr": "Tourner franchement à gauche en Shibuya Crossing",
+        "he": "פנה חדה שמאלה על Shibuya Crossing",
+        "hu": "Forduljon be élesen balra az Shibuya Crossing",
+        "id": "Make a tajam kiri at Shibuya Crossing",
+        "it": "Gira a sinistra al Shibuya Crossing",
+        "ja": "Shibuya Crossingを左戻るです",
+        "ko": "Shibuya Crossing에서 바로좌회전 하세요.",
+        "my": "ဘယ်ဘက် ထောင့်ချိုးပေါ်သို့Shibuya Crossingကိုဆက်သွားပါ",
+        "nl": "Ga scherpe bocht naar links bij Shibuya Crossing",
+        "no": "Ta en skarp venstre i Shibuya Crossing",
+        "pl": "Ostro w lewo na Shibuya Crossing",
+        "pt-BR": "Siga fechada à esquerda em Shibuya Crossing",
+        "pt-PT": "Siga acentuadamente à esquerda em Shibuya Crossing",
+        "ro": "Virați puternic stânga la Shibuya Crossing",
+        "ru": "Двигайтесь налево на Shibuya Crossing",
+        "sl": "Zavijte ostro levo na Shibuya Crossing",
+        "sv": "Sväng vänster vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda keskin sol yöne dön",
+        "uk": "Make a різко ліворуч at Shibuya Crossing",
+        "vi": "Quẹo trái gắt ở Shibuya Crossing",
+        "yo": "Ṣe a didasilẹ ni Shibuya Crossing",
+        "zh-Hans": "Make a 急向左 at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/turn/sharp_left_name.json
+++ b/test/fixtures/v5/turn/sharp_left_name.json
@@ -23,7 +23,7 @@
         "it": "Gira a sinistra in Way Name",
         "ja": "左戻るに向かい、Way Nameを進む",
         "ko": "바로좌회전 하시고 Way Name로 가세요.",
-        "my": "ဘယ်ဘက် ထောင့်ချိုးပေါ်သို့Way Nameကိုဆက်သွားပါ ",
+        "my": "ဘယ်ဘက် ထောင့်ချိုးပေါ်သို့Way Nameကိုဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar links naar Way Name",
         "no": "Ta en skarp venstre inn på Way Name",
         "pl": "Ostro w lewo na Way Name",

--- a/test/fixtures/v5/turn/sharp_left_name.json
+++ b/test/fixtures/v5/turn/sharp_left_name.json
@@ -21,7 +21,7 @@
         "hu": "Forduljon be élesen balra a Way Name felé",
         "id": "Lakukan tajam kiri ke arah Way Name",
         "it": "Gira a sinistra in Way Name",
-        "ja": "大きく左に向かい、Way Nameを進む",
+        "ja": "左戻るに向かい、Way Nameを進む",
         "ko": "바로좌회전 하시고 Way Name로 가세요.",
         "my": "ဘယ်ဘက် ထောင့်ချိုးပေါ်သို့Way Nameကိုဆက်သွားပါ ",
         "nl": "Ga scherpe bocht naar links naar Way Name",

--- a/test/fixtures/v5/turn/sharp_right_default.json
+++ b/test/fixtures/v5/turn/sharp_right_default.json
@@ -21,7 +21,7 @@
         "hu": "Forduljon élesen jobbra",
         "id": "Lakukan tajam kanan",
         "it": "Gira a destra",
-        "ja": "大きく右に向かう",
+        "ja": "右戻るに向かう",
         "ko": "바로우회전 하세요.",
         "my": "ညာဘက် ထောင့်ချိုးကိုလှည့်ပါ",
         "nl": "Ga scherpe bocht naar rechts",

--- a/test/fixtures/v5/turn/sharp_right_destination.json
+++ b/test/fixtures/v5/turn/sharp_right_destination.json
@@ -22,7 +22,7 @@
         "hu": "Forduljon élesen jobbra a Destination 1 irányába",
         "id": "Lakukan tajam kanan menuju Destination 1",
         "it": "Gira a destra verso Destination 1",
-        "ja": "大きく右に向かい、その後Destination 1へ向かう",
+        "ja": "右戻るに向かい、その後Destination 1へ向かう",
         "ko": "바로우회전 하시고 Destination 1까지 가세요.",
         "my": "ညာဘက် ထောင့်ချိုးဆီသို့Destination 1ကို ဆက်သွားပါ ",
         "nl": "Ga scherpe bocht naar rechts richting Destination 1",

--- a/test/fixtures/v5/turn/sharp_right_exit.json
+++ b/test/fixtures/v5/turn/sharp_right_exit.json
@@ -22,7 +22,7 @@
         "hu": "Forduljon be élesen jobbra a Way Name felé",
         "id": "Lakukan tajam kanan ke arah Way Name",
         "it": "Gira a destra in Way Name",
-        "ja": "大きく右に向かい、Way Nameを進む",
+        "ja": "右戻るに向かい、Way Nameを進む",
         "ko": "바로우회전 하시고 Way Name로 가세요.",
         "my": "ညာဘက် ထောင့်ချိုးပေါ်သို့Way Nameကိုဆက်သွားပါ ",
         "nl": "Ga scherpe bocht naar rechts naar Way Name",

--- a/test/fixtures/v5/turn/sharp_right_exit.json
+++ b/test/fixtures/v5/turn/sharp_right_exit.json
@@ -24,7 +24,7 @@
         "it": "Gira a destra in Way Name",
         "ja": "右戻るに向かい、Way Nameを進む",
         "ko": "바로우회전 하시고 Way Name로 가세요.",
-        "my": "ညာဘက် ထောင့်ချိုးပေါ်သို့Way Nameကိုဆက်သွားပါ ",
+        "my": "ညာဘက် ထောင့်ချိုးပေါ်သို့Way Nameကိုဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar rechts naar Way Name",
         "no": "Ta en skarp høyre inn på Way Name",
         "pl": "Ostro w prawo na Way Name",

--- a/test/fixtures/v5/turn/sharp_right_exit_destination.json
+++ b/test/fixtures/v5/turn/sharp_right_exit_destination.json
@@ -23,7 +23,7 @@
         "hu": "Forduljon élesen jobbra a Destination 1 irányába",
         "id": "Lakukan tajam kanan menuju Destination 1",
         "it": "Gira a destra verso Destination 1",
-        "ja": "大きく右に向かい、その後Destination 1へ向かう",
+        "ja": "右戻るに向かい、その後Destination 1へ向かう",
         "ko": "바로우회전 하시고 Destination 1까지 가세요.",
         "my": "ညာဘက် ထောင့်ချိုးဆီသို့Destination 1ကို ဆက်သွားပါ ",
         "nl": "Ga scherpe bocht naar rechts richting Destination 1",

--- a/test/fixtures/v5/turn/sharp_right_junction_name.json
+++ b/test/fixtures/v5/turn/sharp_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "sharp right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يمين حاد على Shibuya Crossing",
+        "da": "Drej skarpt til højre ved Shibuya Crossing",
+        "de": "Make a scharf rechts at Shibuya Crossing",
+        "en": "Make a sharp right at Shibuya Crossing",
+        "eo": "Veturu dekstregen ĉe Shibuya Crossing",
+        "es": "Sigue cerrada a la derecha en Shibuya Crossing",
+        "es-ES": "Gira cerrada a la derecha en Shibuya Crossing",
+        "fi": "Käänny jyrkästi oikeaan Shibuya Crossing",
+        "fr": "Tourner franchement à droite en Shibuya Crossing",
+        "he": "פנה חדה ימינה על Shibuya Crossing",
+        "hu": "Forduljon be élesen jobbra az Shibuya Crossing",
+        "id": "Make a tajam kanan at Shibuya Crossing",
+        "it": "Gira a destra al Shibuya Crossing",
+        "ja": "Shibuya Crossingを右戻るです",
+        "ko": "Shibuya Crossing에서 바로우회전 하세요.",
+        "my": "ညာဘက် ထောင့်ချိုးပေါ်သို့Shibuya Crossingကိုဆက်သွားပါ",
+        "nl": "Ga scherpe bocht naar rechts bij Shibuya Crossing",
+        "no": "Ta en skarp høyre i Shibuya Crossing",
+        "pl": "Ostro w prawo na Shibuya Crossing",
+        "pt-BR": "Siga fechada à direita em Shibuya Crossing",
+        "pt-PT": "Siga acentuadamente à direita em Shibuya Crossing",
+        "ro": "Virați puternic dreapta la Shibuya Crossing",
+        "ru": "Двигайтесь направо на Shibuya Crossing",
+        "sl": "Zavijte ostro desno na Shibuya Crossing",
+        "sv": "Sväng höger vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda keskin sağ yöne dön",
+        "uk": "Make a різко праворуч at Shibuya Crossing",
+        "vi": "Quẹo phải gắt ở Shibuya Crossing",
+        "yo": "Ṣe a didasilẹ ọtun ni Shibuya Crossing",
+        "zh-Hans": "Make a 急向右 at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/turn/sharp_right_name.json
+++ b/test/fixtures/v5/turn/sharp_right_name.json
@@ -23,7 +23,7 @@
         "it": "Gira a destra in Way Name",
         "ja": "右戻るに向かい、Way Nameを進む",
         "ko": "바로우회전 하시고 Way Name로 가세요.",
-        "my": "ညာဘက် ထောင့်ချိုးပေါ်သို့Way Nameကိုဆက်သွားပါ ",
+        "my": "ညာဘက် ထောင့်ချိုးပေါ်သို့Way Nameကိုဆက်သွားပါ",
         "nl": "Ga scherpe bocht naar rechts naar Way Name",
         "no": "Ta en skarp høyre inn på Way Name",
         "pl": "Ostro w prawo na Way Name",

--- a/test/fixtures/v5/turn/sharp_right_name.json
+++ b/test/fixtures/v5/turn/sharp_right_name.json
@@ -21,7 +21,7 @@
         "hu": "Forduljon be élesen jobbra a Way Name felé",
         "id": "Lakukan tajam kanan ke arah Way Name",
         "it": "Gira a destra in Way Name",
-        "ja": "大きく右に向かい、Way Nameを進む",
+        "ja": "右戻るに向かい、Way Nameを進む",
         "ko": "바로우회전 하시고 Way Name로 가세요.",
         "my": "ညာဘက် ထောင့်ချိုးပေါ်သို့Way Nameကိုဆက်သွားပါ ",
         "nl": "Ga scherpe bocht naar rechts naar Way Name",

--- a/test/fixtures/v5/turn/slight_left_exit.json
+++ b/test/fixtures/v5/turn/slight_left_exit.json
@@ -24,7 +24,7 @@
         "it": "Gira a sinistra leggermente in Way Name",
         "ja": "斜め左に向かい、Way Nameを進む",
         "ko": "조금왼쪽 하시고 Way Name로 가세요.",
-        "my": "ဘယ်ဘက် အနည်းငယ်ပေါ်သို့Way Nameကိုဆက်သွားပါ ",
+        "my": "ဘယ်ဘက် အနည်းငယ်ပေါ်သို့Way Nameကိုဆက်သွားပါ",
         "nl": "Ga iets naar links naar Way Name",
         "no": "Ta en litt til venstre inn på Way Name",
         "pl": "Łagodnie w lewo na Way Name",

--- a/test/fixtures/v5/turn/slight_left_junction_name.json
+++ b/test/fixtures/v5/turn/slight_left_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "slight left"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يساراً قليلاً على Shibuya Crossing",
+        "da": "Drej svagt til venstre ved Shibuya Crossing",
+        "de": "Make a leicht links at Shibuya Crossing",
+        "en": "Make a slight left at Shibuya Crossing",
+        "eo": "Veturu maldekstreten ĉe Shibuya Crossing",
+        "es": "Sigue levemente a la izquierda en Shibuya Crossing",
+        "es-ES": "Gira ligeramente a la izquierda en Shibuya Crossing",
+        "fi": "Käänny loivasti vasempaan Shibuya Crossing",
+        "fr": "Tourner légèrement à gauche en Shibuya Crossing",
+        "he": "פנה קלה שמאלה על Shibuya Crossing",
+        "hu": "Forduljon be enyhén balra az Shibuya Crossing",
+        "id": "Make a agak ke kiri at Shibuya Crossing",
+        "it": "Gira a sinistra leggermente al Shibuya Crossing",
+        "ja": "Shibuya Crossingを斜め左です",
+        "ko": "Shibuya Crossing에서 조금왼쪽 하세요.",
+        "my": "ဘယ်ဘက် အနည်းငယ်ပေါ်သို့Shibuya Crossingကိုဆက်သွားပါ",
+        "nl": "Ga iets naar links bij Shibuya Crossing",
+        "no": "Ta en litt til venstre i Shibuya Crossing",
+        "pl": "Łagodnie w lewo na Shibuya Crossing",
+        "pt-BR": "Siga suave à esquerda em Shibuya Crossing",
+        "pt-PT": "Siga ligeiramente à esquerda em Shibuya Crossing",
+        "ro": "Virați ușor stânga la Shibuya Crossing",
+        "ru": "Двигайтесь левее на Shibuya Crossing",
+        "sl": "Zavijte rahlo levo na Shibuya Crossing",
+        "sv": "Sväng vänster vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda hafif sol yöne dön",
+        "uk": "Make a плавно ліворуч at Shibuya Crossing",
+        "vi": "Quẹo trái nghiêng ở Shibuya Crossing",
+        "yo": "Ṣe a diẹ osi ni Shibuya Crossing",
+        "zh-Hans": "Make a 稍向左 at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/turn/slight_left_name.json
+++ b/test/fixtures/v5/turn/slight_left_name.json
@@ -23,7 +23,7 @@
         "it": "Gira a sinistra leggermente in Way Name",
         "ja": "斜め左に向かい、Way Nameを進む",
         "ko": "조금왼쪽 하시고 Way Name로 가세요.",
-        "my": "ဘယ်ဘက် အနည်းငယ်ပေါ်သို့Way Nameကိုဆက်သွားပါ ",
+        "my": "ဘယ်ဘက် အနည်းငယ်ပေါ်သို့Way Nameကိုဆက်သွားပါ",
         "nl": "Ga iets naar links naar Way Name",
         "no": "Ta en litt til venstre inn på Way Name",
         "pl": "Łagodnie w lewo na Way Name",

--- a/test/fixtures/v5/turn/slight_right_exit.json
+++ b/test/fixtures/v5/turn/slight_right_exit.json
@@ -24,7 +24,7 @@
         "it": "Gira a destra leggermente in Way Name",
         "ja": "斜め右に向かい、Way Nameを進む",
         "ko": "조금오른쪽 하시고 Way Name로 가세요.",
-        "my": "ညာဘက် အနည်းငယ်ပေါ်သို့Way Nameကိုဆက်သွားပါ ",
+        "my": "ညာဘက် အနည်းငယ်ပေါ်သို့Way Nameကိုဆက်သွားပါ",
         "nl": "Ga iets naar rechts naar Way Name",
         "no": "Ta en litt til høyre inn på Way Name",
         "pl": "Łagodnie w prawo na Way Name",

--- a/test/fixtures/v5/turn/slight_right_junction_name.json
+++ b/test/fixtures/v5/turn/slight_right_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "slight right"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف يساراً قليلاً على Shibuya Crossing",
+        "da": "Drej svagt til højre ved Shibuya Crossing",
+        "de": "Make a leicht rechts at Shibuya Crossing",
+        "en": "Make a slight right at Shibuya Crossing",
+        "eo": "Veturu dekstreten ĉe Shibuya Crossing",
+        "es": "Sigue levemente a la derecha en Shibuya Crossing",
+        "es-ES": "Gira ligeramente a la derecha en Shibuya Crossing",
+        "fi": "Käänny loivasti oikeaan Shibuya Crossing",
+        "fr": "Tourner légèrement à droite en Shibuya Crossing",
+        "he": "פנה קלה ימינה על Shibuya Crossing",
+        "hu": "Forduljon be enyhén jobbra az Shibuya Crossing",
+        "id": "Make a agak ke kanan at Shibuya Crossing",
+        "it": "Gira a destra leggermente al Shibuya Crossing",
+        "ja": "Shibuya Crossingを斜め右です",
+        "ko": "Shibuya Crossing에서 조금오른쪽 하세요.",
+        "my": "ညာဘက် အနည်းငယ်ပေါ်သို့Shibuya Crossingကိုဆက်သွားပါ",
+        "nl": "Ga iets naar rechts bij Shibuya Crossing",
+        "no": "Ta en litt til høyre i Shibuya Crossing",
+        "pl": "Łagodnie w prawo na Shibuya Crossing",
+        "pt-BR": "Siga suave à direita em Shibuya Crossing",
+        "pt-PT": "Siga ligeiramente à direita em Shibuya Crossing",
+        "ro": "Virați ușor dreapta la Shibuya Crossing",
+        "ru": "Двигайтесь правее на Shibuya Crossing",
+        "sl": "Zavijte rahlo desno na Shibuya Crossing",
+        "sv": "Sväng höger vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda hafif sağ yöne dön",
+        "uk": "Make a плавно праворуч at Shibuya Crossing",
+        "vi": "Quẹo phải nghiêng ở Shibuya Crossing",
+        "yo": "Ṣe a diẹ ọtun ni Shibuya Crossing",
+        "zh-Hans": "Make a 稍向右 at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/turn/slight_right_name.json
+++ b/test/fixtures/v5/turn/slight_right_name.json
@@ -23,7 +23,7 @@
         "it": "Gira a destra leggermente in Way Name",
         "ja": "斜め右に向かい、Way Nameを進む",
         "ko": "조금오른쪽 하시고 Way Name로 가세요.",
-        "my": "ညာဘက် အနည်းငယ်ပေါ်သို့Way Nameကိုဆက်သွားပါ ",
+        "my": "ညာဘက် အနည်းငယ်ပေါ်သို့Way Nameကိုဆက်သွားပါ",
         "nl": "Ga iets naar rechts naar Way Name",
         "no": "Ta en litt til høyre inn på Way Name",
         "pl": "Łagodnie w prawo na Way Name",

--- a/test/fixtures/v5/turn/straight_junction_name.json
+++ b/test/fixtures/v5/turn/straight_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "straight"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انطلق قدما على Shibuya Crossing",
+        "da": "Kør ligeud ved Shibuya Crossing",
+        "de": "Geradeaus weiterfahren an Shibuya Crossing",
+        "en": "Go straight at Shibuya Crossing",
+        "eo": "Veturu rekten ĉe Shibuya Crossing",
+        "es": "Ve recto en Shibuya Crossing",
+        "es-ES": "Continúa recto en Shibuya Crossing",
+        "fi": "Aja suoraan eteenpäin Shibuya Crossing",
+        "fr": "Aller tout droit en Shibuya Crossing",
+        "he": "המשך ישר לShibuya Crossing",
+        "hu": "Hajtson egyenese az Shibuya Crossing",
+        "id": "Go straight at Shibuya Crossing",
+        "it": "Prosegui dritto al Shibuya Crossing",
+        "ja": "Shibuya Crossingを直進です",
+        "ko": "Shibuya Crossing에서 직진 하세요.",
+        "my": "Shibuya Crossingပေါ်သို့တည့်တည့်သွားပါ",
+        "nl": "Ga rechtdoor bij Shibuya Crossing",
+        "no": "Kjør rett frem i Shibuya Crossing",
+        "pl": "Jedź prosto na Shibuya Crossing",
+        "pt-BR": "Siga em frente em Shibuya Crossing",
+        "pt-PT": "Vá em frente em Shibuya Crossing",
+        "ro": "Mergeți înainte la Shibuya Crossing",
+        "ru": "Двигайтесь по Shibuya Crossing",
+        "sl": "Peljite naravnost na Shibuya Crossing",
+        "sv": "Kör rakt fram vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda düz git",
+        "uk": "Go straight at Shibuya Crossing",
+        "vi": "Chạy thẳng ở Shibuya Crossing",
+        "yo": "Rin taara ni Shibuya Crossing",
+        "zh-Hans": "Go straight at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/turn/uturn_exit.json
+++ b/test/fixtures/v5/turn/uturn_exit.json
@@ -24,7 +24,7 @@
         "it": "Gira a inversione a U in Way Name",
         "ja": "Uターンに向かい、Way Nameを進む",
         "ko": "유턴 하시고 Way Name로 가세요.",
-        "my": "ဂ-ကွေ့ပေါ်သို့Way Nameကိုဆက်သွားပါ ",
+        "my": "ဂ-ကွေ့ပေါ်သို့Way Nameကိုဆက်သွားပါ",
         "nl": "Ga omkeren naar Way Name",
         "no": "Ta en U-sving inn på Way Name",
         "pl": "Zawróć na Way Name",

--- a/test/fixtures/v5/turn/uturn_junction_name.json
+++ b/test/fixtures/v5/turn/uturn_junction_name.json
@@ -1,0 +1,43 @@
+{
+    "step": {
+        "maneuver": {
+            "type": "turn",
+            "modifier": "uturn"
+        },
+        "name": "Way Name",
+        "driving_side": "right",
+        "junction_name": "Shibuya Crossing"
+    },
+    "instructions": {
+        "ar": "انعطف الدوران للخلف على Shibuya Crossing",
+        "da": "Foretag en U-vending ved Shibuya Crossing",
+        "de": "Make a 180°-Wendung at Shibuya Crossing",
+        "en": "Make a U-turn at Shibuya Crossing",
+        "eo": "Veturu turniĝu malantaŭen ĉe Shibuya Crossing",
+        "es": "Sigue cambio de sentido en Shibuya Crossing",
+        "es-ES": "Gira cambio de sentido en Shibuya Crossing",
+        "fi": "Käänny U-käännös Shibuya Crossing",
+        "fr": "Tourner demi-tour en Shibuya Crossing",
+        "he": "פנה פניית פרסה על Shibuya Crossing",
+        "hu": "Forduljon be vissza az Shibuya Crossing",
+        "id": "Make a putar balik at Shibuya Crossing",
+        "it": "Gira a inversione a U al Shibuya Crossing",
+        "ja": "Shibuya CrossingをUターンです",
+        "ko": "Shibuya Crossing에서 유턴 하세요.",
+        "my": "ဂ-ကွေ့ပေါ်သို့Shibuya Crossingကိုဆက်သွားပါ",
+        "nl": "Ga omkeren bij Shibuya Crossing",
+        "no": "Ta en U-sving i Shibuya Crossing",
+        "pl": "Zawróć na Shibuya Crossing",
+        "pt-BR": "Siga retorno em Shibuya Crossing",
+        "pt-PT": "Siga inversão de marcha em Shibuya Crossing",
+        "ro": "Virați întoarcere la Shibuya Crossing",
+        "ru": "Двигайтесь на разворот на Shibuya Crossing",
+        "sl": "Zavijte polkrožni obrat na Shibuya Crossing",
+        "sv": "Sväng U-sväng vid Shibuya Crossing",
+        "tr": "Shibuya Crossing konumunda U dönüşü yöne dön",
+        "uk": "Make a розворот at Shibuya Crossing",
+        "vi": "Quẹo ngược ở Shibuya Crossing",
+        "yo": "Ṣe a U-tan ni Shibuya Crossing",
+        "zh-Hans": "Make a 调头 at Shibuya Crossing"
+    }
+}

--- a/test/fixtures/v5/turn/uturn_name.json
+++ b/test/fixtures/v5/turn/uturn_name.json
@@ -23,7 +23,7 @@
         "it": "Gira a inversione a U in Way Name",
         "ja": "Uターンに向かい、Way Nameを進む",
         "ko": "유턴 하시고 Way Name로 가세요.",
-        "my": "ဂ-ကွေ့ပေါ်သို့Way Nameကိုဆက်သွားပါ ",
+        "my": "ဂ-ကွေ့ပေါ်သို့Way Nameကိုဆက်သွားပါ",
         "nl": "Ga omkeren naar Way Name",
         "no": "Ta en U-sving inn på Way Name",
         "pl": "Zawróć na Way Name",

--- a/test/fixtures_test.js
+++ b/test/fixtures_test.js
@@ -64,7 +64,7 @@ tape.test('verify existence/update fixtures', function(assert) {
         } else {
             assert.ok(
                 fs.existsSync(fileToWrite),
-                `verified existance of ${phrasePath}`
+                `verified existence of ${phrasePath}`
             );
         }
     }
@@ -90,7 +90,7 @@ tape.test('verify existence/update fixtures', function(assert) {
             );
             assert.ok(true, `updated ${testName}`);
         } else {
-            // check for existance
+            // check for existence
             assert.ok(
                 fs.existsSync(fileName),
                 `verified existence of ${testName}`
@@ -128,6 +128,13 @@ tape.test('verify existence/update fixtures', function(assert) {
             exits: '4A;4B'
         });
         checkOrWrite(step, `${basePath}_exit_destination`);
+
+        // junction_name
+        step = Object.assign(clone(baseStep), {
+            name: 'Way Name',
+            'junction_name': 'Shibuya Crossing'
+        });
+        checkOrWrite(step, `${basePath}_junction_name`);
     }
 
     ['modes', 'other', 'arrive_waypoint', 'arrive_waypoint_last', 'arrive_waypoint_name', 'arrive_upcoming', 'arrive_short', 'arrive_short_upcoming'].concat(constants.types).forEach((type) => {
@@ -639,10 +646,10 @@ tape.test('verify existence/update fixtures', function(assert) {
             );
             assert.ok(true, `updated ${phrase}`);
         } else {
-            // check for existance
+            // check for existence
             assert.ok(
                 fs.existsSync(fileName),
-                `verified existance of ${phrase}`
+                `verified existence of ${phrase}`
             );
         }
     }


### PR DESCRIPTION
# Issue

Updates ramp and exit instructions for the Japanese localization, courtesy of @tichimura. These changes were based on feedback from @tsuz who noted the "rampu" phrases sounded unnatural. 

@tsuz @YoshiYazawa for review. 

## Tasklist

 - [x] Add changelog entry
 - [ ] Test with osrm-frontend (?)
 - [ ] Review

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
