### PR TITLE
v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
-## master
+## 0.15.0 2024-03-03
 
 - This package now requires Node 16 and above. [#312](https://github.com/Project-OSRM/osrm-text-instructions/pull/312)
 - Added a Catalan localization. [#312](https://github.com/Project-OSRM/osrm-text-instructions/pull/312)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osrm-text-instructions",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "osrm-text-instructions",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "BSD-2-Clause",
       "devDependencies": {
         "@transifex/api": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "OSRM Text Instructions",
   "url": "https://github.com/Project-OSRM/osrm-text-instructions.js",
   "homepage": "http://project-osrm.org",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "main": "./index.js",
   "license": "BSD-2-Clause",
   "bugs": {


### PR DESCRIPTION
Finally got around to publishing a new release on NPM, numbered [v0.15.0](https://www.npmjs.com/package/osrm-text-instructions/v/0.15.0) because of the higher Node.js requirement:

* This package now requires Node 16 and above. (#312)
* Added a Catalan localization. (#312)
* Updated translations in Brazilian Portuguese, Danish, Esperanto, French, Hungarian, Japanese, Polish, Russian, Simplified Chinese, Swedish, Ukrainian, and Yoruba. (#312)