### PR TITLE
Voice and Banner instructions for OSRM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
+## master
+
+- Added voice and banner instructions
+
 ## 0.15.0 2024-03-03
 
 - This package now requires Node 16 and above. [#312](https://github.com/Project-OSRM/osrm-text-instructions/pull/312)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ key | type | description
 `legIndex` | integer | Zero-based index of the leg containing the step; together with `legCount`, this option determines which waypoint the user has arrived at
 `formatToken` | function | Function that formats the given token value after grammaticalization and capitalization but before the value is inserted into the instruction string; useful for wrapping tokens in markup
 `waypointName` | string | Optional custom name for the leg's destination, replaces `"your {nth} destination"`
+`verboseNavigation` | boolean |Allows you to add voice and banner instructions (default: false)
+`announcementsDistancesBelow500m` | double | Determines how often to receive instructions under 500 meter (default: `150`) 
+`announcementsWayMinimumDistance` | double | Determines the distance from maneauver location to include way name into instruction (default: `250`) 
+`distanceLastAnnouncement` | double |Determines when to receive last announcement (default: `30`)
 
 `formatToken` takes two parameters:
 


### PR DESCRIPTION
## Issue
I want to use OSRM API Call in [Maplibre-Navigation](https://github.com/maplibre/maplibre-navigation-android) adding voice and banner instructions. I was inspired by [Valhalla](https://valhalla.github.io/valhalla/api/) keys and I added them to RouteStep. 

The algorithm is based on these properties that can be set up into options to personalize the output.

key | description
----|----
`verboseNavigation` | Allows you to add voice and banner instructions 
`announcementsDistancesBelow500m` | Determines how often to receive instructions under 500 meter. 
`announcementsWayMinimumDistance` | Determines the distance from maneauver location to include way name into instruction. 
`distanceLastAnnouncement` | Determines when to receive last announcement. 
 
## Tasklist
    - [x] Add voice and banner instructions
    - [x] Add changelog entry 
    - [x] Test with osrm-frontend (?)
    - [] Review

## Requirements / Relations
None
