### PR TITLE
chore(ci): use conventional commit messages for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"


### PR DESCRIPTION
Dependabot currently opens PRs with subjects like `Bump eslint from 10.7.0 to 10.8.0`, which do not follow the conventional commit format.

This adds a `commit-message` block to the npm updater so its commits carry a type and scope:

- `chore(deps): bump eslint from 10.7.0 to 10.8.0` for runtime dependencies
- `chore(deps-dev): bump @types/node from 26.1.1 to 26.1.2` for dev dependencies

The `include: scope` setting is what appends `(deps)` / `(deps-dev)`, and the lowercase prefix also makes Dependabot lowercase its usual `Bump`.